### PR TITLE
Adds a fix to support 3 digit issues

### DIFF
--- a/frontend/src/System/Updates/UpdateChanges.js
+++ b/frontend/src/System/Updates/UpdateChanges.js
@@ -24,7 +24,7 @@ class UpdateChanges extends Component {
         <ul>
           {
             changes.map((change, index) => {
-              const checkChange = change.replace(/#\d{4,5}\b/g, (match, contents) => {
+              const checkChange = change.replace(/#\d{3,4,5}\b/g, (match, contents) => {
                 return `[${match}](https://github.com/Prowlarr/Prowlarr/issues/${match.substring(1)})`;
               });
 

--- a/frontend/src/System/Updates/UpdateChanges.js
+++ b/frontend/src/System/Updates/UpdateChanges.js
@@ -24,7 +24,7 @@ class UpdateChanges extends Component {
         <ul>
           {
             changes.map((change, index) => {
-              const checkChange = change.replace(/#\d{3,4,5}\b/g, (match, contents) => {
+              const checkChange = change.replace(/#\d{3,5}\b/g, (match, contents) => {
                 return `[${match}](https://github.com/Prowlarr/Prowlarr/issues/${match.substring(1)})`;
               });
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Currently, the regex to replace issues `#0000` only works on issues that are 4 or 5 characters, currently, as we are so early in the process, we are still going through 3 digits (156 being the highest at the time of writing) therefore they aren't replaced with links.

#### Screenshot (if UI related)
Fixes 
![image](https://user-images.githubusercontent.com/24227350/121122058-aa7cad80-c818-11eb-82d1-4d2521c2bdcc.png)

#### Issues Fixed or Closed by this PR

* Fixes #156 