### PR TITLE
Fixed: Correct spelling of 'freeleech'

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/Gazelle/GazelleSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Gazelle/GazelleSettings.cs
@@ -31,7 +31,7 @@ namespace NzbDrone.Core.Indexers.Gazelle
         [FieldDefinition(2, Label = "Password", Type = FieldType.Password, HelpText = "Password", Privacy = PrivacyLevel.Password)]
         public string Password { get; set; }
 
-        [FieldDefinition(3, Type = FieldType.Checkbox, Label = "Use Freeleech Token", HelpText = "Use Freeleach Token")]
+        [FieldDefinition(3, Type = FieldType.Checkbox, Label = "Use Freeleech Token", HelpText = "Use Freeleech Token")]
         public bool UseFreeleechToken { get; set; }
 
         public NzbDroneValidationResult Validate()

--- a/src/Prowlarr.Api.V1/swagger.json
+++ b/src/Prowlarr.Api.V1/swagger.json
@@ -1047,7 +1047,7 @@
                         "name": "Any",
                         "upgradeAllowed": true,
                         "cutoff": 20,
-                        "preferredTags": "freeleach",
+                        "preferredTags": "freeleech",
                         "items": [
                           {
                             "quality": {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
"Freeleech" is misspelled in a couple places.

#### Todos
- [ ] Tests
- [ ] Translation Keys

#### Issues Fixed or Closed by this PR
N/A