### PR TITLE
Fixed: Error when trying to parse the value 'Unknown' as an IP Address

### DIFF
--- a/src/Prowlarr.Http/Extensions/RequestExtensions.cs
+++ b/src/Prowlarr.Http/Extensions/RequestExtensions.cs
@@ -164,9 +164,10 @@ namespace Prowlarr.Http.Extensions
         public static string GetHostName(this HttpRequest request)
         {
             string ip = request.GetRemoteIP();
-            IPAddress myIP = IPAddress.Parse(ip);
+
             try
             {
+                IPAddress myIP = IPAddress.Parse(ip);
                 IPHostEntry getIPHost = Dns.GetHostEntry(myIP);
                 List<string> compName = getIPHost.HostName.ToString().Split('.').ToList();
                 return compName.First();


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fixes error when the request header is null and so doesn't have a Remote IP to parse. 

#### Issues Fixed or Closed by this PR

* Fixes #96