### PR TITLE
Fixed: Website Links going to api not site

### DIFF
--- a/frontend/src/Indexer/Index/Table/IndexerIndexRow.js
+++ b/frontend/src/Indexer/Index/Table/IndexerIndexRow.js
@@ -248,7 +248,7 @@ class IndexerIndexRow extends Component {
                     className={styles.externalLink}
                     name={icons.EXTERNAL_LINK}
                     title={'Website'}
-                    to={baseUrl}
+                    to={baseUrl.replace('api.', '')}
                   />
 
                   <IconButton


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Removes `api.` from the beginning of the site links within the indexers table - this is based on the sites that I have access to and what was showing for those - others may be different and still need to be handled appropriately

#### Issues Fixed or Closed by this PR

* Fixes #183 