### PR TITLE
(Indexers) Add Support for Unit3d API / Convert AnimeWorld

### DIFF
--- a/src/NzbDrone.Core/IndexerVersions/IndexerDefinitionUpdateService.cs
+++ b/src/NzbDrone.Core/IndexerVersions/IndexerDefinitionUpdateService.cs
@@ -24,7 +24,7 @@ namespace NzbDrone.Core.IndexerVersions
     public class IndexerDefinitionUpdateService : IIndexerDefinitionUpdateService, IExecute<IndexerDefinitionUpdateCommand>
     {
         private const int DEFINITION_VERSION = 1;
-        private readonly List<string> _defintionBlacklist = new List<string>() { "blutopia", "beyond-hd", "beyond-hd-oneurl", "hdbits" };
+        private readonly List<string> _defintionBlacklist = new List<string>() { "animeworld", "blutopia", "beyond-hd", "beyond-hd-oneurl", "hdbits" };
 
         private readonly IHttpClient _httpClient;
         private readonly IAppFolderInfo _appFolderInfo;

--- a/src/NzbDrone.Core/Indexers/Definitions/AnimeWorld.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/AnimeWorld.cs
@@ -1,0 +1,59 @@
+using System.Collections.Generic;
+using NLog;
+using NzbDrone.Common.Http;
+using NzbDrone.Core.Configuration;
+using NzbDrone.Core.Indexers.Definitions.UNIT3D;
+using NzbDrone.Core.Messaging.Events;
+
+namespace NzbDrone.Core.Indexers.Definitions
+{
+    public class AnimeWorld : Unit3dBase
+    {
+        public override string Name => "AnimeWorld";
+        public override string BaseUrl => "https://animeworld.cx/";
+
+        public override IndexerPrivacy Privacy => IndexerPrivacy.Private;
+        public AnimeWorld(IHttpClient httpClient, IEventAggregator eventAggregator, IIndexerStatusService indexerStatusService, IConfigService configService, Logger logger)
+            : base(httpClient, eventAggregator, indexerStatusService, configService, logger)
+        {
+        }
+
+        protected override IndexerCapabilities SetCapabilities()
+        {
+            var caps = new IndexerCapabilities
+            {
+                TvSearchParams = new List<TvSearchParam>
+                       {
+                           TvSearchParam.Q, TvSearchParam.Season, TvSearchParam.Ep, TvSearchParam.ImdbId, TvSearchParam.TvdbId
+                       },
+                MovieSearchParams = new List<MovieSearchParam>
+                       {
+                           MovieSearchParam.Q, MovieSearchParam.ImdbId, MovieSearchParam.TmdbId
+                       },
+                MusicSearchParams = new List<MusicSearchParam>
+                       {
+                           MusicSearchParam.Q
+                       },
+                BookSearchParams = new List<BookSearchParam>
+                       {
+                           BookSearchParam.Q
+                       }
+            };
+
+            caps.Categories.AddCategoryMapping(1, NewznabStandardCategory.Movies, "Anime Movie");
+            caps.Categories.AddCategoryMapping(2, NewznabStandardCategory.TVAnime, "Anime Series");
+            caps.Categories.AddCategoryMapping(3, NewznabStandardCategory.Audio, "Anime Musik/OST");
+            caps.Categories.AddCategoryMapping(4, NewznabStandardCategory.PCGames, "Anime Spiele");
+            caps.Categories.AddCategoryMapping(5, NewznabStandardCategory.XXX, "Hentai");
+            caps.Categories.AddCategoryMapping(6, NewznabStandardCategory.PCGames, "Spiele Linux");
+            caps.Categories.AddCategoryMapping(7, NewznabStandardCategory.Other, "Sonstiges");
+            caps.Categories.AddCategoryMapping(8, NewznabStandardCategory.Movies, "Filme");
+            caps.Categories.AddCategoryMapping(9, NewznabStandardCategory.TV, "Serien");
+            caps.Categories.AddCategoryMapping(10, NewznabStandardCategory.PCGames, "Spiele");
+            caps.Categories.AddCategoryMapping(11, NewznabStandardCategory.Audio, "Musik");
+            caps.Categories.AddCategoryMapping(12, NewznabStandardCategory.BooksComics, "Mangas");
+
+            return caps;
+        }
+    }
+}

--- a/src/NzbDrone.Core/Indexers/Definitions/AnimeWorld.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/AnimeWorld.cs
@@ -11,6 +11,8 @@ namespace NzbDrone.Core.Indexers.Definitions
     {
         public override string Name => "AnimeWorld";
         public override string BaseUrl => "https://animeworld.cx/";
+        public override string Description => "AnimeWorld (AW) is a GERMAN Private site for ANIME / MANGA / HENTAI";
+        public override string Language => "de-de";
 
         public override IndexerPrivacy Privacy => IndexerPrivacy.Private;
         public AnimeWorld(IHttpClient httpClient, IEventAggregator eventAggregator, IIndexerStatusService indexerStatusService, IConfigService configService, Logger logger)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Added support for the Unit3d API for the tracker AnimeWorld.
Before it used the Jackett definition, which was disliked by the admins.
Tested all the categories, they all returned the correct results

#### Screenshot (if UI related)
#### Todos
- [ ] Tests
- [ ] Translation Keys
- [ ] Wiki Updates

#### Issues Fixed or Closed by this PR