### PR TITLE
Fixed: Cardigann redirect handling fails for relative location headers

### DIFF
--- a/src/NzbDrone.Common/Http/HttpResponse.cs
+++ b/src/NzbDrone.Common/Http/HttpResponse.cs
@@ -62,6 +62,20 @@ namespace NzbDrone.Common.Http
                                        StatusCode == HttpStatusCode.TemporaryRedirect ||
                                        StatusCode == HttpStatusCode.Found;
 
+        public string RedirectUrl
+        {
+            get
+            {
+                var newUrl = Headers["Location"];
+                if (newUrl == null || newUrl.IsNullOrWhiteSpace())
+                {
+                    return string.Empty;
+                }
+
+                return (Request.Url += new HttpUri(newUrl)).FullUri;
+            }
+        }
+
         public string[] GetCookieHeaders()
         {
             return Headers.GetValues("Set-Cookie") ?? Array.Empty<string>();

--- a/src/NzbDrone.Core/Indexers/Definitions/Cardigann/CardigannParser.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Cardigann/CardigannParser.cs
@@ -36,7 +36,7 @@ namespace NzbDrone.Core.Indexers.Cardigann
             if (indexerResponse.HttpResponse.StatusCode != HttpStatusCode.OK)
             {
                 // Remove cookie cache
-                if (indexerResponse.HttpResponse.HasHttpRedirect && indexerResponse.HttpResponse.Headers["Location"]
+                if (indexerResponse.HttpResponse.HasHttpRedirect && indexerResponse.HttpResponse.RedirectUrl
                         .ContainsIgnoreCase("login.php"))
                 {
                     CookiesUpdater(null, null);

--- a/src/NzbDrone.Core/Indexers/Definitions/Cardigann/CardigannRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Cardigann/CardigannRequestGenerator.cs
@@ -635,14 +635,14 @@ namespace NzbDrone.Core.Indexers.Cardigann
         {
             if (requestUrl.StartsWith(SiteLink) && !redirectUrl.StartsWith(SiteLink))
             {
-                var uri = new Uri(redirectUrl);
+                var uri = new HttpUri(redirectUrl);
                 return uri.Scheme + "://" + uri.Host + "/";
             }
 
             return null;
         }
 
-        protected string GetRedirectDomainHint(HttpResponse result) => GetRedirectDomainHint(result.Request.Url.ToString(), result.Headers.GetSingleValue("Location"));
+        protected string GetRedirectDomainHint(HttpResponse result) => GetRedirectDomainHint(result.Request.Url.ToString(), result.RedirectUrl);
 
         protected async Task<HttpResponse> HandleRequest(RequestBlock request, Dictionary<string, object> variables = null, string referer = null)
         {

--- a/src/NzbDrone.Core/Indexers/Definitions/PassThePopcorn/PassThePopcornParser.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/PassThePopcorn/PassThePopcornParser.cs
@@ -29,7 +29,7 @@ namespace NzbDrone.Core.Indexers.PassThePopcorn
             if (indexerResponse.HttpResponse.StatusCode != HttpStatusCode.OK)
             {
                 // Remove cookie cache
-                if (indexerResponse.HttpResponse.HasHttpRedirect && indexerResponse.HttpResponse.Headers["Location"]
+                if (indexerResponse.HttpResponse.HasHttpRedirect && indexerResponse.HttpResponse.RedirectUrl
                         .ContainsIgnoreCase("login.php"))
                 {
                     CookiesUpdater(null, null);


### PR DESCRIPTION
#### Database Migration
NO

#### Description
If location header is returned with relative path like `login.php`, Cardigann will fail with UriFormatException. This ensures we use the full redirect Uri instead of just the the location header value itself when location is relative.

#### Todos
- [ ] Tests

#### Issues Fixed or Closed by this PR

* Fixes HD-Forever and others