### PR TITLE
New: Detect and map App Indexers setup outside of Prowlarr

### DIFF
--- a/src/NzbDrone.Core/Applications/ApplicationBase.cs
+++ b/src/NzbDrone.Core/Applications/ApplicationBase.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using FluentValidation.Results;
 using NLog;
 using NzbDrone.Core.Indexers;
@@ -12,6 +13,9 @@ namespace NzbDrone.Core.Applications
     {
         protected readonly IAppIndexerMapService _appIndexerMapService;
         protected readonly Logger _logger;
+
+        protected static readonly Regex AppIndexerRegex = new Regex(@"api\/v\d*\/indexer\/(?<indexer>\d*)",
+                                                                RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         public abstract string Name { get; }
 
@@ -54,6 +58,7 @@ namespace NzbDrone.Core.Applications
         public abstract void AddIndexer(IndexerDefinition indexer);
         public abstract void UpdateIndexer(IndexerDefinition indexer);
         public abstract void RemoveIndexer(int indexerId);
+        public abstract Dictionary<int, int> GetIndexerMappings();
 
         public virtual object RequestAction(string action, IDictionary<string, string> query)
         {

--- a/src/NzbDrone.Core/Applications/IApplication.cs
+++ b/src/NzbDrone.Core/Applications/IApplication.cs
@@ -9,5 +9,6 @@ namespace NzbDrone.Core.Applications
         void AddIndexer(IndexerDefinition indexer);
         void UpdateIndexer(IndexerDefinition indexer);
         void RemoveIndexer(int indexerId);
+        Dictionary<int, int> GetIndexerMappings();
     }
 }

--- a/src/NzbDrone.Core/Applications/Lidarr/LidarrV1Proxy.cs
+++ b/src/NzbDrone.Core/Applications/Lidarr/LidarrV1Proxy.cs
@@ -64,7 +64,7 @@ namespace NzbDrone.Core.Applications.Lidarr
         public void RemoveIndexer(int indexerId, LidarrSettings settings)
         {
             var request = BuildRequest(settings, $"/api/v1/indexer/{indexerId}", HttpMethod.DELETE);
-            var response = _httpClient.Execute(request);
+            _httpClient.Execute(request);
         }
 
         public List<LidarrIndexer> GetIndexerSchema(LidarrSettings settings)

--- a/src/NzbDrone.Core/Applications/Radarr/RadarrV3Proxy.cs
+++ b/src/NzbDrone.Core/Applications/Radarr/RadarrV3Proxy.cs
@@ -64,7 +64,7 @@ namespace NzbDrone.Core.Applications.Radarr
         public void RemoveIndexer(int indexerId, RadarrSettings settings)
         {
             var request = BuildRequest(settings, $"/api/v3/indexer/{indexerId}", HttpMethod.DELETE);
-            var response = _httpClient.Execute(request);
+            _httpClient.Execute(request);
         }
 
         public List<RadarrIndexer> GetIndexerSchema(RadarrSettings settings)

--- a/src/NzbDrone.Core/Applications/Readarr/Readarr.cs
+++ b/src/NzbDrone.Core/Applications/Readarr/Readarr.cs
@@ -37,6 +37,28 @@ namespace NzbDrone.Core.Applications.Readarr
             return new ValidationResult(failures);
         }
 
+        public override Dictionary<int, int> GetIndexerMappings()
+        {
+            var indexers = _readarrV1Proxy.GetIndexers(Settings);
+            var mappings = new Dictionary<int, int>();
+
+            foreach (var indexer in indexers)
+            {
+                if ((string)indexer.Fields.FirstOrDefault(x => x.Name == "apiKey").Value == _configFileProvider.ApiKey)
+                {
+                    var match = AppIndexerRegex.Match((string)indexer.Fields.FirstOrDefault(x => x.Name == "baseUrl").Value);
+
+                    if (match.Groups["indexer"].Success && int.TryParse(match.Groups["indexer"].Value, out var indexerId))
+                    {
+                        //Add parsed mapping if it's mapped to a Indexer in this Prowlarr instance
+                        mappings.Add(indexer.Id, indexerId);
+                    }
+                }
+            }
+
+            return mappings;
+        }
+
         public override void AddIndexer(IndexerDefinition indexer)
         {
             if (indexer.Capabilities.Categories.SupportedCategories(Settings.SyncCategories.ToArray()).Any())

--- a/src/NzbDrone.Core/Applications/Readarr/ReadarrV1Proxy.cs
+++ b/src/NzbDrone.Core/Applications/Readarr/ReadarrV1Proxy.cs
@@ -64,7 +64,7 @@ namespace NzbDrone.Core.Applications.Readarr
         public void RemoveIndexer(int indexerId, ReadarrSettings settings)
         {
             var request = BuildRequest(settings, $"/api/v1/indexer/{indexerId}", HttpMethod.DELETE);
-            var response = _httpClient.Execute(request);
+            _httpClient.Execute(request);
         }
 
         public List<ReadarrIndexer> GetIndexerSchema(ReadarrSettings settings)

--- a/src/NzbDrone.Core/Applications/Sonarr/Sonarr.cs
+++ b/src/NzbDrone.Core/Applications/Sonarr/Sonarr.cs
@@ -37,6 +37,28 @@ namespace NzbDrone.Core.Applications.Sonarr
             return new ValidationResult(failures);
         }
 
+        public override Dictionary<int, int> GetIndexerMappings()
+        {
+            var indexers = _sonarrV3Proxy.GetIndexers(Settings);
+            var mappings = new Dictionary<int, int>();
+
+            foreach (var indexer in indexers)
+            {
+                if ((string)indexer.Fields.FirstOrDefault(x => x.Name == "apiKey").Value == _configFileProvider.ApiKey)
+                {
+                    var match = AppIndexerRegex.Match((string)indexer.Fields.FirstOrDefault(x => x.Name == "baseUrl").Value);
+
+                    if (match.Groups["indexer"].Success && int.TryParse(match.Groups["indexer"].Value, out var indexerId))
+                    {
+                        //Add parsed mapping if it's mapped to a Indexer in this Prowlarr instance
+                        mappings.Add(indexer.Id, indexerId);
+                    }
+                }
+            }
+
+            return mappings;
+        }
+
         public override void AddIndexer(IndexerDefinition indexer)
         {
             if (indexer.Capabilities.Categories.SupportedCategories(Settings.SyncCategories.ToArray()).Any())

--- a/src/NzbDrone.Core/Applications/Sonarr/SonarrV3Proxy.cs
+++ b/src/NzbDrone.Core/Applications/Sonarr/SonarrV3Proxy.cs
@@ -64,7 +64,7 @@ namespace NzbDrone.Core.Applications.Sonarr
         public void RemoveIndexer(int indexerId, SonarrSettings settings)
         {
             var request = BuildRequest(settings, $"/api/v3/indexer/{indexerId}", HttpMethod.DELETE);
-            var response = _httpClient.Execute(request);
+            _httpClient.Execute(request);
         }
 
         public List<SonarrIndexer> GetIndexerSchema(SonarrSettings settings)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
During sync look for Indexers that exist on remote applications that point back to this Prowlarr instance and setup a map for them. Handle these cases where indexers are manually setup and then Sync is later turned on, or when mapping table was wiped but indexers remain in remote applications (cleanup) to avoid Prowlarr trying to setup a duplicate of the indexer. 

#### Todos
- [ ] Tests
