### PR TITLE
Fixed: Port set for downloads even when not used Request

### DIFF
--- a/src/Prowlarr.Http/Extensions/RequestExtensions.cs
+++ b/src/Prowlarr.Http/Extensions/RequestExtensions.cs
@@ -158,7 +158,7 @@ namespace Prowlarr.Http.Extensions
         public static string GetServerUrl(this HttpRequest request)
         {
             var scheme = request.Scheme;
-            var port = request.HttpContext.Connection.LocalPort;
+            var port = request.HttpContext.Request.Host.Port;
 
             // Check for protocol headers added by reverse proxys
             // X-Forwarded-Proto: A de facto standard for identifying the originating protocol of an HTTP request


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Grab port from request and not the connection to ensure we don't use it when not needed

#### Screenshot (if UI related)

#### Todos
- [ ] Tests

#### Issues Fixed or Closed by this PR

* Fixes #71 