### PR TITLE
Add animetosho

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/Newznab/Newznab.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Newznab/Newznab.cs
@@ -84,6 +84,7 @@ namespace NzbDrone.Core.Indexers.Newznab
             {
                 yield return GetDefinition("abNZB", GetSettings("https://abnzb.com"));
                 yield return GetDefinition("altHUB", GetSettings("https://althub.co.za"));
+                yield return GetDefinition("AnimeTosho (Usenet)", GetSettings("https://feed.animetosho.org"));
                 yield return GetDefinition("DOGnzb", GetSettings("https://api.dognzb.cr"));
                 yield return GetDefinition("DrunkenSlug", GetSettings("https://api.drunkenslug.com"));
                 yield return GetDefinition("GingaDADDY", GetSettings("https://www.gingadaddy.com"));

--- a/src/NzbDrone.Core/Indexers/Definitions/Torznab/Torznab.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Torznab/Torznab.cs
@@ -44,6 +44,7 @@ namespace NzbDrone.Core.Indexers.Torznab
         {
             get
             {
+                yield return GetDefinition("AnimeTosho", GetSettings("https://feed.animetosho.org"));
                 yield return GetDefinition("HD4Free.xyz", GetSettings("http://hd4free.xyz"));
                 yield return GetDefinition("Generic Torznab", GetSettings(""));
             }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Untested; theory should work

Ref
https://animetosho.org/about

Newznab/Torznab links to: `https://feed.animetosho.org/api`
>Is there a feed available?
>RSS2 (torrents only), Newznab/Torznab and ATOM. If you are trying to add any of these to an application which insists on an API key, please just put 0 as the key (or anything else, as Anime Tosho doesn't require an API key, but it's helpful if everyone uses the same key for server caching).
Is there an API available?
>The feed (see above) can serve as an API. You can also replace the rss2 or atom in the feed URL with json to get a JSON formatted version. The JSON API also supports querying torrent/file info if given a supplied torrent ID (example).
>Alternatively, daily database exports are also available for download here.

#### Screenshot (if UI related)
#### Todos
- Tests-N/A
- Translation Keys-N/A
- Wiki Updates-N/A

#### Issues Fixed or Closed by this PR

* Fixes #XXXX