### PR TITLE
New: Better Application Tests

### DIFF
--- a/src/NzbDrone.Core/Applications/Lidarr/Lidarr.cs
+++ b/src/NzbDrone.Core/Applications/Lidarr/Lidarr.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using FluentValidation.Results;
 using Newtonsoft.Json.Linq;
 using NLog;
@@ -31,7 +32,25 @@ namespace NzbDrone.Core.Applications.Lidarr
         {
             var failures = new List<ValidationFailure>();
 
-            failures.AddIfNotNull(_lidarrV1Proxy.Test(Settings));
+            var testIndexer = new IndexerDefinition
+            {
+                Id = 0,
+                Name = "Test",
+                Protocol = DownloadProtocol.Usenet,
+                Capabilities = new IndexerCapabilities()
+            };
+
+            testIndexer.Capabilities.Categories.AddCategoryMapping(1, NewznabStandardCategory.Audio);
+
+            try
+            {
+                failures.AddIfNotNull(_lidarrV1Proxy.TestConnection(BuildLidarrIndexer(testIndexer, DownloadProtocol.Usenet), Settings));
+            }
+            catch (WebException ex)
+            {
+                _logger.Error(ex, "Unable to send test message");
+                failures.AddIfNotNull(new ValidationFailure("BaseUrl", "Unable to complete application test, cannot connect to Lidarr"));
+            }
 
             return new ValidationResult(failures);
         }

--- a/src/NzbDrone.Core/Applications/Lidarr/LidarrSettings.cs
+++ b/src/NzbDrone.Core/Applications/Lidarr/LidarrSettings.cs
@@ -28,7 +28,7 @@ namespace NzbDrone.Core.Applications.Lidarr
 
         public IEnumerable<int> SyncCategories { get; set; }
 
-        [FieldDefinition(0, Label = "Prowlarr Server", HelpText = "Prowlarr server URL as Lidarr sees it, including http(s):// and port if needed")]
+        [FieldDefinition(0, Label = "Prowlarr Server", HelpText = "Prowlarr server URL as Lidarr sees it, including http(s)://, port, and urlbase if needed")]
         public string ProwlarrUrl { get; set; }
 
         [FieldDefinition(1, Label = "Lidarr Server", HelpText = "Lidarr server URL, including http(s):// and port if needed")]

--- a/src/NzbDrone.Core/Applications/Radarr/Radarr.cs
+++ b/src/NzbDrone.Core/Applications/Radarr/Radarr.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using FluentValidation.Results;
 using Newtonsoft.Json.Linq;
 using NLog;
@@ -31,7 +32,25 @@ namespace NzbDrone.Core.Applications.Radarr
         {
             var failures = new List<ValidationFailure>();
 
-            failures.AddIfNotNull(_radarrV3Proxy.Test(Settings));
+            var testIndexer = new IndexerDefinition
+            {
+                Id = 0,
+                Name = "Test",
+                Protocol = DownloadProtocol.Usenet,
+                Capabilities = new IndexerCapabilities()
+            };
+
+            testIndexer.Capabilities.Categories.AddCategoryMapping(1, NewznabStandardCategory.Movies);
+
+            try
+            {
+                failures.AddIfNotNull(_radarrV3Proxy.TestConnection(BuildRadarrIndexer(testIndexer, DownloadProtocol.Usenet), Settings));
+            }
+            catch (WebException ex)
+            {
+                _logger.Error(ex, "Unable to send test message");
+                failures.AddIfNotNull(new ValidationFailure("BaseUrl", "Unable to complete application test, cannot connect to Radarr"));
+            }
 
             return new ValidationResult(failures);
         }

--- a/src/NzbDrone.Core/Applications/Radarr/RadarrSettings.cs
+++ b/src/NzbDrone.Core/Applications/Radarr/RadarrSettings.cs
@@ -28,7 +28,7 @@ namespace NzbDrone.Core.Applications.Radarr
 
         public IEnumerable<int> SyncCategories { get; set; }
 
-        [FieldDefinition(0, Label = "Prowlarr Server", HelpText = "Prowlarr server URL as Radarr sees it, including http(s):// and port if needed")]
+        [FieldDefinition(0, Label = "Prowlarr Server", HelpText = "Prowlarr server URL as Radarr sees it, including http(s)://, port, and urlbase if needed")]
         public string ProwlarrUrl { get; set; }
 
         [FieldDefinition(1, Label = "Radarr Server", HelpText = "Radarr server URL, including http(s):// and port if needed")]

--- a/src/NzbDrone.Core/Applications/Readarr/ReadarrSettings.cs
+++ b/src/NzbDrone.Core/Applications/Readarr/ReadarrSettings.cs
@@ -28,7 +28,7 @@ namespace NzbDrone.Core.Applications.Readarr
 
         public IEnumerable<int> SyncCategories { get; set; }
 
-        [FieldDefinition(0, Label = "Prowlarr Server", HelpText = "Prowlarr server URL as Readarr sees it, including http(s):// and port if needed")]
+        [FieldDefinition(0, Label = "Prowlarr Server", HelpText = "Prowlarr server URL as Readarr sees it, including http(s)://, port, and urlbase if needed")]
         public string ProwlarrUrl { get; set; }
 
         [FieldDefinition(1, Label = "Readarr Server", HelpText = "Readarr server URL, including http(s):// and port if needed")]

--- a/src/NzbDrone.Core/Applications/Sonarr/Sonarr.cs
+++ b/src/NzbDrone.Core/Applications/Sonarr/Sonarr.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using FluentValidation.Results;
 using Newtonsoft.Json.Linq;
 using NLog;
@@ -31,7 +32,25 @@ namespace NzbDrone.Core.Applications.Sonarr
         {
             var failures = new List<ValidationFailure>();
 
-            failures.AddIfNotNull(_sonarrV3Proxy.Test(Settings));
+            var testIndexer = new IndexerDefinition
+            {
+                Id = 0,
+                Name = "Test",
+                Protocol = DownloadProtocol.Usenet,
+                Capabilities = new IndexerCapabilities()
+            };
+
+            testIndexer.Capabilities.Categories.AddCategoryMapping(1, NewznabStandardCategory.TV);
+
+            try
+            {
+                failures.AddIfNotNull(_sonarrV3Proxy.TestConnection(BuildSonarrIndexer(testIndexer, DownloadProtocol.Usenet), Settings));
+            }
+            catch (WebException ex)
+            {
+                _logger.Error(ex, "Unable to send test message");
+                failures.AddIfNotNull(new ValidationFailure("BaseUrl", "Unable to complete application test, cannot connect to Sonarr"));
+            }
 
             return new ValidationResult(failures);
         }

--- a/src/NzbDrone.Core/Applications/Sonarr/SonarrSettings.cs
+++ b/src/NzbDrone.Core/Applications/Sonarr/SonarrSettings.cs
@@ -28,7 +28,7 @@ namespace NzbDrone.Core.Applications.Sonarr
 
         public IEnumerable<int> SyncCategories { get; set; }
 
-        [FieldDefinition(0, Label = "Prowlarr Server", HelpText = "Prowlarr server URL as Sonarr sees it, including http(s):// and port if needed")]
+        [FieldDefinition(0, Label = "Prowlarr Server", HelpText = "Prowlarr server URL as Sonarr sees it, including http(s)://, port, and urlbase if needed")]
         public string ProwlarrUrl { get; set; }
 
         [FieldDefinition(1, Label = "Sonarr Server", HelpText = "Sonarr server URL, including http(s):// and port if needed")]

--- a/src/Prowlarr.Api.V1/Indexers/NewznabController.cs
+++ b/src/Prowlarr.Api.V1/Indexers/NewznabController.cs
@@ -62,6 +62,39 @@ namespace NzbDrone.Api.V1.Indexers
                 }
             }
 
+            if (id == 0)
+            {
+                switch (requestType)
+                {
+                    case "caps":
+                        var caps = new IndexerCapabilities();
+                        foreach (var cat in NewznabStandardCategory.AllCats)
+                        {
+                            caps.Categories.AddCategoryMapping(1, cat);
+                        }
+
+                        return Content(caps.ToXml(), "application/rss+xml");
+                    case "search":
+                    case "tvsearch":
+                    case "music":
+                    case "book":
+                    case "movie":
+                        var results = new NewznabResults();
+                        results.Releases = new List<ReleaseInfo>
+                        {
+                            new ReleaseInfo
+                            {
+                                Title = "Test Release",
+                                Guid = "https://prowlarr.com",
+                                DownloadUrl = "https://prowlarr.com",
+                                PublishDate = DateTime.Now
+                            }
+                        };
+
+                        return Content(results.ToXml(DownloadProtocol.Usenet), "application/rss+xml");
+                }
+            }
+
             var indexer = _indexerFactory.Get(id);
 
             if (indexer == null)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Instead of just calling `System/Status` on the application to test connection, this extends the tests to do a mock indexer test call. This ensures the application calls back to Prowlarr to test the indexer connection thus testing both the connection to the app and the connection back to Prowlarr. This should eliminate or minimize the reports sync failing due to bad application settings.

This also adds code to the Newznab endpoint to return mock results if calling with indexer id of 0

#### Issues Fixed or Closed by this PR

* Fixes #209 