### PR TITLE
Fixed: Push Downloads to client fails for download overrides

### DIFF
--- a/src/NzbDrone.Core.Test/Download/DownloadClientProviderFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientProviderFixture.cs
@@ -1,0 +1,227 @@
+﻿using System;
+using System.Collections.Generic;
+using FizzWare.NBuilder;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using NzbDrone.Core.Download;
+using NzbDrone.Core.Indexers;
+using NzbDrone.Core.Test.Framework;
+
+namespace NzbDrone.Core.Test.Download
+{
+    [TestFixture]
+    public class DownloadClientProviderFixture : CoreTest<DownloadClientProvider>
+    {
+        private List<IDownloadClient> _downloadClients;
+        private List<DownloadClientStatus> _blockedProviders;
+        private int _nextId;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _downloadClients = new List<IDownloadClient>();
+            _blockedProviders = new List<DownloadClientStatus>();
+            _nextId = 1;
+
+            Mocker.GetMock<IDownloadClientFactory>()
+                  .Setup(v => v.GetAvailableProviders())
+                  .Returns(_downloadClients);
+
+            Mocker.GetMock<IDownloadClientStatusService>()
+                  .Setup(v => v.GetBlockedProviders())
+                  .Returns(_blockedProviders);
+        }
+
+        private Mock<IDownloadClient> WithUsenetClient(int priority = 0)
+        {
+            var mock = new Mock<IDownloadClient>(MockBehavior.Default);
+            mock.SetupGet(s => s.Definition)
+                .Returns(Builder<DownloadClientDefinition>
+                    .CreateNew()
+                    .With(v => v.Id = _nextId++)
+                    .With(v => v.Priority = priority)
+                    .Build());
+
+            _downloadClients.Add(mock.Object);
+
+            mock.SetupGet(v => v.Protocol).Returns(DownloadProtocol.Usenet);
+
+            return mock;
+        }
+
+        private Mock<IDownloadClient> WithTorrentClient(int priority = 0)
+        {
+            var mock = new Mock<IDownloadClient>(MockBehavior.Default);
+            mock.SetupGet(s => s.Definition)
+                .Returns(Builder<DownloadClientDefinition>
+                    .CreateNew()
+                    .With(v => v.Id = _nextId++)
+                    .With(v => v.Priority = priority)
+                    .Build());
+
+            _downloadClients.Add(mock.Object);
+
+            mock.SetupGet(v => v.Protocol).Returns(DownloadProtocol.Torrent);
+
+            return mock;
+        }
+
+        private void GivenBlockedClient(int id)
+        {
+            _blockedProviders.Add(new DownloadClientStatus
+            {
+                ProviderId = id,
+                DisabledTill = DateTime.UtcNow.AddHours(3)
+            });
+        }
+
+        [Test]
+        public void should_roundrobin_over_usenet_client()
+        {
+            WithUsenetClient();
+            WithUsenetClient();
+            WithUsenetClient();
+            WithTorrentClient();
+
+            var client1 = Subject.GetDownloadClient(DownloadProtocol.Usenet);
+            var client2 = Subject.GetDownloadClient(DownloadProtocol.Usenet);
+            var client3 = Subject.GetDownloadClient(DownloadProtocol.Usenet);
+            var client4 = Subject.GetDownloadClient(DownloadProtocol.Usenet);
+            var client5 = Subject.GetDownloadClient(DownloadProtocol.Usenet);
+
+            client1.Definition.Id.Should().Be(1);
+            client2.Definition.Id.Should().Be(2);
+            client3.Definition.Id.Should().Be(3);
+            client4.Definition.Id.Should().Be(1);
+            client5.Definition.Id.Should().Be(2);
+        }
+
+        [Test]
+        public void should_roundrobin_over_torrent_client()
+        {
+            WithUsenetClient();
+            WithTorrentClient();
+            WithTorrentClient();
+            WithTorrentClient();
+
+            var client1 = Subject.GetDownloadClient(DownloadProtocol.Torrent);
+            var client2 = Subject.GetDownloadClient(DownloadProtocol.Torrent);
+            var client3 = Subject.GetDownloadClient(DownloadProtocol.Torrent);
+            var client4 = Subject.GetDownloadClient(DownloadProtocol.Torrent);
+            var client5 = Subject.GetDownloadClient(DownloadProtocol.Torrent);
+
+            client1.Definition.Id.Should().Be(2);
+            client2.Definition.Id.Should().Be(3);
+            client3.Definition.Id.Should().Be(4);
+            client4.Definition.Id.Should().Be(2);
+            client5.Definition.Id.Should().Be(3);
+        }
+
+        [Test]
+        public void should_roundrobin_over_protocol_separately()
+        {
+            WithUsenetClient();
+            WithTorrentClient();
+            WithTorrentClient();
+
+            var client1 = Subject.GetDownloadClient(DownloadProtocol.Usenet);
+            var client2 = Subject.GetDownloadClient(DownloadProtocol.Torrent);
+            var client3 = Subject.GetDownloadClient(DownloadProtocol.Torrent);
+            var client4 = Subject.GetDownloadClient(DownloadProtocol.Torrent);
+
+            client1.Definition.Id.Should().Be(1);
+            client2.Definition.Id.Should().Be(2);
+            client3.Definition.Id.Should().Be(3);
+            client4.Definition.Id.Should().Be(2);
+        }
+
+        [Test]
+        public void should_skip_blocked_torrent_client()
+        {
+            WithUsenetClient();
+            WithTorrentClient();
+            WithTorrentClient();
+            WithTorrentClient();
+
+            GivenBlockedClient(3);
+
+            var client1 = Subject.GetDownloadClient(DownloadProtocol.Torrent);
+            var client2 = Subject.GetDownloadClient(DownloadProtocol.Torrent);
+            var client3 = Subject.GetDownloadClient(DownloadProtocol.Torrent);
+            var client4 = Subject.GetDownloadClient(DownloadProtocol.Torrent);
+            var client5 = Subject.GetDownloadClient(DownloadProtocol.Torrent);
+
+            client1.Definition.Id.Should().Be(2);
+            client2.Definition.Id.Should().Be(4);
+            client3.Definition.Id.Should().Be(2);
+            client4.Definition.Id.Should().Be(4);
+        }
+
+        [Test]
+        public void should_not_skip_blocked_torrent_client_if_all_blocked()
+        {
+            WithUsenetClient();
+            WithTorrentClient();
+            WithTorrentClient();
+            WithTorrentClient();
+
+            GivenBlockedClient(2);
+            GivenBlockedClient(3);
+            GivenBlockedClient(4);
+
+            var client1 = Subject.GetDownloadClient(DownloadProtocol.Torrent);
+            var client2 = Subject.GetDownloadClient(DownloadProtocol.Torrent);
+            var client3 = Subject.GetDownloadClient(DownloadProtocol.Torrent);
+            var client4 = Subject.GetDownloadClient(DownloadProtocol.Torrent);
+            var client5 = Subject.GetDownloadClient(DownloadProtocol.Torrent);
+
+            client1.Definition.Id.Should().Be(2);
+            client2.Definition.Id.Should().Be(3);
+            client3.Definition.Id.Should().Be(4);
+            client4.Definition.Id.Should().Be(2);
+        }
+
+        [Test]
+        public void should_skip_secondary_prio_torrent_client()
+        {
+            WithUsenetClient();
+            WithTorrentClient(2);
+            WithTorrentClient();
+            WithTorrentClient();
+
+            var client1 = Subject.GetDownloadClient(DownloadProtocol.Torrent);
+            var client2 = Subject.GetDownloadClient(DownloadProtocol.Torrent);
+            var client3 = Subject.GetDownloadClient(DownloadProtocol.Torrent);
+            var client4 = Subject.GetDownloadClient(DownloadProtocol.Torrent);
+            var client5 = Subject.GetDownloadClient(DownloadProtocol.Torrent);
+
+            client1.Definition.Id.Should().Be(3);
+            client2.Definition.Id.Should().Be(4);
+            client3.Definition.Id.Should().Be(3);
+            client4.Definition.Id.Should().Be(4);
+        }
+
+        [Test]
+        public void should_not_skip_secondary_prio_torrent_client_if_primary_blocked()
+        {
+            WithUsenetClient();
+            WithTorrentClient(2);
+            WithTorrentClient(2);
+            WithTorrentClient();
+
+            GivenBlockedClient(4);
+
+            var client1 = Subject.GetDownloadClient(DownloadProtocol.Torrent);
+            var client2 = Subject.GetDownloadClient(DownloadProtocol.Torrent);
+            var client3 = Subject.GetDownloadClient(DownloadProtocol.Torrent);
+            var client4 = Subject.GetDownloadClient(DownloadProtocol.Torrent);
+            var client5 = Subject.GetDownloadClient(DownloadProtocol.Torrent);
+
+            client1.Definition.Id.Should().Be(2);
+            client2.Definition.Id.Should().Be(3);
+            client3.Definition.Id.Should().Be(2);
+            client4.Definition.Id.Should().Be(3);
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/Download/DownloadClientStatusServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientStatusServiceFixture.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Linq;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using NzbDrone.Common.EnvironmentInfo;
+using NzbDrone.Core.Download;
+using NzbDrone.Core.Test.Framework;
+
+namespace NzbDrone.Core.Test.Download
+{
+    public class DownloadClientStatusServiceFixture : CoreTest<DownloadClientStatusService>
+    {
+        private DateTime _epoch;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _epoch = DateTime.UtcNow;
+
+            Mocker.GetMock<IRuntimeInfo>()
+                .SetupGet(v => v.StartTime)
+                .Returns(_epoch - TimeSpan.FromHours(1));
+        }
+
+        private DownloadClientStatus WithStatus(DownloadClientStatus status)
+        {
+            Mocker.GetMock<IDownloadClientStatusRepository>()
+                .Setup(v => v.FindByProviderId(1))
+                .Returns(status);
+
+            Mocker.GetMock<IDownloadClientStatusRepository>()
+                .Setup(v => v.All())
+                .Returns(new[] { status });
+
+            return status;
+        }
+
+        private void VerifyUpdate()
+        {
+            Mocker.GetMock<IDownloadClientStatusRepository>()
+                .Verify(v => v.Upsert(It.IsAny<DownloadClientStatus>()), Times.Once());
+        }
+
+        private void VerifyNoUpdate()
+        {
+            Mocker.GetMock<IDownloadClientStatusRepository>()
+                .Verify(v => v.Upsert(It.IsAny<DownloadClientStatus>()), Times.Never());
+        }
+
+        [Test]
+        public void should_not_consider_blocked_within_5_minutes_since_initial_failure()
+        {
+            WithStatus(new DownloadClientStatus
+            {
+                InitialFailure = _epoch - TimeSpan.FromMinutes(4),
+                MostRecentFailure = _epoch - TimeSpan.FromSeconds(4),
+                EscalationLevel = 3
+            });
+
+            Subject.RecordFailure(1);
+
+            VerifyUpdate();
+
+            var status = Subject.GetBlockedProviders().FirstOrDefault();
+            status.Should().BeNull();
+        }
+
+        [Test]
+        public void should_consider_blocked_after_5_minutes_since_initial_failure()
+        {
+            WithStatus(new DownloadClientStatus
+            {
+                InitialFailure = _epoch - TimeSpan.FromMinutes(6),
+                MostRecentFailure = _epoch - TimeSpan.FromSeconds(120),
+                EscalationLevel = 3
+            });
+
+            Subject.RecordFailure(1);
+
+            VerifyUpdate();
+
+            var status = Subject.GetBlockedProviders().FirstOrDefault();
+            status.Should().NotBeNull();
+        }
+
+        [Test]
+        public void should_not_escalate_further_till_after_5_minutes_since_initial_failure()
+        {
+            var origStatus = WithStatus(new DownloadClientStatus
+            {
+                InitialFailure = _epoch - TimeSpan.FromMinutes(4),
+                MostRecentFailure = _epoch - TimeSpan.FromSeconds(4),
+                EscalationLevel = 3
+            });
+
+            Subject.RecordFailure(1);
+            Subject.RecordFailure(1);
+            Subject.RecordFailure(1);
+            Subject.RecordFailure(1);
+            Subject.RecordFailure(1);
+            Subject.RecordFailure(1);
+            Subject.RecordFailure(1);
+
+            var status = Subject.GetBlockedProviders().FirstOrDefault();
+            status.Should().BeNull();
+
+            origStatus.EscalationLevel.Should().Be(3);
+        }
+
+        [Test]
+        public void should_escalate_further_after_5_minutes_since_initial_failure()
+        {
+            WithStatus(new DownloadClientStatus
+            {
+                InitialFailure = _epoch - TimeSpan.FromMinutes(6),
+                MostRecentFailure = _epoch - TimeSpan.FromSeconds(120),
+                EscalationLevel = 3
+            });
+
+            Subject.RecordFailure(1);
+            Subject.RecordFailure(1);
+            Subject.RecordFailure(1);
+            Subject.RecordFailure(1);
+            Subject.RecordFailure(1);
+            Subject.RecordFailure(1);
+            Subject.RecordFailure(1);
+
+            var status = Subject.GetBlockedProviders().FirstOrDefault();
+            status.Should().NotBeNull();
+
+            status.EscalationLevel.Should().BeGreaterThan(3);
+        }
+
+        [Test]
+        public void should_not_escalate_beyond_3_hours()
+        {
+            WithStatus(new DownloadClientStatus
+            {
+                InitialFailure = _epoch - TimeSpan.FromMinutes(6),
+                MostRecentFailure = _epoch - TimeSpan.FromSeconds(120),
+                EscalationLevel = 3
+            });
+
+            Subject.RecordFailure(1);
+            Subject.RecordFailure(1);
+            Subject.RecordFailure(1);
+            Subject.RecordFailure(1);
+            Subject.RecordFailure(1);
+            Subject.RecordFailure(1);
+            Subject.RecordFailure(1);
+            Subject.RecordFailure(1);
+            Subject.RecordFailure(1);
+
+            var status = Subject.GetBlockedProviders().FirstOrDefault();
+            status.Should().NotBeNull();
+            status.DisabledTill.Should().HaveValue();
+            status.DisabledTill.Should().NotBeAfter(_epoch + TimeSpan.FromHours(3.1));
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/IndexerTests/TestIndexer.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/TestIndexer.cs
@@ -1,12 +1,13 @@
 using NLog;
 using NzbDrone.Common.Http;
 using NzbDrone.Core.Configuration;
+using NzbDrone.Core.Download;
 using NzbDrone.Core.Indexers;
 using NzbDrone.Core.Messaging.Events;
 
 namespace NzbDrone.Core.Test.IndexerTests
 {
-    public class TestIndexer : HttpIndexerBase<TestIndexerSettings>
+    public class TestIndexer : UsenetIndexerBase<TestIndexerSettings>
     {
         public override string Name => "Test Indexer";
         public override string BaseUrl => "http://testindexer.com";
@@ -18,8 +19,8 @@ namespace NzbDrone.Core.Test.IndexerTests
         public int _supportedPageSize;
         public override int PageSize => _supportedPageSize;
 
-        public TestIndexer(IHttpClient httpClient, IEventAggregator eventAggregator, IIndexerStatusService indexerStatusService, IConfigService configService, Logger logger)
-            : base(httpClient, eventAggregator, indexerStatusService, configService, logger)
+        public TestIndexer(IHttpClient httpClient, IEventAggregator eventAggregator, IIndexerStatusService indexerStatusService, IConfigService configService, IValidateNzbs nzbValidationService, Logger logger)
+            : base(httpClient, eventAggregator, indexerStatusService, configService, nzbValidationService, logger)
         {
         }
 

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/UsenetDownloadStation.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/UsenetDownloadStation.cs
@@ -31,9 +31,8 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
                                      IHttpClient httpClient,
                                      IConfigService configService,
                                      IDiskProvider diskProvider,
-                                     IValidateNzbs nzbValidationService,
                                      Logger logger)
-        : base(httpClient, configService, diskProvider, nzbValidationService, logger)
+        : base(httpClient, configService, diskProvider, logger)
         {
             _dsInfoProxy = dsInfoProxy;
             _dsTaskProxy = dsTaskProxy;

--- a/src/NzbDrone.Core/Download/Clients/NzbVortex/NzbVortex.cs
+++ b/src/NzbDrone.Core/Download/Clients/NzbVortex/NzbVortex.cs
@@ -20,9 +20,8 @@ namespace NzbDrone.Core.Download.Clients.NzbVortex
                        IHttpClient httpClient,
                        IConfigService configService,
                        IDiskProvider diskProvider,
-                       IValidateNzbs nzbValidationService,
                        Logger logger)
-            : base(httpClient, configService, diskProvider, nzbValidationService, logger)
+            : base(httpClient, configService, diskProvider, logger)
         {
             _proxy = proxy;
         }

--- a/src/NzbDrone.Core/Download/Clients/Nzbget/Nzbget.cs
+++ b/src/NzbDrone.Core/Download/Clients/Nzbget/Nzbget.cs
@@ -25,9 +25,8 @@ namespace NzbDrone.Core.Download.Clients.Nzbget
                       IHttpClient httpClient,
                       IConfigService configService,
                       IDiskProvider diskProvider,
-                      IValidateNzbs nzbValidationService,
                       Logger logger)
-            : base(httpClient, configService, diskProvider, nzbValidationService, logger)
+            : base(httpClient, configService, diskProvider, logger)
         {
             _proxy = proxy;
         }

--- a/src/NzbDrone.Core/Download/Clients/Sabnzbd/Sabnzbd.cs
+++ b/src/NzbDrone.Core/Download/Clients/Sabnzbd/Sabnzbd.cs
@@ -22,9 +22,8 @@ namespace NzbDrone.Core.Download.Clients.Sabnzbd
                        IHttpClient httpClient,
                        IConfigService configService,
                        IDiskProvider diskProvider,
-                       IValidateNzbs nzbValidationService,
                        Logger logger)
-            : base(httpClient, configService, diskProvider, nzbValidationService, logger)
+            : base(httpClient, configService, diskProvider, logger)
         {
             _proxy = proxy;
         }

--- a/src/NzbDrone.Core/Download/Clients/rTorrent/RTorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/rTorrent/RTorrent.cs
@@ -66,7 +66,7 @@ namespace NzbDrone.Core.Download.Clients.RTorrent
             {
                 _logger.Debug("rTorrent didn't add the torrent within {0} seconds: {1}.", tries * retryDelay / 1000, filename);
 
-                throw new ReleaseDownloadException(release, "Downloading torrent failed");
+                throw new ReleaseDownloadException("Downloading torrent failed");
             }
 
             return hash;

--- a/src/NzbDrone.Core/Download/DownloadClientBase.cs
+++ b/src/NzbDrone.Core/Download/DownloadClientBase.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using FluentValidation.Results;
 using NLog;
 using NzbDrone.Common.Disk;
@@ -54,7 +55,7 @@ namespace NzbDrone.Core.Download
             get;
         }
 
-        public abstract string Download(ReleaseInfo release, bool redirect);
+        public abstract Task<string> Download(ReleaseInfo release, bool redirect, IIndexer indexer);
 
         public ValidationResult Test()
         {

--- a/src/NzbDrone.Core/Download/DownloadMappingService.cs
+++ b/src/NzbDrone.Core/Download/DownloadMappingService.cs
@@ -6,7 +6,7 @@ using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Security;
 
-namespace NzbDrone.Core.Indexers
+namespace NzbDrone.Core.Download
 {
     public interface IDownloadMappingService
     {

--- a/src/NzbDrone.Core/Download/IDownloadClient.cs
+++ b/src/NzbDrone.Core/Download/IDownloadClient.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using NzbDrone.Core.Indexers;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.ThingiProvider;
@@ -7,6 +8,6 @@ namespace NzbDrone.Core.Download
     public interface IDownloadClient : IProvider
     {
         DownloadProtocol Protocol { get; }
-        string Download(ReleaseInfo release, bool redirect);
+        Task<string> Download(ReleaseInfo release, bool redirect, IIndexer indexer);
     }
 }

--- a/src/NzbDrone.Core/Download/NzbValidationService.cs
+++ b/src/NzbDrone.Core/Download/NzbValidationService.cs
@@ -8,12 +8,12 @@ namespace NzbDrone.Core.Download
 {
     public interface IValidateNzbs
     {
-        void Validate(string filename, byte[] fileContent);
+        void Validate(byte[] fileContent);
     }
 
     public class NzbValidationService : IValidateNzbs
     {
-        public void Validate(string filename, byte[] fileContent)
+        public void Validate(byte[] fileContent)
         {
             var reader = new StreamReader(new MemoryStream(fileContent));
 
@@ -24,7 +24,7 @@ namespace NzbDrone.Core.Download
 
                 if (nzb == null)
                 {
-                    throw new InvalidNzbException("Invalid NZB: No Root element [{0}]", filename);
+                    throw new InvalidNzbException("Invalid NZB: No Root element");
                 }
 
                 // nZEDb has an bug in their error reporting code spitting out invalid http status codes
@@ -37,7 +37,7 @@ namespace NzbDrone.Core.Download
 
                 if (!nzb.Name.LocalName.Equals("nzb"))
                 {
-                    throw new InvalidNzbException("Invalid NZB: Unexpected root element. Expected 'nzb' found '{0}' [{1}]", nzb.Name.LocalName, filename);
+                    throw new InvalidNzbException("Invalid NZB: Unexpected root element. Expected 'nzb' found '{0}'", nzb.Name.LocalName);
                 }
 
                 var ns = nzb.Name.Namespace;
@@ -45,7 +45,7 @@ namespace NzbDrone.Core.Download
 
                 if (files.Empty())
                 {
-                    throw new InvalidNzbException("Invalid NZB: No files [{0}]", filename);
+                    throw new InvalidNzbException("Invalid NZB: No files");
                 }
             }
         }

--- a/src/NzbDrone.Core/Exceptions/DownloadClientRejectedReleaseException.cs
+++ b/src/NzbDrone.Core/Exceptions/DownloadClientRejectedReleaseException.cs
@@ -1,28 +1,33 @@
-﻿using System;
+using System;
 using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.Exceptions
 {
     public class DownloadClientRejectedReleaseException : ReleaseDownloadException
     {
+        public ReleaseInfo Release { get; set; }
         public DownloadClientRejectedReleaseException(ReleaseInfo release, string message, params object[] args)
-            : base(release, message, args)
+            : base(message, args)
         {
+            Release = release;
         }
 
         public DownloadClientRejectedReleaseException(ReleaseInfo release, string message)
-            : base(release, message)
+            : base(message)
         {
+            Release = release;
         }
 
         public DownloadClientRejectedReleaseException(ReleaseInfo release, string message, Exception innerException, params object[] args)
-            : base(release, message, innerException, args)
+            : base(message, innerException, args)
         {
+            Release = release;
         }
 
         public DownloadClientRejectedReleaseException(ReleaseInfo release, string message, Exception innerException)
-            : base(release, message, innerException)
+            : base(message, innerException)
         {
+            Release = release;
         }
     }
 }

--- a/src/NzbDrone.Core/Exceptions/ReleaseDownloadException.cs
+++ b/src/NzbDrone.Core/Exceptions/ReleaseDownloadException.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using NzbDrone.Common.Exceptions;
 using NzbDrone.Core.Parser.Model;
 
@@ -6,30 +6,24 @@ namespace NzbDrone.Core.Exceptions
 {
     public class ReleaseDownloadException : NzbDroneException
     {
-        public ReleaseInfo Release { get; set; }
-
-        public ReleaseDownloadException(ReleaseInfo release, string message, params object[] args)
+        public ReleaseDownloadException(string message, params object[] args)
             : base(message, args)
         {
-            Release = release;
         }
 
-        public ReleaseDownloadException(ReleaseInfo release, string message)
+        public ReleaseDownloadException(string message)
             : base(message)
         {
-            Release = release;
         }
 
-        public ReleaseDownloadException(ReleaseInfo release, string message, Exception innerException, params object[] args)
+        public ReleaseDownloadException(string message, Exception innerException, params object[] args)
             : base(message, innerException, args)
         {
-            Release = release;
         }
 
-        public ReleaseDownloadException(ReleaseInfo release, string message, Exception innerException)
+        public ReleaseDownloadException(string message, Exception innerException)
             : base(message, innerException)
         {
-            Release = release;
         }
     }
 }

--- a/src/NzbDrone.Core/Exceptions/ReleaseUnavailableException.cs
+++ b/src/NzbDrone.Core/Exceptions/ReleaseUnavailableException.cs
@@ -1,27 +1,27 @@
-﻿using System;
+using System;
 using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.Exceptions
 {
     public class ReleaseUnavailableException : ReleaseDownloadException
     {
-        public ReleaseUnavailableException(ReleaseInfo release, string message, params object[] args)
-            : base(release, message, args)
+        public ReleaseUnavailableException(string message, params object[] args)
+            : base(message, args)
         {
         }
 
-        public ReleaseUnavailableException(ReleaseInfo release, string message)
-            : base(release, message)
+        public ReleaseUnavailableException(string message)
+            : base(message)
         {
         }
 
-        public ReleaseUnavailableException(ReleaseInfo release, string message, Exception innerException, params object[] args)
-            : base(release, message, innerException, args)
+        public ReleaseUnavailableException(string message, Exception innerException, params object[] args)
+            : base(message, innerException, args)
         {
         }
 
-        public ReleaseUnavailableException(ReleaseInfo release, string message, Exception innerException)
-            : base(release, message, innerException)
+        public ReleaseUnavailableException(string message, Exception innerException)
+            : base(message, innerException)
         {
         }
     }

--- a/src/NzbDrone.Core/IndexerSearch/NzbSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/NzbSearchService.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using NLog;
 using NzbDrone.Common.Instrumentation.Extensions;
+using NzbDrone.Core.Download;
 using NzbDrone.Core.Indexers;
 using NzbDrone.Core.Indexers.Events;
 using NzbDrone.Core.IndexerSearch.Definitions;

--- a/src/NzbDrone.Core/Indexers/Definitions/AnimeBytes.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/AnimeBytes.cs
@@ -23,7 +23,7 @@ using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.Definitions
 {
-    public class AnimeBytes : HttpIndexerBase<AnimeBytesSettings>
+    public class AnimeBytes : TorrentIndexerBase<AnimeBytesSettings>
     {
         public override string Name => "AnimeBytes";
         public override string BaseUrl => "https://animebytes.tv/";

--- a/src/NzbDrone.Core/Indexers/Definitions/AnimeTorrents.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/AnimeTorrents.cs
@@ -21,7 +21,7 @@ using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.Definitions
 {
-    public class AnimeTorrents : HttpIndexerBase<AnimeTorrentsSettings>
+    public class AnimeTorrents : TorrentIndexerBase<AnimeTorrentsSettings>
     {
         public override string Name => "AnimeTorrents";
 

--- a/src/NzbDrone.Core/Indexers/Definitions/Avistaz/AvistazBase.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Avistaz/AvistazBase.cs
@@ -9,7 +9,7 @@ using NzbDrone.Core.Messaging.Events;
 
 namespace NzbDrone.Core.Indexers.Definitions.Avistaz
 {
-    public abstract class AvistazBase : HttpIndexerBase<AvistazSettings>
+    public abstract class AvistazBase : TorrentIndexerBase<AvistazSettings>
     {
         public override DownloadProtocol Protocol => DownloadProtocol.Torrent;
         public override string BaseUrl => "";

--- a/src/NzbDrone.Core/Indexers/Definitions/BakaBT.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/BakaBT.cs
@@ -21,7 +21,7 @@ using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.Definitions
 {
-    public class BakaBT : HttpIndexerBase<BakaBTSettings>
+    public class BakaBT : TorrentIndexerBase<BakaBTSettings>
     {
         public override string Name => "BakaBT";
 

--- a/src/NzbDrone.Core/Indexers/Definitions/BeyondHD.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/BeyondHD.cs
@@ -21,7 +21,7 @@ using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.Definitions
 {
-    public class BeyondHD : HttpIndexerBase<BeyondHDSettings>
+    public class BeyondHD : TorrentIndexerBase<BeyondHDSettings>
     {
         public override string Name => "BeyondHD";
 

--- a/src/NzbDrone.Core/Indexers/Definitions/BroadcastheNet/BroadcastheNet.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/BroadcastheNet/BroadcastheNet.cs
@@ -6,7 +6,7 @@ using NzbDrone.Core.Messaging.Events;
 
 namespace NzbDrone.Core.Indexers.BroadcastheNet
 {
-    public class BroadcastheNet : HttpIndexerBase<BroadcastheNetSettings>
+    public class BroadcastheNet : TorrentIndexerBase<BroadcastheNetSettings>
     {
         public override string Name => "BroadcasTheNet";
 

--- a/src/NzbDrone.Core/Indexers/Definitions/DigitalCore.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/DigitalCore.cs
@@ -21,7 +21,7 @@ using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.Definitions
 {
-    public class DigitalCore : HttpIndexerBase<DigitalCoreSettings>
+    public class DigitalCore : TorrentIndexerBase<DigitalCoreSettings>
     {
         public override string Name => "DigitalCore";
         public override string BaseUrl => "https://digitalcore.club/";

--- a/src/NzbDrone.Core/Indexers/Definitions/FileList/FileList.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/FileList/FileList.cs
@@ -6,7 +6,7 @@ using NzbDrone.Core.Messaging.Events;
 
 namespace NzbDrone.Core.Indexers.FileList
 {
-    public class FileList : HttpIndexerBase<FileListSettings>
+    public class FileList : TorrentIndexerBase<FileListSettings>
     {
         public override string Name => "FileList.io";
         public override string BaseUrl => "https://filelist.io";

--- a/src/NzbDrone.Core/Indexers/Definitions/Gazelle/Gazelle.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Gazelle/Gazelle.cs
@@ -7,7 +7,7 @@ using NzbDrone.Core.Messaging.Events;
 
 namespace NzbDrone.Core.Indexers.Gazelle
 {
-    public abstract class Gazelle : HttpIndexerBase<GazelleSettings>
+    public abstract class Gazelle : TorrentIndexerBase<GazelleSettings>
     {
         public override DownloadProtocol Protocol => DownloadProtocol.Torrent;
         public override string BaseUrl => "";

--- a/src/NzbDrone.Core/Indexers/Definitions/HDBits/HDBits.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/HDBits/HDBits.cs
@@ -6,7 +6,7 @@ using NzbDrone.Core.Messaging.Events;
 
 namespace NzbDrone.Core.Indexers.HDBits
 {
-    public class HDBits : HttpIndexerBase<HDBitsSettings>
+    public class HDBits : TorrentIndexerBase<HDBitsSettings>
     {
         public override string Name => "HDBits";
         public override string BaseUrl => "https://hdbits.org";

--- a/src/NzbDrone.Core/Indexers/Definitions/HDTorrents.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/HDTorrents.cs
@@ -20,7 +20,7 @@ using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.Definitions
 {
-    public class HDTorrents : HttpIndexerBase<HDTorrentsSettings>
+    public class HDTorrents : TorrentIndexerBase<HDTorrentsSettings>
     {
         public override string Name => "HD-Torrents";
 

--- a/src/NzbDrone.Core/Indexers/Definitions/Headphones/Headphones.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Headphones/Headphones.cs
@@ -6,11 +6,12 @@ using FluentValidation.Results;
 using NLog;
 using NzbDrone.Common.Http;
 using NzbDrone.Core.Configuration;
+using NzbDrone.Core.Download;
 using NzbDrone.Core.Messaging.Events;
 
 namespace NzbDrone.Core.Indexers.Headphones
 {
-    public class Headphones : HttpIndexerBase<HeadphonesSettings>
+    public class Headphones : UsenetIndexerBase<HeadphonesSettings>
     {
         public override string Name => "Headphones VIP";
 
@@ -35,8 +36,8 @@ namespace NzbDrone.Core.Indexers.Headphones
             return new HeadphonesRssParser(Capabilities.Categories);
         }
 
-        public Headphones(IHttpClient httpClient, IEventAggregator eventAggregator, IIndexerStatusService indexerStatusService, IConfigService configService, Logger logger)
-            : base(httpClient, eventAggregator, indexerStatusService, configService, logger)
+        public Headphones(IHttpClient httpClient, IEventAggregator eventAggregator, IIndexerStatusService indexerStatusService, IConfigService configService, IValidateNzbs nzbValidationService, Logger logger)
+            : base(httpClient, eventAggregator, indexerStatusService, configService, nzbValidationService, logger)
         {
         }
 

--- a/src/NzbDrone.Core/Indexers/Definitions/IPTorrents.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/IPTorrents.cs
@@ -18,7 +18,7 @@ using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.Definitions
 {
-    public class IPTorrents : HttpIndexerBase<IPTorrentsSettings>
+    public class IPTorrents : TorrentIndexerBase<IPTorrentsSettings>
     {
         public override string Name => "IPTorrents";
 

--- a/src/NzbDrone.Core/Indexers/Definitions/ImmortalSeed.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/ImmortalSeed.cs
@@ -21,7 +21,7 @@ using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.Definitions
 {
-    public class ImmortalSeed : HttpIndexerBase<ImmortalSeedSettings>
+    public class ImmortalSeed : TorrentIndexerBase<ImmortalSeedSettings>
     {
         public override string Name => "ImmortalSeed";
 

--- a/src/NzbDrone.Core/Indexers/Definitions/Milkie.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Milkie.cs
@@ -16,7 +16,7 @@ using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.Definitions
 {
-    public class Milkie : HttpIndexerBase<MilkieSettings>
+    public class Milkie : TorrentIndexerBase<MilkieSettings>
     {
         public override string Name => "Milkie";
 

--- a/src/NzbDrone.Core/Indexers/Definitions/MyAnonamouse.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/MyAnonamouse.cs
@@ -18,7 +18,7 @@ using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.Definitions
 {
-    public class MyAnonamouse : HttpIndexerBase<MyAnonamouseSettings>
+    public class MyAnonamouse : TorrentIndexerBase<MyAnonamouseSettings>
     {
         public override string Name => "MyAnonamouse";
 

--- a/src/NzbDrone.Core/Indexers/Definitions/Newznab/Newznab.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Newznab/Newznab.cs
@@ -7,13 +7,14 @@ using NLog;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Http;
 using NzbDrone.Core.Configuration;
+using NzbDrone.Core.Download;
 using NzbDrone.Core.Messaging.Events;
 using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.Newznab
 {
-    public class Newznab : HttpIndexerBase<NewznabSettings>
+    public class Newznab : UsenetIndexerBase<NewznabSettings>
     {
         private readonly INewznabCapabilitiesProvider _capabilitiesProvider;
 
@@ -108,8 +109,8 @@ namespace NzbDrone.Core.Indexers.Newznab
             }
         }
 
-        public Newznab(INewznabCapabilitiesProvider capabilitiesProvider, IHttpClient httpClient, IEventAggregator eventAggregator, IIndexerStatusService indexerStatusService, IConfigService configService, Logger logger)
-            : base(httpClient, eventAggregator, indexerStatusService, configService, logger)
+        public Newznab(INewznabCapabilitiesProvider capabilitiesProvider, IHttpClient httpClient, IEventAggregator eventAggregator, IIndexerStatusService indexerStatusService, IConfigService configService, IValidateNzbs nzbValidationService, Logger logger)
+            : base(httpClient, eventAggregator, indexerStatusService, configService, nzbValidationService, logger)
         {
             _capabilitiesProvider = capabilitiesProvider;
         }

--- a/src/NzbDrone.Core/Indexers/Definitions/PassThePopcorn/PassThePopcorn.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/PassThePopcorn/PassThePopcorn.cs
@@ -7,7 +7,7 @@ using NzbDrone.Core.Messaging.Events;
 
 namespace NzbDrone.Core.Indexers.PassThePopcorn
 {
-    public class PassThePopcorn : HttpIndexerBase<PassThePopcornSettings>
+    public class PassThePopcorn : TorrentIndexerBase<PassThePopcornSettings>
     {
         public override string Name => "PassThePopcorn";
         public override string BaseUrl => "https://passthepopcorn.me";

--- a/src/NzbDrone.Core/Indexers/Definitions/PreToMe.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/PreToMe.cs
@@ -21,7 +21,7 @@ using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.Definitions
 {
-    public class PreToMe : HttpIndexerBase<PreToMeSettings>
+    public class PreToMe : TorrentIndexerBase<PreToMeSettings>
     {
         public override string Name => "PreToMe";
         public override string BaseUrl => "https://pretome.info/";

--- a/src/NzbDrone.Core/Indexers/Definitions/Rarbg/Rarbg.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Rarbg/Rarbg.cs
@@ -11,7 +11,7 @@ using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.Rarbg
 {
-    public class Rarbg : HttpIndexerBase<RarbgSettings>
+    public class Rarbg : TorrentIndexerBase<RarbgSettings>
     {
         private readonly IRarbgTokenProvider _tokenProvider;
 

--- a/src/NzbDrone.Core/Indexers/Definitions/RevolutionTT.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/RevolutionTT.cs
@@ -21,7 +21,7 @@ using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.Definitions
 {
-    public class RevolutionTT : HttpIndexerBase<RevolutionTTSettings>
+    public class RevolutionTT : TorrentIndexerBase<RevolutionTTSettings>
     {
         public override string Name => "RevolutionTT";
 

--- a/src/NzbDrone.Core/Indexers/Definitions/SubsPlease.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/SubsPlease.cs
@@ -18,7 +18,7 @@ using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.Definitions
 {
-    public class SubsPlease : HttpIndexerBase<SubsPleaseSettings>
+    public class SubsPlease : TorrentIndexerBase<SubsPleaseSettings>
     {
         public override string Name => "SubsPlease";
         public override string BaseUrl => "https://subsplease.org/";

--- a/src/NzbDrone.Core/Indexers/Definitions/SuperBits.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/SuperBits.cs
@@ -19,7 +19,7 @@ using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.Definitions
 {
-    public class SuperBits : HttpIndexerBase<SuperBitsSettings>
+    public class SuperBits : TorrentIndexerBase<SuperBitsSettings>
     {
         public override string Name => "SuperBits";
 

--- a/src/NzbDrone.Core/Indexers/Definitions/ThePirateBay.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/ThePirateBay.cs
@@ -18,7 +18,7 @@ using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.Definitions
 {
-    public class ThePirateBay : HttpIndexerBase<ThePirateBaySettings>
+    public class ThePirateBay : TorrentIndexerBase<ThePirateBaySettings>
     {
         public override string Name => "ThePirateBay";
         public override string BaseUrl => "https://thepiratebay.org/";

--- a/src/NzbDrone.Core/Indexers/Definitions/TorrentDay.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/TorrentDay.cs
@@ -17,7 +17,7 @@ using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.Definitions
 {
-    public class TorrentDay : HttpIndexerBase<TorrentDaySettings>
+    public class TorrentDay : TorrentIndexerBase<TorrentDaySettings>
     {
         public override string Name => "TorrentDay";
 

--- a/src/NzbDrone.Core/Indexers/Definitions/TorrentLeech.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/TorrentLeech.cs
@@ -21,7 +21,7 @@ using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.Definitions
 {
-    public class TorrentLeech : HttpIndexerBase<TorrentLeechSettings>
+    public class TorrentLeech : TorrentIndexerBase<TorrentLeechSettings>
     {
         public override string Name => "TorrentLeech";
 

--- a/src/NzbDrone.Core/Indexers/Definitions/TorrentPotato/TorrentPotato.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/TorrentPotato/TorrentPotato.cs
@@ -6,7 +6,7 @@ using NzbDrone.Core.Messaging.Events;
 
 namespace NzbDrone.Core.Indexers.TorrentPotato
 {
-    public class TorrentPotato : HttpIndexerBase<TorrentPotatoSettings>
+    public class TorrentPotato : TorrentIndexerBase<TorrentPotatoSettings>
     {
         public override string Name => "TorrentPotato";
         public override string BaseUrl => "http://127.0.0.1";

--- a/src/NzbDrone.Core/Indexers/Definitions/TorrentSeeds.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/TorrentSeeds.cs
@@ -20,7 +20,7 @@ using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.Definitions
 {
-    public class TorrentSeeds : HttpIndexerBase<TorrentSeedsSettings>
+    public class TorrentSeeds : TorrentIndexerBase<TorrentSeedsSettings>
     {
         public override string Name => "TorrentSeeds";
 

--- a/src/NzbDrone.Core/Indexers/Definitions/Torznab/Torznab.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Torznab/Torznab.cs
@@ -14,7 +14,7 @@ using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.Torznab
 {
-    public class Torznab : HttpIndexerBase<TorznabSettings>
+    public class Torznab : TorrentIndexerBase<TorznabSettings>
     {
         private readonly INewznabCapabilitiesProvider _capabilitiesProvider;
 

--- a/src/NzbDrone.Core/Indexers/Definitions/UNIT3D/Unit3dBase.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/UNIT3D/Unit3dBase.cs
@@ -5,7 +5,7 @@ using NzbDrone.Core.Messaging.Events;
 
 namespace NzbDrone.Core.Indexers.Definitions.UNIT3D
 {
-    public abstract class Unit3dBase : HttpIndexerBase<Unit3dSettings>
+    public abstract class Unit3dBase : TorrentIndexerBase<Unit3dSettings>
     {
         public override DownloadProtocol Protocol => DownloadProtocol.Torrent;
         public override string BaseUrl => "";

--- a/src/NzbDrone.Core/Indexers/HttpIndexerBase.cs
+++ b/src/NzbDrone.Core/Indexers/HttpIndexerBase.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Text;
@@ -10,7 +9,6 @@ using NLog;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Http;
 using NzbDrone.Core.Configuration;
-using NzbDrone.Core.Exceptions;
 using NzbDrone.Core.Http.CloudFlare;
 using NzbDrone.Core.Indexers.Events;
 using NzbDrone.Core.Indexers.Exceptions;
@@ -103,42 +101,6 @@ namespace NzbDrone.Core.Indexers
             }
 
             return FetchReleases(g => SetCookieFunctions(g).GetSearchRequests(searchCriteria));
-        }
-
-        public override async Task<byte[]> Download(Uri link)
-        {
-            Cookies = GetCookies();
-
-            if (link.Scheme == "magnet")
-            {
-                return Encoding.UTF8.GetBytes(link.OriginalString);
-            }
-
-            var requestBuilder = new HttpRequestBuilder(link.AbsoluteUri);
-
-            if (Cookies != null)
-            {
-                requestBuilder.SetCookies(Cookies);
-            }
-
-            var request = requestBuilder.Build();
-            request.AllowAutoRedirect = FollowRedirect;
-
-            var downloadBytes = Array.Empty<byte>();
-
-            try
-            {
-                var response = await _httpClient.ExecuteAsync(request);
-                downloadBytes = response.ResponseData;
-            }
-            catch (Exception)
-            {
-                _indexerStatusService.RecordFailure(Definition.Id);
-                _logger.Error("Download failed");
-                throw;
-            }
-
-            return downloadBytes;
         }
 
         protected IIndexerRequestGenerator SetCookieFunctions(IIndexerRequestGenerator generator)

--- a/src/NzbDrone.Core/Indexers/IndexerBase.cs
+++ b/src/NzbDrone.Core/Indexers/IndexerBase.cs
@@ -77,7 +77,7 @@ namespace NzbDrone.Core.Indexers
         public abstract Task<IndexerPageableQueryResult> Fetch(TvSearchCriteria searchCriteria);
         public abstract Task<IndexerPageableQueryResult> Fetch(BookSearchCriteria searchCriteria);
         public abstract Task<IndexerPageableQueryResult> Fetch(BasicSearchCriteria searchCriteria);
-        public abstract Task<byte[]> Download(Uri searchCriteria);
+        public abstract Task<byte[]> Download(Uri link);
 
         public abstract IndexerCapabilities GetCapabilities();
 

--- a/src/NzbDrone.Core/Indexers/TorrentIndexerBase.cs
+++ b/src/NzbDrone.Core/Indexers/TorrentIndexerBase.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using MonoTorrent;
+using NLog;
+using NzbDrone.Common.Http;
+using NzbDrone.Core.Configuration;
+using NzbDrone.Core.Exceptions;
+using NzbDrone.Core.Messaging.Events;
+using NzbDrone.Core.ThingiProvider;
+
+namespace NzbDrone.Core.Indexers
+{
+    public abstract class TorrentIndexerBase<TSettings> : HttpIndexerBase<TSettings>
+        where TSettings : IProviderConfig, new()
+    {
+        protected TorrentIndexerBase(IHttpClient httpClient, IEventAggregator eventAggregator, IIndexerStatusService indexerStatusService, IConfigService configService, Logger logger)
+            : base(httpClient, eventAggregator, indexerStatusService, configService, logger)
+        {
+        }
+
+        public override async Task<byte[]> Download(Uri link)
+        {
+            Cookies = GetCookies();
+
+            if (link.Scheme == "magnet")
+            {
+                ValidateMagnet(link.OriginalString);
+                return Encoding.UTF8.GetBytes(link.OriginalString);
+            }
+
+            var requestBuilder = new HttpRequestBuilder(link.AbsoluteUri);
+
+            if (Cookies != null)
+            {
+                requestBuilder.SetCookies(Cookies);
+            }
+
+            var request = requestBuilder.Build();
+            request.AllowAutoRedirect = FollowRedirect;
+
+            byte[] torrentData;
+
+            try
+            {
+                var response = await _httpClient.ExecuteAsync(request);
+                torrentData = response.ResponseData;
+            }
+            catch (HttpException ex)
+            {
+                if (ex.Response.StatusCode == HttpStatusCode.NotFound)
+                {
+                    _logger.Error(ex, "Downloading torrent file for release failed since it no longer exists ({0})", link.AbsoluteUri);
+                    throw new ReleaseUnavailableException("Downloading torrent failed", ex);
+                }
+
+                if ((int)ex.Response.StatusCode == 429)
+                {
+                    _logger.Error("API Grab Limit reached for {0}", link.AbsoluteUri);
+                }
+                else
+                {
+                    _logger.Error(ex, "Downloading torrent file for release failed ({0})", link.AbsoluteUri);
+                }
+
+                throw new ReleaseDownloadException("Downloading torrent failed", ex);
+            }
+            catch (WebException ex)
+            {
+                _logger.Error(ex, "Downloading torrent file for release failed ({0})", link.AbsoluteUri);
+
+                throw new ReleaseDownloadException("Downloading torrent failed", ex);
+            }
+            catch (Exception)
+            {
+                _indexerStatusService.RecordFailure(Definition.Id);
+                _logger.Error("Downloading torrent failed");
+                throw;
+            }
+
+            return torrentData;
+        }
+
+        protected void ValidateMagnet(string link)
+        {
+            MagnetLink.Parse(link);
+        }
+    }
+}

--- a/src/NzbDrone.Core/Indexers/UsenetIndexerBase.cs
+++ b/src/NzbDrone.Core/Indexers/UsenetIndexerBase.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Net;
+using System.Threading.Tasks;
+using NLog;
+using NzbDrone.Common.Http;
+using NzbDrone.Core.Configuration;
+using NzbDrone.Core.Download;
+using NzbDrone.Core.Exceptions;
+using NzbDrone.Core.Messaging.Events;
+using NzbDrone.Core.ThingiProvider;
+
+namespace NzbDrone.Core.Indexers
+{
+    public abstract class UsenetIndexerBase<TSettings> : HttpIndexerBase<TSettings>
+        where TSettings : IProviderConfig, new()
+    {
+        private readonly IValidateNzbs _nzbValidationService;
+
+        protected UsenetIndexerBase(IHttpClient httpClient, IEventAggregator eventAggregator, IIndexerStatusService indexerStatusService, IConfigService configService, IValidateNzbs nzbValidationService, Logger logger)
+            : base(httpClient, eventAggregator, indexerStatusService, configService, logger)
+        {
+            _nzbValidationService = nzbValidationService;
+        }
+
+        public override async Task<byte[]> Download(Uri link)
+        {
+            Cookies = GetCookies();
+
+            var requestBuilder = new HttpRequestBuilder(link.AbsoluteUri);
+
+            if (Cookies != null)
+            {
+                requestBuilder.SetCookies(Cookies);
+            }
+
+            var request = requestBuilder.Build();
+            request.AllowAutoRedirect = FollowRedirect;
+
+            byte[] nzbData;
+
+            try
+            {
+                var response = await _httpClient.ExecuteAsync(request);
+                nzbData = response.ResponseData;
+
+                _logger.Debug("Downloaded nzb for release finished ({0} bytes from {1})", nzbData.Length, link.AbsoluteUri);
+            }
+            catch (HttpException ex)
+            {
+                if (ex.Response.StatusCode == HttpStatusCode.NotFound)
+                {
+                    _logger.Error(ex, "Downloading nzb file for release failed since it no longer exists ({0})", link.AbsoluteUri);
+                    throw new ReleaseUnavailableException("Downloading nzb failed", ex);
+                }
+
+                if ((int)ex.Response.StatusCode == 429)
+                {
+                    _logger.Error("API Grab Limit reached for {0}", link.AbsoluteUri);
+                }
+                else
+                {
+                    _logger.Error(ex, "Downloading nzb for release failed ({0})", link.AbsoluteUri);
+                }
+
+                throw new ReleaseDownloadException("Downloading nzb failed", ex);
+            }
+            catch (WebException ex)
+            {
+                _logger.Error(ex, "Downloading nzb for release failed ({0})", link.AbsoluteUri);
+
+                throw new ReleaseDownloadException("Downloading nzb failed", ex);
+            }
+            catch (Exception)
+            {
+                _indexerStatusService.RecordFailure(Definition.Id);
+                _logger.Error("Downloading nzb failed");
+                throw;
+            }
+
+            _nzbValidationService.Validate(nzbData);
+
+            return nzbData;
+        }
+    }
+}


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Download clients now use indexer.Download and any override for grabbing the nzb or torrent file. Additionally this PR adds magnet link validation and nzbData validation for client grabs and nab grabs from apps

#### Screenshot (if UI related)
#### Todos
- [ ] Tests
- [ ] Test to ensure usenet and torrent grabs are still working for (nab, to client, manual download)

#### Issues Fixed or Closed by this PR

* Fixes #79 