### PR TITLE
New: Removal of indexers on application sync that are no longer defined within Prowlarr

### DIFF
--- a/src/NzbDrone.Core/Applications/ApplicationService.cs
+++ b/src/NzbDrone.Core/Applications/ApplicationService.cs
@@ -147,6 +147,15 @@ namespace NzbDrone.Core.Applications
                         }
                     }
                 }
+
+                foreach (var mapping in indexerMappings)
+                {
+                    if (!indexers.Any(x => x.Id == mapping.IndexerId))
+                    {
+                        _logger.Info("Indexer with the ID {0} was found within {1} but is no longer defined within Prowlarr, this is being removed.", mapping.IndexerId, app.Name);
+                        ExecuteAction(a => a.RemoveIndexer(mapping.IndexerId), app);
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
When an indexer is removed but the applications are down this will remove that application at the next "Application Indexer Sync"

#### Todos
- [ ] Tests
- [ ] Translation Keys
- [ ] Wiki Updates