### PR TITLE
fix(TableMapping): make own non Camel Case Converter for Cookies

### DIFF
--- a/src/NzbDrone.Core/Datastore/Converters/CookieConverter.cs
+++ b/src/NzbDrone.Core/Datastore/Converters/CookieConverter.cs
@@ -1,0 +1,36 @@
+﻿using System.Collections.Generic;
+using System.Data;
+using System.Text.Json;
+using Dapper;
+using NzbDrone.Common.Serializer;
+
+namespace NzbDrone.Core.Datastore.Converters
+{
+    public class CookieConverter : SqlMapper.TypeHandler<IDictionary<string, string>>
+    {
+        protected readonly JsonSerializerOptions SerializerSettings;
+
+        public CookieConverter()
+        {
+            var serializerSettings = new JsonSerializerOptions
+            {
+                AllowTrailingCommas = true,
+                IgnoreNullValues = true,
+                PropertyNameCaseInsensitive = true,
+                WriteIndented = true
+            };
+
+            SerializerSettings = serializerSettings;
+        }
+
+        public override void SetValue(IDbDataParameter parameter, IDictionary<string, string> value)
+        {
+            parameter.Value = JsonSerializer.Serialize(value, SerializerSettings);
+        }
+
+        public override IDictionary<string, string> Parse(object value)
+        {
+            return JsonSerializer.Deserialize<Dictionary<string, string>>((string)value, SerializerSettings);
+        }
+    }
+}

--- a/src/NzbDrone.Core/Datastore/TableMapping.cs
+++ b/src/NzbDrone.Core/Datastore/TableMapping.cs
@@ -100,7 +100,7 @@ namespace NzbDrone.Core.Datastore
             SqlMapper.RemoveTypeMap(typeof(DateTime));
             SqlMapper.AddTypeHandler(new DapperUtcConverter());
             SqlMapper.AddTypeHandler(new EmbeddedDocumentConverter<Dictionary<string, string>>());
-            SqlMapper.AddTypeHandler(new EmbeddedDocumentConverter<IDictionary<string, string>>());
+            SqlMapper.AddTypeHandler(new CookieConverter());
             SqlMapper.AddTypeHandler(new EmbeddedDocumentConverter<List<int>>());
             SqlMapper.AddTypeHandler(new EmbeddedDocumentConverter<List<KeyValuePair<string, int>>>());
             SqlMapper.AddTypeHandler(new EmbeddedDocumentConverter<KeyValuePair<string, int>>());

--- a/src/NzbDrone.Core/ThingiProvider/ProviderRepository.cs
+++ b/src/NzbDrone.Core/ThingiProvider/ProviderRepository.cs
@@ -23,7 +23,6 @@ namespace NzbDrone.Core.ThingiProvider
                 AllowTrailingCommas = true,
                 IgnoreNullValues = true,
                 PropertyNameCaseInsensitive = true,
-                DictionaryKeyPolicy = JsonNamingPolicy.CamelCase,
                 PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
                 WriteIndented = true
             };

--- a/src/NzbDrone.Core/ThingiProvider/ProviderRepository.cs
+++ b/src/NzbDrone.Core/ThingiProvider/ProviderRepository.cs
@@ -23,6 +23,7 @@ namespace NzbDrone.Core.ThingiProvider
                 AllowTrailingCommas = true,
                 IgnoreNullValues = true,
                 PropertyNameCaseInsensitive = true,
+                DictionaryKeyPolicy = JsonNamingPolicy.CamelCase,
                 PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
                 WriteIndented = true
             };


### PR DESCRIPTION
#### Database Migration
NO

#### Description
 The current way of storing Cookies persistently is broken because the Cookies IDictionary<string, string> has a CamelCase Key Police. This results in the cookie key being converted to Camel Case which kills the cookie for some sites (like AnimeTorrents)

#### Screenshot (if UI related)
#### Todos
- [ ] Tests
- [ ] Translation Keys
- [ ] Wiki Updates

#### Issues Fixed or Closed by this PR
 Fixes #217