### PR TITLE
Fixes the BarChart to have a stepSize multiplier of 1 instead of auto

### DIFF
--- a/frontend/src/Components/Chart/BarChart.js
+++ b/frontend/src/Components/Chart/BarChart.js
@@ -23,6 +23,16 @@ class BarChart extends Component {
     this.myChart = new Chart(this.canvasRef.current, {
       type: 'bar',
       options: {
+        x: {
+          ticks: {
+            stepSize: 1
+          }
+        },
+        y: {
+          ticks: {
+            stepSize: 1
+          }
+        },
         indexAxis: this.props.horizontal ? 'y' : 'x',
         maintainAspectRatio: false,
         plugins: {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Using [the docs](https://www.chartjs.org/docs/latest/axes/cartesian/linear.html#step-size) for chart.js as a guide, it sets the `stepSize` for barCharts to 1 as otherwise, it will use `0.5`. This does scale "up" as this just locks it to whole numbers, tested with charts that only have 3 data points and ones that went up to 800. 

#### Screenshot (if UI related)
Before
![image](https://user-images.githubusercontent.com/24227350/121160900-656e7080-c844-11eb-8e89-de1ba1b78e7f.png)
After
![image](https://user-images.githubusercontent.com/24227350/121160910-68696100-c844-11eb-92e0-42ce2e82b1c1.png)

#### Issues Fixed or Closed by this PR

* Fixes #162 