### PR TITLE
Fixed: Correct Password and Username field Privacy

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/AnimeBytes.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/AnimeBytes.cs
@@ -497,7 +497,7 @@ namespace NzbDrone.Core.Indexers.Definitions
         [FieldDefinition(1, Label = "Passkey", Privacy = PrivacyLevel.Password, Type = FieldType.Password, HelpText = "Site Passkey")]
         public string Passkey { get; set; }
 
-        [FieldDefinition(1, Label = "Username", HelpText = "Site Username")]
+        [FieldDefinition(1, Label = "Username", HelpText = "Site Username", Type = FieldType.Textbox, Privacy = PrivacyLevel.UserName)]
         public string Username { get; set; }
 
         public NzbDroneValidationResult Validate()

--- a/src/NzbDrone.Core/Indexers/Definitions/AnimeTorrents.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/AnimeTorrents.cs
@@ -350,10 +350,10 @@ namespace NzbDrone.Core.Indexers.Definitions
             Password = "";
         }
 
-        [FieldDefinition(1, Label = "Username", HelpText = "Site Username")]
+        [FieldDefinition(1, Label = "Username", HelpText = "Site Username", Type = FieldType.Textbox, Privacy = PrivacyLevel.UserName)]
         public string Username { get; set; }
 
-        [FieldDefinition(2, Label = "Password", Type = FieldType.Password, HelpText = "Site Password", Privacy = PrivacyLevel.Password)]
+        [FieldDefinition(2, Label = "Password", HelpText = "Site Password", Type = FieldType.Password, Privacy = PrivacyLevel.Password)]
         public string Password { get; set; }
 
         public NzbDroneValidationResult Validate()

--- a/src/NzbDrone.Core/Indexers/Definitions/Anthelion.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Anthelion.cs
@@ -310,10 +310,10 @@ namespace NzbDrone.Core.Indexers.Definitions
             Password = "";
         }
 
-        [FieldDefinition(1, Label = "Username", Advanced = false, HelpText = "Site Username")]
+        [FieldDefinition(1, Label = "Username", HelpText = "Site Username", Type = FieldType.Textbox, Privacy = PrivacyLevel.UserName)]
         public string Username { get; set; }
 
-        [FieldDefinition(1, Label = "Password", Advanced = false, HelpText = "Site Password")]
+        [FieldDefinition(1, Label = "Password", HelpText = "Site Password", Type = FieldType.Password, Privacy = PrivacyLevel.Password)]
         public string Password { get; set; }
 
         public NzbDroneValidationResult Validate()

--- a/src/NzbDrone.Core/Indexers/Definitions/Avistaz/AvistazSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Avistaz/AvistazSettings.cs
@@ -25,10 +25,10 @@ namespace NzbDrone.Core.Indexers.Definitions.Avistaz
 
         public string Token { get; set; }
 
-        [FieldDefinition(1, Label = "Username", HelpText = "Username", Privacy = PrivacyLevel.UserName)]
+        [FieldDefinition(1, Label = "Username", HelpText = "Site Username", Type = FieldType.Textbox, Privacy = PrivacyLevel.UserName)]
         public string Username { get; set; }
 
-        [FieldDefinition(2, Label = "Password", Type = FieldType.Password, HelpText = "Password", Privacy = PrivacyLevel.Password)]
+        [FieldDefinition(2, Label = "Password", HelpText = "Site Password", Type = FieldType.Password, Privacy = PrivacyLevel.Password)]
         public string Password { get; set; }
 
         [FieldDefinition(3, Label = "PID", HelpText = "PID from My Account or My Profile page")]

--- a/src/NzbDrone.Core/Indexers/Definitions/BakaBT.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/BakaBT.cs
@@ -402,10 +402,10 @@ namespace NzbDrone.Core.Indexers.Definitions
             Password = "";
         }
 
-        [FieldDefinition(1, Label = "Username", HelpText = "Site Username")]
+        [FieldDefinition(1, Label = "Username", HelpText = "Site Username", Type = FieldType.Textbox, Privacy = PrivacyLevel.UserName)]
         public string Username { get; set; }
 
-        [FieldDefinition(2, Label = "Password", Type = FieldType.Password, HelpText = "Site Password", Privacy = PrivacyLevel.Password)]
+        [FieldDefinition(2, Label = "Password", HelpText = "Site Password", Type = FieldType.Password, Privacy = PrivacyLevel.Password)]
         public string Password { get; set; }
 
         [FieldDefinition(3, Label = "Add Romaji Title", Type = FieldType.Checkbox, HelpText = "Add releases for Romaji Title")]

--- a/src/NzbDrone.Core/Indexers/Definitions/FileList/FileListSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/FileList/FileListSettings.cs
@@ -22,7 +22,7 @@ namespace NzbDrone.Core.Indexers.FileList
         {
         }
 
-        [FieldDefinition(0, Label = "Username", Privacy = PrivacyLevel.UserName)]
+        [FieldDefinition(0, Label = "Username", HelpText = "Site Username", Type = FieldType.Textbox, Privacy = PrivacyLevel.UserName)]
         public string Username { get; set; }
 
         [FieldDefinition(1, Label = "Passkey", Privacy = PrivacyLevel.ApiKey)]

--- a/src/NzbDrone.Core/Indexers/Definitions/Gazelle/GazelleSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Gazelle/GazelleSettings.cs
@@ -25,10 +25,10 @@ namespace NzbDrone.Core.Indexers.Gazelle
         public string AuthKey;
         public string PassKey;
 
-        [FieldDefinition(1, Label = "Username", HelpText = "Username", Privacy = PrivacyLevel.UserName)]
+        [FieldDefinition(1, Label = "Username", HelpText = "Site Username", Type = FieldType.Textbox, Privacy = PrivacyLevel.UserName)]
         public string Username { get; set; }
 
-        [FieldDefinition(2, Label = "Password", Type = FieldType.Password, HelpText = "Password", Privacy = PrivacyLevel.Password)]
+        [FieldDefinition(2, Label = "Password", HelpText = "Site Password", Type = FieldType.Password, Privacy = PrivacyLevel.Password)]
         public string Password { get; set; }
 
         [FieldDefinition(3, Type = FieldType.Checkbox, Label = "Use Freeleech Token", HelpText = "Use Freeleech Token")]

--- a/src/NzbDrone.Core/Indexers/Definitions/HDBits/HDBitsSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/HDBits/HDBitsSettings.cs
@@ -24,7 +24,7 @@ namespace NzbDrone.Core.Indexers.HDBits
             Mediums = System.Array.Empty<int>();
         }
 
-        [FieldDefinition(0, Label = "Username", Privacy = PrivacyLevel.UserName)]
+        [FieldDefinition(0, Label = "Username", HelpText = "Site Username", Type = FieldType.Textbox, Privacy = PrivacyLevel.UserName)]
         public string Username { get; set; }
 
         [FieldDefinition(2, Label = "API Key", Privacy = PrivacyLevel.ApiKey)]

--- a/src/NzbDrone.Core/Indexers/Definitions/HDTorrents.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/HDTorrents.cs
@@ -375,10 +375,10 @@ namespace NzbDrone.Core.Indexers.Definitions
             Password = "";
         }
 
-        [FieldDefinition(1, Label = "Username", HelpText = "Site Username")]
+        [FieldDefinition(1, Label = "Username", HelpText = "Site Username", Type = FieldType.Textbox, Privacy = PrivacyLevel.UserName)]
         public string Username { get; set; }
 
-        [FieldDefinition(2, Label = "Password", Type = FieldType.Password, HelpText = "Site Password", Privacy = PrivacyLevel.Password)]
+        [FieldDefinition(2, Label = "Password", HelpText = "Site Password", Type = FieldType.Password, Privacy = PrivacyLevel.Password)]
         public string Password { get; set; }
 
         public NzbDroneValidationResult Validate()

--- a/src/NzbDrone.Core/Indexers/Definitions/Headphones/HeadphonesSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Headphones/HeadphonesSettings.cs
@@ -28,10 +28,10 @@ namespace NzbDrone.Core.Indexers.Headphones
 
         public string ApiKey { get; set; }
 
-        [FieldDefinition(1, Label = "Username")]
+        [FieldDefinition(1, Label = "Username", HelpText = "Site Username", Type = FieldType.Textbox, Privacy = PrivacyLevel.UserName)]
         public string Username { get; set; }
 
-        [FieldDefinition(2, Label = "Password", Type = FieldType.Password)]
+        [FieldDefinition(2, Label = "Password", HelpText = "Site Password", Type = FieldType.Password, Privacy = PrivacyLevel.Password)]
         public string Password { get; set; }
 
         public virtual NzbDroneValidationResult Validate()

--- a/src/NzbDrone.Core/Indexers/Definitions/ImmortalSeed.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/ImmortalSeed.cs
@@ -345,10 +345,10 @@ namespace NzbDrone.Core.Indexers.Definitions
             Password = "";
         }
 
-        [FieldDefinition(1, Label = "Username", HelpText = "Site Username")]
+        [FieldDefinition(1, Label = "Username", HelpText = "Site Username", Type = FieldType.Textbox, Privacy = PrivacyLevel.UserName)]
         public string Username { get; set; }
 
-        [FieldDefinition(2, Label = "Password", Type = FieldType.Password, HelpText = "Site Password", Privacy = PrivacyLevel.Password)]
+        [FieldDefinition(2, Label = "Password", HelpText = "Site Password", Type = FieldType.Password, Privacy = PrivacyLevel.Password)]
         public string Password { get; set; }
 
         public NzbDroneValidationResult Validate()

--- a/src/NzbDrone.Core/Indexers/Definitions/Nebulance.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Nebulance.cs
@@ -289,10 +289,10 @@ namespace NzbDrone.Core.Indexers.Definitions
             TwoFactorAuth = "";
         }
 
-        [FieldDefinition(1, Label = "Username", HelpText = "Site Username")]
+        [FieldDefinition(1, Label = "Username", HelpText = "Site Username", Type = FieldType.Textbox, Privacy = PrivacyLevel.UserName)]
         public string Username { get; set; }
 
-        [FieldDefinition(2, Label = "Password", Privacy = PrivacyLevel.Password, Type = FieldType.Password, HelpText = "Site Password")]
+        [FieldDefinition(2, Label = "Password", HelpText = "Site Password", Type = FieldType.Password, Privacy = PrivacyLevel.Password)]
         public string Password { get; set; }
 
         [FieldDefinition(3, Label = "Two Factor Auth", HelpText = "Two-Factor Auth")]

--- a/src/NzbDrone.Core/Indexers/Definitions/PreToMe.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/PreToMe.cs
@@ -404,10 +404,10 @@ namespace NzbDrone.Core.Indexers.Definitions
         [FieldDefinition(1, Label = "Pin", HelpText = "Site Pin")]
         public string Pin { get; set; }
 
-        [FieldDefinition(2, Label = "Username", HelpText = "Site Username")]
+        [FieldDefinition(2, Label = "Username", HelpText = "Site Username", Type = FieldType.Textbox, Privacy = PrivacyLevel.UserName)]
         public string Username { get; set; }
 
-        [FieldDefinition(3, Label = "Password", Privacy = PrivacyLevel.Password, Type = FieldType.Password, HelpText = "Site Password")]
+        [FieldDefinition(3, Label = "Password", HelpText = "Site Password", Type = FieldType.Password, Privacy = PrivacyLevel.Password)]
         public string Password { get; set; }
 
         public NzbDroneValidationResult Validate()

--- a/src/NzbDrone.Core/Indexers/Definitions/RevolutionTT.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/RevolutionTT.cs
@@ -343,10 +343,10 @@ namespace NzbDrone.Core.Indexers.Definitions
             Password = "";
         }
 
-        [FieldDefinition(1, Label = "Username", HelpText = "Site Username")]
+        [FieldDefinition(1, Label = "Username", HelpText = "Site Username", Type = FieldType.Textbox, Privacy = PrivacyLevel.UserName)]
         public string Username { get; set; }
 
-        [FieldDefinition(2, Label = "Password", Type = FieldType.Password, HelpText = "Site Password", Privacy = PrivacyLevel.Password)]
+        [FieldDefinition(2, Label = "Password", HelpText = "Site Password", Type = FieldType.Password, Privacy = PrivacyLevel.Password)]
         public string Password { get; set; }
 
         public NzbDroneValidationResult Validate()

--- a/src/NzbDrone.Core/Indexers/Definitions/SpeedApp.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/SpeedApp.cs
@@ -418,7 +418,7 @@ namespace NzbDrone.Core.Indexers.Definitions
         [FieldDefinition(1, Label = "Email", HelpText = "Site email")]
         public string Email { get; set; }
 
-        [FieldDefinition(1, Label = "Password", HelpText = "Site Password", Privacy = PrivacyLevel.Password, Type = FieldType.Password)]
+        [FieldDefinition(1, Label = "Password", HelpText = "Site Password", Type = FieldType.Password, Privacy = PrivacyLevel.Password)]
         public string Password { get; set; }
 
         [FieldDefinition(0, Label = "Api Key", Hidden = HiddenType.Hidden)]

--- a/src/NzbDrone.Core/Indexers/Definitions/TorrentLeech.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/TorrentLeech.cs
@@ -345,10 +345,10 @@ namespace NzbDrone.Core.Indexers.Definitions
             Password = "";
         }
 
-        [FieldDefinition(1, Label = "Username", HelpText = "Site Username")]
+        [FieldDefinition(1, Label = "Username", HelpText = "Site Username", Type = FieldType.Textbox, Privacy = PrivacyLevel.UserName)]
         public string Username { get; set; }
 
-        [FieldDefinition(2, Label = "Password", Type = FieldType.Password, HelpText = "Site Password", Privacy = PrivacyLevel.Password)]
+        [FieldDefinition(2, Label = "Password", HelpText = "Site Password", Type = FieldType.Password, Privacy = PrivacyLevel.Password)]
         public string Password { get; set; }
 
         [FieldDefinition(3, Label = "FreeLeech Only", Type = FieldType.Checkbox, Advanced = true, HelpText = "Search Freeleech torrents only")]

--- a/src/NzbDrone.Core/Indexers/Definitions/TorrentPotato/TorrentPotatoSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/TorrentPotato/TorrentPotatoSettings.cs
@@ -20,10 +20,10 @@ namespace NzbDrone.Core.Indexers.TorrentPotato
         {
         }
 
-        [FieldDefinition(1, Label = "Username", HelpText = "The username you use at your indexer.", Privacy = PrivacyLevel.UserName)]
+        [FieldDefinition(1, Label = "Username", HelpText = "Site Username", Type = FieldType.Textbox, Privacy = PrivacyLevel.UserName)]
         public string User { get; set; }
 
-        [FieldDefinition(2, Label = "Passkey", HelpText = "The password you use at your Indexer.", Privacy = PrivacyLevel.Password)]
+        [FieldDefinition(2, Label = "Password", HelpText = "Site Password", Type = FieldType.Password, Privacy = PrivacyLevel.Password)]
         public string Passkey { get; set; }
 
         public NzbDroneValidationResult Validate()

--- a/src/NzbDrone.Core/Indexers/Definitions/TorrentSeeds.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/TorrentSeeds.cs
@@ -354,10 +354,10 @@ namespace NzbDrone.Core.Indexers.Definitions
             Password = "";
         }
 
-        [FieldDefinition(1, Label = "Username", HelpText = "Site Username")]
+        [FieldDefinition(1, Label = "Username", HelpText = "Site Username", Type = FieldType.Textbox, Privacy = PrivacyLevel.UserName)]
         public string Username { get; set; }
 
-        [FieldDefinition(2, Label = "Password", Type = FieldType.Password, HelpText = "Site Password", Privacy = PrivacyLevel.Password)]
+        [FieldDefinition(2, Label = "Password", HelpText = "Site Password", Type = FieldType.Password, Privacy = PrivacyLevel.Password)]
         public string Password { get; set; }
 
         public NzbDroneValidationResult Validate()

--- a/src/NzbDrone.Core/Indexers/Definitions/ZonaQ.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/ZonaQ.cs
@@ -419,10 +419,10 @@ namespace NzbDrone.Core.Indexers.Definitions
             Password = "";
         }
 
-        [FieldDefinition(1, Label = "Username", HelpText = "Site Username")]
+        [FieldDefinition(1, Label = "Username", HelpText = "Site Username", Type = FieldType.Textbox, Privacy = PrivacyLevel.UserName)]
         public string Username { get; set; }
 
-        [FieldDefinition(1, Label = "Password", Privacy = PrivacyLevel.Password, Type = FieldType.Password, HelpText = "Site Password")]
+        [FieldDefinition(1, Label = "Password", HelpText = "Site Password", Type = FieldType.Password, Privacy = PrivacyLevel.Password)]
         public string Password { get; set; }
 
         public NzbDroneValidationResult Validate()

--- a/src/NzbDrone.Core/Notifications/Email/EmailSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Email/EmailSettings.cs
@@ -49,10 +49,10 @@ namespace NzbDrone.Core.Notifications.Email
         [FieldDefinition(2, Label = "Require Encryption", HelpText = "Require SSL (Port 465 only) or StartTLS (any other port)", Type = FieldType.Checkbox)]
         public bool RequireEncryption { get; set; }
 
-        [FieldDefinition(3, Label = "Username", Privacy = PrivacyLevel.UserName)]
+        [FieldDefinition(3, Label = "Username", HelpText = "Username", Type = FieldType.Textbox, Privacy = PrivacyLevel.UserName)]
         public string Username { get; set; }
 
-        [FieldDefinition(4, Label = "Password", Type = FieldType.Password, Privacy = PrivacyLevel.Password)]
+        [FieldDefinition(4, Label = "Password", HelpText = "Password", Type = FieldType.Password, Privacy = PrivacyLevel.Password)]
         public string Password { get; set; }
 
         [FieldDefinition(5, Label = "From Address")]

--- a/src/NzbDrone.Core/Notifications/Webhook/WebhookSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Webhook/WebhookSettings.cs
@@ -29,10 +29,10 @@ namespace NzbDrone.Core.Notifications.Webhook
         [FieldDefinition(1, Label = "Method", Type = FieldType.Select, SelectOptions = typeof(WebhookMethod), HelpText = "Which HTTP method to use submit to the Webservice")]
         public int Method { get; set; }
 
-        [FieldDefinition(2, Label = "Username", Privacy = PrivacyLevel.UserName)]
+        [FieldDefinition(2, Label = "Username", HelpText = "Username", Type = FieldType.Textbox, Privacy = PrivacyLevel.UserName)]
         public string Username { get; set; }
 
-        [FieldDefinition(3, Label = "Password", Type = FieldType.Password, Privacy = PrivacyLevel.Password)]
+        [FieldDefinition(3, Label = "Password", HelpText = "Password", Type = FieldType.Password, Privacy = PrivacyLevel.Password)]
         public string Password { get; set; }
 
         public NzbDroneValidationResult Validate()


### PR DESCRIPTION
Fixed: Consistent help text and settings for Credential Fields

#### Database Migration
NO

#### Description
- make password fields as privacy passwords
- consistent helptext and field labels
- make username fields as privacy username
- set username and password to NOT advanced

#### Screenshot (if UI related)
#### Todos
- N/A Tests
- N/A Translation Keys
- N/A Wiki Updates

#### Issues Fixed or Closed by this PR

* Fixes password in plain text for #252