### PR TITLE
New: Alternative Site Links

### DIFF
--- a/frontend/src/Indexer/Index/Table/IndexerIndexRow.js
+++ b/frontend/src/Indexer/Index/Table/IndexerIndexRow.js
@@ -71,7 +71,7 @@ class IndexerIndexRow extends Component {
     const {
       id,
       name,
-      baseUrl,
+      indexerUrls,
       enable,
       redirect,
       tags,
@@ -248,7 +248,7 @@ class IndexerIndexRow extends Component {
                     className={styles.externalLink}
                     name={icons.EXTERNAL_LINK}
                     title={'Website'}
-                    to={baseUrl.replace('api.', '')}
+                    to={indexerUrls[0].replace('api.', '')}
                   />
 
                   <IconButton
@@ -289,7 +289,7 @@ class IndexerIndexRow extends Component {
 
 IndexerIndexRow.propTypes = {
   id: PropTypes.number.isRequired,
-  baseUrl: PropTypes.string.isRequired,
+  indexerUrls: PropTypes.arrayOf(PropTypes.string).isRequired,
   protocol: PropTypes.string.isRequired,
   privacy: PropTypes.string.isRequired,
   priority: PropTypes.number.isRequired,

--- a/src/NzbDrone.Core.Test/IndexerTests/FileListTests/FileListRequestGeneratorFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/FileListTests/FileListRequestGeneratorFixture.cs
@@ -19,7 +19,8 @@ namespace NzbDrone.Core.Test.IndexerTests.FileListTests
             Subject.Settings = new FileListSettings()
             {
                 Passkey = "abcd",
-                Username = "somename"
+                Username = "somename",
+                BaseUrl = "https://filelist.io"
             };
 
             Subject.Capabilities = new IndexerCapabilities
@@ -54,8 +55,6 @@ namespace NzbDrone.Core.Test.IndexerTests.FileListTests
                 SearchTerm = "Star Wars",
                 Categories = new int[] { 2000 }
             };
-
-            Subject.BaseUrl = "https://filelist.io";
         }
 
         private void MovieWithoutIMDB()

--- a/src/NzbDrone.Core.Test/IndexerTests/TestIndexer.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/TestIndexer.cs
@@ -10,7 +10,8 @@ namespace NzbDrone.Core.Test.IndexerTests
     public class TestIndexer : UsenetIndexerBase<TestIndexerSettings>
     {
         public override string Name => "Test Indexer";
-        public override string BaseUrl => "http://testindexer.com";
+        public override string[] IndexerUrls => new string[] { "http://testindexer.com" };
+        public override string Description => "";
 
         public override DownloadProtocol Protocol => DownloadProtocol.Usenet;
 

--- a/src/NzbDrone.Core.Test/IndexerTests/TestIndexerSettings.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/TestIndexerSettings.cs
@@ -1,12 +1,10 @@
 using System;
-using System.Collections.Generic;
 using NzbDrone.Core.Indexers;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Test.IndexerTests
 {
-    public class TestIndexerSettings : IProviderConfig
+    public class TestIndexerSettings : IIndexerSettings
     {
         public NzbDroneValidationResult Validate()
         {

--- a/src/NzbDrone.Core/Authentication/UserService.cs
+++ b/src/NzbDrone.Core/Authentication/UserService.cs
@@ -1,11 +1,7 @@
 using System;
-using System.Linq;
-using System.Xml.Linq;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.EnvironmentInfo;
 using NzbDrone.Common.Extensions;
-using NzbDrone.Core.Lifecycle;
-using NzbDrone.Core.Messaging.Events;
 
 namespace NzbDrone.Core.Authentication
 {

--- a/src/NzbDrone.Core/Datastore/Migration/004_add_update_history.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/004_add_update_history.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Data;
 using FluentMigrator;
 using NzbDrone.Core.Datastore.Migration.Framework;
 

--- a/src/NzbDrone.Core/Datastore/Migration/005_update_notifiarr.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/005_update_notifiarr.cs
@@ -1,5 +1,4 @@
 using FluentMigrator;
-using Newtonsoft.Json.Linq;
 using NzbDrone.Core.Datastore.Migration.Framework;
 
 namespace NzbDrone.Core.Datastore.Migration

--- a/src/NzbDrone.Core/Datastore/TableMapping.cs
+++ b/src/NzbDrone.Core/Datastore/TableMapping.cs
@@ -46,7 +46,7 @@ namespace NzbDrone.Core.Datastore
                   .Ignore(i => i.Description)
                   .Ignore(i => i.Language)
                   .Ignore(i => i.Encoding)
-                  .Ignore(i => i.BaseUrl)
+                  .Ignore(i => i.IndexerUrls)
                   .Ignore(i => i.Protocol)
                   .Ignore(i => i.Privacy)
                   .Ignore(i => i.SupportsRss)

--- a/src/NzbDrone.Core/Download/Clients/Pneumatic/Pneumatic.cs
+++ b/src/NzbDrone.Core/Download/Clients/Pneumatic/Pneumatic.cs
@@ -6,7 +6,6 @@ using FluentValidation.Results;
 using NLog;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.Extensions;
-using NzbDrone.Common.Http;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Indexers;
 using NzbDrone.Core.Parser;

--- a/src/NzbDrone.Core/Download/TorrentClientBase.cs
+++ b/src/NzbDrone.Core/Download/TorrentClientBase.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Net;
 using System.Text;
 using System.Threading.Tasks;
 using MonoTorrent;

--- a/src/NzbDrone.Core/Exceptions/ReleaseDownloadException.cs
+++ b/src/NzbDrone.Core/Exceptions/ReleaseDownloadException.cs
@@ -1,6 +1,5 @@
 using System;
 using NzbDrone.Common.Exceptions;
-using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.Exceptions
 {

--- a/src/NzbDrone.Core/Exceptions/ReleaseUnavailableException.cs
+++ b/src/NzbDrone.Core/Exceptions/ReleaseUnavailableException.cs
@@ -1,5 +1,4 @@
 using System;
-using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.Exceptions
 {

--- a/src/NzbDrone.Core/Indexers/Definitions/Aither.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Aither.cs
@@ -10,7 +10,7 @@ namespace NzbDrone.Core.Indexers.Definitions
     public class Aither : Unit3dBase
     {
         public override string Name => "Aither";
-        public override string BaseUrl => "https://aither.cc/";
+        public override string[] IndexerUrls => new string[] { "https://aither.cc/" };
         public override string Description => "Aither is a Private Torrent Tracker for HD MOVIES / TV";
         public override string Language => "en-us";
         public override IndexerPrivacy Privacy => IndexerPrivacy.Private;

--- a/src/NzbDrone.Core/Indexers/Definitions/AlphaRatio.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/AlphaRatio.cs
@@ -9,7 +9,7 @@ namespace NzbDrone.Core.Indexers.Definitions
     public class AlphaRatio : Gazelle.Gazelle
     {
         public override string Name => "AlphaRatio";
-        public override string BaseUrl => "https://alpharatio.cc/";
+        public override string[] IndexerUrls => new string[] { "https://alpharatio.cc/" };
         public override string Description => "AlphaRatio(AR) is a Private Torrent Tracker for 0DAY / GENERAL";
         public override IndexerPrivacy Privacy => IndexerPrivacy.Private;
 
@@ -25,8 +25,7 @@ namespace NzbDrone.Core.Indexers.Definitions
                 Settings = Settings,
                 HttpClient = _httpClient,
                 Logger = _logger,
-                Capabilities = Capabilities,
-                BaseUrl = BaseUrl
+                Capabilities = Capabilities
             };
         }
 

--- a/src/NzbDrone.Core/Indexers/Definitions/AnimeTorrents.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/AnimeTorrents.cs
@@ -16,7 +16,6 @@ using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Messaging.Events;
 using NzbDrone.Core.Parser;
 using NzbDrone.Core.Parser.Model;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.Definitions
@@ -25,8 +24,9 @@ namespace NzbDrone.Core.Indexers.Definitions
     {
         public override string Name => "AnimeTorrents";
 
-        public override string BaseUrl => "https://animetorrents.me/";
-        private string LoginUrl => BaseUrl + "login.php";
+        public override string[] IndexerUrls => new string[] { "https://animetorrents.me/" };
+        public override string Description => "Definitive source for anime and manga";
+        private string LoginUrl => Settings.BaseUrl + "login.php";
         public override DownloadProtocol Protocol => DownloadProtocol.Torrent;
         public override IndexerPrivacy Privacy => IndexerPrivacy.Private;
         public override IndexerCapabilities Capabilities => SetCapabilities();
@@ -38,12 +38,12 @@ namespace NzbDrone.Core.Indexers.Definitions
 
         public override IIndexerRequestGenerator GetRequestGenerator()
         {
-            return new AnimeTorrentsRequestGenerator() { Settings = Settings, Capabilities = Capabilities, BaseUrl = BaseUrl };
+            return new AnimeTorrentsRequestGenerator() { Settings = Settings, Capabilities = Capabilities };
         }
 
         public override IParseIndexerResponse GetParser()
         {
-            return new AnimeTorrentsParser(Settings, Capabilities.Categories, BaseUrl);
+            return new AnimeTorrentsParser(Settings, Capabilities.Categories);
         }
 
         protected override async Task DoLogin()
@@ -135,7 +135,6 @@ namespace NzbDrone.Core.Indexers.Definitions
     {
         public AnimeTorrentsSettings Settings { get; set; }
         public IndexerCapabilities Capabilities { get; set; }
-        public string BaseUrl { get; set; }
 
         public AnimeTorrentsRequestGenerator()
         {
@@ -148,8 +147,8 @@ namespace NzbDrone.Core.Indexers.Definitions
             //  replace any space, special char, etc. with % (wildcard)
             var replaceRegex = new Regex("[^a-zA-Z0-9]+");
             searchString = replaceRegex.Replace(searchString, "%");
-            var searchUrl = BaseUrl + "ajax/torrents_data.php";
-            var searchUrlReferer = BaseUrl + "torrents.php?cat=0&searchin=filename&search=";
+            var searchUrl = Settings.BaseUrl + "ajax/torrents_data.php";
+            var searchUrlReferer = Settings.BaseUrl + "torrents.php?cat=0&searchin=filename&search=";
 
             var trackerCats = Capabilities.Categories.MapTorznabCapsToTrackers(categories) ?? new List<string>();
 
@@ -229,13 +228,11 @@ namespace NzbDrone.Core.Indexers.Definitions
     {
         private readonly AnimeTorrentsSettings _settings;
         private readonly IndexerCapabilitiesCategories _categories;
-        private readonly string _baseUrl;
 
-        public AnimeTorrentsParser(AnimeTorrentsSettings settings, IndexerCapabilitiesCategories categories, string baseUrl)
+        public AnimeTorrentsParser(AnimeTorrentsSettings settings, IndexerCapabilitiesCategories categories)
         {
             _settings = settings;
             _categories = categories;
-            _baseUrl = baseUrl;
         }
 
         public IList<ReleaseInfo> ParseResponse(IndexerResponse indexerResponse)
@@ -340,7 +337,7 @@ namespace NzbDrone.Core.Indexers.Definitions
         }
     }
 
-    public class AnimeTorrentsSettings : IProviderConfig
+    public class AnimeTorrentsSettings : IIndexerSettings
     {
         private static readonly AnimeTorrentsSettingsValidator Validator = new AnimeTorrentsSettingsValidator();
 
@@ -350,10 +347,13 @@ namespace NzbDrone.Core.Indexers.Definitions
             Password = "";
         }
 
-        [FieldDefinition(1, Label = "Username", HelpText = "Site Username", Type = FieldType.Textbox, Privacy = PrivacyLevel.UserName)]
+        [FieldDefinition(1, Label = "Base Url", Type = FieldType.Select, SelectOptionsProviderAction = "getUrls", HelpText = "Select which baseurl Prowlarr will use for requests to the site")]
+        public string BaseUrl { get; set; }
+
+        [FieldDefinition(2, Label = "Username", HelpText = "Site Username", Privacy = PrivacyLevel.UserName)]
         public string Username { get; set; }
 
-        [FieldDefinition(2, Label = "Password", HelpText = "Site Password", Type = FieldType.Password, Privacy = PrivacyLevel.Password)]
+        [FieldDefinition(3, Label = "Password", Type = FieldType.Password, HelpText = "Site Password", Privacy = PrivacyLevel.Password)]
         public string Password { get; set; }
 
         public NzbDroneValidationResult Validate()

--- a/src/NzbDrone.Core/Indexers/Definitions/AnimeWorld.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/AnimeWorld.cs
@@ -10,7 +10,7 @@ namespace NzbDrone.Core.Indexers.Definitions
     public class AnimeWorld : Unit3dBase
     {
         public override string Name => "AnimeWorld";
-        public override string BaseUrl => "https://animeworld.cx/";
+        public override string[] IndexerUrls => new string[] { "https://animeworld.cx/" };
         public override string Description => "AnimeWorld (AW) is a GERMAN Private site for ANIME / MANGA / HENTAI";
         public override string Language => "de-de";
 

--- a/src/NzbDrone.Core/Indexers/Definitions/AvistaZ.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/AvistaZ.cs
@@ -10,7 +10,8 @@ namespace NzbDrone.Core.Indexers.Definitions
     public class AvistaZ : AvistazBase
     {
         public override string Name => "AvistaZ";
-        public override string BaseUrl => "https://avistaz.to/";
+        public override string[] IndexerUrls => new string[] { "https://avistaz.to/" };
+        public override string Description => "Aka AsiaTorrents";
         public override IndexerPrivacy Privacy => IndexerPrivacy.Private;
 
         public AvistaZ(IIndexerRepository indexerRepository, IHttpClient httpClient, IEventAggregator eventAggregator, IIndexerStatusService indexerStatusService, IConfigService configService, Logger logger)
@@ -25,8 +26,7 @@ namespace NzbDrone.Core.Indexers.Definitions
                 Settings = Settings,
                 HttpClient = _httpClient,
                 Logger = _logger,
-                Capabilities = Capabilities,
-                BaseUrl = BaseUrl
+                Capabilities = Capabilities
             };
         }
 

--- a/src/NzbDrone.Core/Indexers/Definitions/Avistaz/AvistazBase.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Avistaz/AvistazBase.cs
@@ -12,8 +12,8 @@ namespace NzbDrone.Core.Indexers.Definitions.Avistaz
     public abstract class AvistazBase : TorrentIndexerBase<AvistazSettings>
     {
         public override DownloadProtocol Protocol => DownloadProtocol.Torrent;
-        public override string BaseUrl => "";
-        protected virtual string LoginUrl => BaseUrl + "api/v1/jackett/auth";
+        public override string[] IndexerUrls => new string[] { "" };
+        protected virtual string LoginUrl => Settings.BaseUrl + "api/v1/jackett/auth";
         public override bool SupportsRss => true;
         public override bool SupportsSearch => true;
         public override int PageSize => 50;
@@ -38,8 +38,7 @@ namespace NzbDrone.Core.Indexers.Definitions.Avistaz
                 Settings = Settings,
                 HttpClient = _httpClient,
                 Logger = _logger,
-                Capabilities = Capabilities,
-                BaseUrl = BaseUrl
+                Capabilities = Capabilities
             };
         }
 

--- a/src/NzbDrone.Core/Indexers/Definitions/Avistaz/AvistazRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Avistaz/AvistazRequestGenerator.cs
@@ -12,14 +12,13 @@ namespace NzbDrone.Core.Indexers.Definitions.Avistaz
     public class AvistazRequestGenerator : IIndexerRequestGenerator
     {
         public AvistazSettings Settings { get; set; }
-        public string BaseUrl { get; set; }
 
         public IDictionary<string, string> AuthCookieCache { get; set; }
         public IHttpClient HttpClient { get; set; }
         public IndexerCapabilities Capabilities { get; set; }
         public Logger Logger { get; set; }
 
-        protected virtual string SearchUrl => BaseUrl + "api/v1/jackett/torrents";
+        protected virtual string SearchUrl => Settings.BaseUrl + "api/v1/jackett/torrents";
         protected virtual bool ImdbInTags => false;
 
         public Func<IDictionary<string, string>> GetCookies { get; set; }

--- a/src/NzbDrone.Core/Indexers/Definitions/Avistaz/AvistazSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Avistaz/AvistazSettings.cs
@@ -1,6 +1,5 @@
 using FluentValidation;
 using NzbDrone.Core.Annotations;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.Definitions.Avistaz
@@ -15,7 +14,7 @@ namespace NzbDrone.Core.Indexers.Definitions.Avistaz
         }
     }
 
-    public class AvistazSettings : IProviderConfig
+    public class AvistazSettings : IIndexerSettings
     {
         private static readonly AvistazSettingsValidator Validator = new AvistazSettingsValidator();
 
@@ -26,13 +25,16 @@ namespace NzbDrone.Core.Indexers.Definitions.Avistaz
 
         public string Token { get; set; }
 
-        [FieldDefinition(1, Label = "Username", HelpText = "Site Username", Type = FieldType.Textbox, Privacy = PrivacyLevel.UserName)]
+        [FieldDefinition(1, Label = "Base Url", Type = FieldType.Select, SelectOptionsProviderAction = "getUrls", HelpText = "Select which baseurl Prowlarr will use for requests to the site")]
+        public string BaseUrl { get; set; }
+
+        [FieldDefinition(2, Label = "Username", HelpText = "Username", Privacy = PrivacyLevel.UserName)]
         public string Username { get; set; }
 
-        [FieldDefinition(2, Label = "Password", HelpText = "Site Password", Type = FieldType.Password, Privacy = PrivacyLevel.Password)]
+        [FieldDefinition(3, Label = "Password", Type = FieldType.Password, HelpText = "Password", Privacy = PrivacyLevel.Password)]
         public string Password { get; set; }
 
-        [FieldDefinition(3, Label = "PID", HelpText = "PID from My Account or My Profile page")]
+        [FieldDefinition(4, Label = "PID", HelpText = "PID from My Account or My Profile page")]
         public string Pid { get; set; }
 
         public NzbDroneValidationResult Validate()

--- a/src/NzbDrone.Core/Indexers/Definitions/BeyondHD.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/BeyondHD.cs
@@ -16,7 +16,6 @@ using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Messaging.Events;
 using NzbDrone.Core.Parser;
 using NzbDrone.Core.Parser.Model;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.Definitions
@@ -25,7 +24,8 @@ namespace NzbDrone.Core.Indexers.Definitions
     {
         public override string Name => "BeyondHD";
 
-        public override string BaseUrl => "https://beyond-hd.me/";
+        public override string[] IndexerUrls => new string[] { "https://beyond-hd.me/" };
+        public override string Description => "Without BeyondHD, your HDTV is just a TV";
         public override DownloadProtocol Protocol => DownloadProtocol.Torrent;
         public override IndexerPrivacy Privacy => IndexerPrivacy.Private;
         public override IndexerCapabilities Capabilities => SetCapabilities();
@@ -37,12 +37,12 @@ namespace NzbDrone.Core.Indexers.Definitions
 
         public override IIndexerRequestGenerator GetRequestGenerator()
         {
-            return new BeyondHDRequestGenerator() { Settings = Settings, Capabilities = Capabilities, BaseUrl = BaseUrl };
+            return new BeyondHDRequestGenerator() { Settings = Settings, Capabilities = Capabilities };
         }
 
         public override IParseIndexerResponse GetParser()
         {
-            return new BeyondHDParser(Settings, Capabilities.Categories, BaseUrl);
+            return new BeyondHDParser(Settings, Capabilities.Categories);
         }
 
         private IndexerCapabilities SetCapabilities()
@@ -70,7 +70,6 @@ namespace NzbDrone.Core.Indexers.Definitions
     {
         public BeyondHDSettings Settings { get; set; }
         public IndexerCapabilities Capabilities { get; set; }
-        public string BaseUrl { get; set; }
 
         public BeyondHDRequestGenerator()
         {
@@ -106,7 +105,7 @@ namespace NzbDrone.Core.Indexers.Definitions
                 body.Add("categories", string.Join(",", cats));
             }
 
-            var searchUrl = BaseUrl + "api/torrents/" + Settings.ApiKey;
+            var searchUrl = Settings.BaseUrl + "api/torrents/" + Settings.ApiKey;
 
             var request = new HttpRequest(searchUrl, HttpAccept.Json);
 
@@ -172,13 +171,11 @@ namespace NzbDrone.Core.Indexers.Definitions
     {
         private readonly BeyondHDSettings _settings;
         private readonly IndexerCapabilitiesCategories _categories;
-        private readonly string _baseUrl;
 
-        public BeyondHDParser(BeyondHDSettings settings, IndexerCapabilitiesCategories categories, string baseUrl)
+        public BeyondHDParser(BeyondHDSettings settings, IndexerCapabilitiesCategories categories)
         {
             _settings = settings;
             _categories = categories;
-            _baseUrl = baseUrl;
         }
 
         public IList<ReleaseInfo> ParseResponse(IndexerResponse indexerResponse)
@@ -242,7 +239,7 @@ namespace NzbDrone.Core.Indexers.Definitions
         }
     }
 
-    public class BeyondHDSettings : IProviderConfig
+    public class BeyondHDSettings : IIndexerSettings
     {
         private static readonly BeyondHDSettingsValidator Validator = new BeyondHDSettingsValidator();
 
@@ -250,10 +247,13 @@ namespace NzbDrone.Core.Indexers.Definitions
         {
         }
 
-        [FieldDefinition(1, Label = "API Key", HelpText = "API Key from Site", Privacy = PrivacyLevel.ApiKey)]
+        [FieldDefinition(1, Label = "Base Url", Type = FieldType.Select, SelectOptionsProviderAction = "getUrls", HelpText = "Select which baseurl Prowlarr will use for requests to the site")]
+        public string BaseUrl { get; set; }
+
+        [FieldDefinition(2, Label = "API Key", HelpText = "API Key from Site", Privacy = PrivacyLevel.ApiKey)]
         public string ApiKey { get; set; }
 
-        [FieldDefinition(2, Label = "RSS Key", HelpText = "RSS Key from Site", Privacy = PrivacyLevel.ApiKey)]
+        [FieldDefinition(3, Label = "RSS Key", HelpText = "RSS Key from Site", Privacy = PrivacyLevel.ApiKey)]
         public string RssKey { get; set; }
 
         public NzbDroneValidationResult Validate()

--- a/src/NzbDrone.Core/Indexers/Definitions/Blutopia.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Blutopia.cs
@@ -10,7 +10,8 @@ namespace NzbDrone.Core.Indexers.Definitions
     public class Blutopia : Unit3dBase
     {
         public override string Name => "Blutopia";
-        public override string BaseUrl => "https://blutopia.xyz/";
+        public override string[] IndexerUrls => new string[] { "https://blutopia.xyz/" };
+        public override string Description => "Blutopia (BLU) is a Private Torrent Tracker for HD MOVIES / TV";
         public override IndexerPrivacy Privacy => IndexerPrivacy.Private;
 
         public Blutopia(IHttpClient httpClient, IEventAggregator eventAggregator, IIndexerStatusService indexerStatusService, IConfigService configService, Logger logger)

--- a/src/NzbDrone.Core/Indexers/Definitions/BroadcastheNet/BroadcastheNet.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/BroadcastheNet/BroadcastheNet.cs
@@ -17,7 +17,8 @@ namespace NzbDrone.Core.Indexers.BroadcastheNet
         public override int PageSize => 100;
         public override IndexerCapabilities Capabilities => SetCapabilities();
 
-        public override string BaseUrl => "http://api.broadcasthe.net/";
+        public override string[] IndexerUrls => new string[] { "http://api.broadcasthe.net/" };
+        public override string Description => "BroadcasTheNet (BTN) is an invite-only torrent tracker focused on TV shows";
 
         public BroadcastheNet(IHttpClient httpClient, IEventAggregator eventAggregator, IIndexerStatusService indexerStatusService, IConfigService configService, Logger logger)
             : base(httpClient, eventAggregator, indexerStatusService, configService, logger)
@@ -26,7 +27,7 @@ namespace NzbDrone.Core.Indexers.BroadcastheNet
 
         public override IIndexerRequestGenerator GetRequestGenerator()
         {
-            var requestGenerator = new BroadcastheNetRequestGenerator() { Settings = Settings, PageSize = PageSize, BaseUrl = BaseUrl, Capabilities = Capabilities };
+            var requestGenerator = new BroadcastheNetRequestGenerator() { Settings = Settings, PageSize = PageSize, Capabilities = Capabilities };
 
             var releaseInfo = _indexerStatusService.GetLastRssSyncReleaseInfo(Definition.Id);
             if (releaseInfo != null)

--- a/src/NzbDrone.Core/Indexers/Definitions/BroadcastheNet/BroadcastheNetRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/BroadcastheNet/BroadcastheNetRequestGenerator.cs
@@ -16,7 +16,6 @@ namespace NzbDrone.Core.Indexers.BroadcastheNet
 
         public Func<IDictionary<string, string>> GetCookies { get; set; }
         public Action<IDictionary<string, string>, DateTime?> CookiesUpdater { get; set; }
-        public string BaseUrl { get; set; }
 
         public BroadcastheNetRequestGenerator()
         {
@@ -26,7 +25,7 @@ namespace NzbDrone.Core.Indexers.BroadcastheNet
 
         private IEnumerable<IndexerRequest> GetPagedRequests(BroadcastheNetTorrentQuery parameters, int results, int offset)
         {
-            var builder = new JsonRpcRequestBuilder(BaseUrl)
+            var builder = new JsonRpcRequestBuilder(Settings.BaseUrl)
                 .Call("getTorrents", Settings.ApiKey, parameters, results, offset);
             builder.SuppressHttpError = true;
 

--- a/src/NzbDrone.Core/Indexers/Definitions/BroadcastheNet/BroadcastheNetSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/BroadcastheNet/BroadcastheNetSettings.cs
@@ -1,6 +1,5 @@
 using FluentValidation;
 using NzbDrone.Core.Annotations;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.BroadcastheNet
@@ -13,7 +12,7 @@ namespace NzbDrone.Core.Indexers.BroadcastheNet
         }
     }
 
-    public class BroadcastheNetSettings : IProviderConfig
+    public class BroadcastheNetSettings : IIndexerSettings
     {
         private static readonly BroadcastheNetSettingsValidator Validator = new BroadcastheNetSettingsValidator();
 
@@ -21,7 +20,10 @@ namespace NzbDrone.Core.Indexers.BroadcastheNet
         {
         }
 
-        [FieldDefinition(1, Label = "API Key", Privacy = PrivacyLevel.ApiKey)]
+        [FieldDefinition(1, Label = "Base Url", Type = FieldType.Select, SelectOptionsProviderAction = "getUrls", HelpText = "Select which baseurl Prowlarr will use for requests to the site")]
+        public string BaseUrl { get; set; }
+
+        [FieldDefinition(2, Label = "API Key", Privacy = PrivacyLevel.ApiKey)]
         public string ApiKey { get; set; }
 
         public NzbDroneValidationResult Validate()

--- a/src/NzbDrone.Core/Indexers/Definitions/BrokenStones.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/BrokenStones.cs
@@ -8,7 +8,8 @@ namespace NzbDrone.Core.Indexers.Definitions
     public class BrokenStones : Gazelle.Gazelle
     {
         public override string Name => "BrokenStones";
-        public override string BaseUrl => "https://brokenstones.club/";
+        public override string[] IndexerUrls => new string[] { "https://brokenstones.club/" };
+        public override string Description => "Broken Stones is a Private site for MacOS and iOS APPS / GAMES";
         public override IndexerPrivacy Privacy => IndexerPrivacy.Private;
 
         public BrokenStones(IHttpClient httpClient, IEventAggregator eventAggregator, IIndexerStatusService indexerStatusService, IConfigService configService, Logger logger)

--- a/src/NzbDrone.Core/Indexers/Definitions/CGPeers.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/CGPeers.cs
@@ -8,7 +8,8 @@ namespace NzbDrone.Core.Indexers.Definitions
     public class CGPeers : Gazelle.Gazelle
     {
         public override string Name => "CGPeers";
-        public override string BaseUrl => "https://cgpeers.to/";
+        public override string[] IndexerUrls => new string[] { "https://cgpeers.to/" };
+        public override string Description => "CGPeers is a Private Torrent Tracker for GRAPHICS SOFTWARE / TUTORIALS / ETC";
         public override IndexerPrivacy Privacy => IndexerPrivacy.Private;
 
         public CGPeers(IHttpClient httpClient, IEventAggregator eventAggregator, IIndexerStatusService indexerStatusService, IConfigService configService, Logger logger)

--- a/src/NzbDrone.Core/Indexers/Definitions/Cardigann/Cardigann.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Cardigann/Cardigann.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Text;
 using System.Threading.Tasks;
@@ -22,7 +23,8 @@ namespace NzbDrone.Core.Indexers.Cardigann
         private readonly ICached<CardigannRequestGenerator> _generatorCache;
 
         public override string Name => "Cardigann";
-        public override string BaseUrl => "";
+        public override string[] IndexerUrls => new string[] { "" };
+        public override string Description => "";
 
         public override DownloadProtocol Protocol => DownloadProtocol.Torrent;
         public override IndexerPrivacy Privacy => IndexerPrivacy.Private;
@@ -120,6 +122,7 @@ namespace NzbDrone.Core.Indexers.Cardigann
                 Language = definition.Language,
                 Description = definition.Description,
                 Implementation = GetType().Name,
+                IndexerUrls = definition.Links.ToArray(),
                 Settings = new CardigannSettings { DefinitionFile = definition.File },
                 Protocol = DownloadProtocol.Torrent,
                 Privacy = definition.Type == "private" ? IndexerPrivacy.Private : IndexerPrivacy.Public,
@@ -233,6 +236,16 @@ namespace NzbDrone.Core.Indexers.Cardigann
                 return new
                 {
                     captchaRequest = result
+                };
+            }
+
+            if (action == "getUrls")
+            {
+                var devices = ((IndexerDefinition)Definition).IndexerUrls;
+
+                return new
+                {
+                    options = devices.Select(d => new { Value = d, Name = d })
                 };
             }
 

--- a/src/NzbDrone.Core/Indexers/Definitions/Cardigann/CardigannBase.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Cardigann/CardigannBase.cs
@@ -23,7 +23,7 @@ namespace NzbDrone.Core.Indexers.Cardigann
         protected readonly Encoding _encoding;
         protected readonly IConfigService _configService;
 
-        protected string SiteLink { get; private set; }
+        protected virtual string SiteLink { get; private set; }
 
         protected readonly List<CategoryMapping> _categoryMapping = new List<CategoryMapping>();
         protected readonly List<string> _defaultCategories = new List<string>();

--- a/src/NzbDrone.Core/Indexers/Definitions/Cardigann/CardigannParser.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Cardigann/CardigannParser.cs
@@ -18,6 +18,8 @@ namespace NzbDrone.Core.Indexers.Cardigann
     {
         public Action<IDictionary<string, string>, DateTime?> CookiesUpdater { get; set; }
 
+        protected override string SiteLink => Settings?.BaseUrl ?? _definition.Links.First();
+
         public CardigannParser(IConfigService configService,
                                CardigannDefinition definition,
                                Logger logger)

--- a/src/NzbDrone.Core/Indexers/Definitions/Cardigann/CardigannRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Cardigann/CardigannRequestGenerator.cs
@@ -22,6 +22,7 @@ namespace NzbDrone.Core.Indexers.Cardigann
         public IDictionary<string, string> Cookies { get; set; }
         protected HttpResponse landingResult;
         protected IHtmlDocument landingResultDocument;
+        protected override string SiteLink => Settings?.BaseUrl ?? _definition.Links.First();
 
         public CardigannRequestGenerator(IConfigService configService,
                                          CardigannDefinition definition,

--- a/src/NzbDrone.Core/Indexers/Definitions/Cardigann/CardigannSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Cardigann/CardigannSettings.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using FluentValidation;
 using NzbDrone.Core.Annotations;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.Cardigann
@@ -13,7 +12,7 @@ namespace NzbDrone.Core.Indexers.Cardigann
         }
     }
 
-    public class CardigannSettings : IProviderConfig
+    public class CardigannSettings : IIndexerSettings
     {
         private static readonly CardigannSettingsValidator Validator = new CardigannSettingsValidator();
 
@@ -24,6 +23,9 @@ namespace NzbDrone.Core.Indexers.Cardigann
 
         [FieldDefinition(0, Hidden = HiddenType.Hidden)]
         public string DefinitionFile { get; set; }
+
+        [FieldDefinition(1, Label = "Base Url", Type = FieldType.Select, SelectOptionsProviderAction = "getUrls", HelpText = "Select which baseurl Prowlarr will use for requests to the site")]
+        public string BaseUrl { get; set; }
 
         public Dictionary<string, object> ExtraFieldData { get; set; }
 

--- a/src/NzbDrone.Core/Indexers/Definitions/CinemaZ.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/CinemaZ.cs
@@ -10,7 +10,8 @@ namespace NzbDrone.Core.Indexers.Definitions
     public class CinemaZ : AvistazBase
     {
         public override string Name => "CinemaZ";
-        public override string BaseUrl => "https://cinemaz.to/";
+        public override string[] IndexerUrls => new string[] { "https://cinemaz.to/" };
+        public override string Description => "Part of the Avistaz network.";
         public override IndexerPrivacy Privacy => IndexerPrivacy.Private;
 
         public CinemaZ(IIndexerRepository indexerRepository, IHttpClient httpClient, IEventAggregator eventAggregator, IIndexerStatusService indexerStatusService, IConfigService configService, Logger logger)
@@ -25,8 +26,7 @@ namespace NzbDrone.Core.Indexers.Definitions
                 Settings = Settings,
                 HttpClient = _httpClient,
                 Logger = _logger,
-                Capabilities = Capabilities,
-                BaseUrl = BaseUrl
+                Capabilities = Capabilities
             };
         }
 

--- a/src/NzbDrone.Core/Indexers/Definitions/ExoticaZ.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/ExoticaZ.cs
@@ -10,7 +10,8 @@ namespace NzbDrone.Core.Indexers.Definitions
     public class ExoticaZ : AvistazBase
     {
         public override string Name => "ExoticaZ";
-        public override string BaseUrl => "https://exoticaz.to/";
+        public override string[] IndexerUrls => new string[] { "https://exoticaz.to/" };
+        public override string Description => "ExoticaZ (YourExotic) is a Private Torrent Tracker for 3X";
         public override IndexerPrivacy Privacy => IndexerPrivacy.Private;
 
         public ExoticaZ(IIndexerRepository indexerRepository, IHttpClient httpClient, IEventAggregator eventAggregator, IIndexerStatusService indexerStatusService, IConfigService configService, Logger logger)
@@ -26,7 +27,6 @@ namespace NzbDrone.Core.Indexers.Definitions
                 HttpClient = _httpClient,
                 Logger = _logger,
                 Capabilities = Capabilities,
-                BaseUrl = BaseUrl
             };
         }
 

--- a/src/NzbDrone.Core/Indexers/Definitions/FileList/FileList.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/FileList/FileList.cs
@@ -9,7 +9,8 @@ namespace NzbDrone.Core.Indexers.FileList
     public class FileList : TorrentIndexerBase<FileListSettings>
     {
         public override string Name => "FileList.io";
-        public override string BaseUrl => "https://filelist.io";
+        public override string[] IndexerUrls => new string[] { "https://filelist.io" };
+        public override string Description => "";
         public override DownloadProtocol Protocol => DownloadProtocol.Torrent;
         public override IndexerPrivacy Privacy => IndexerPrivacy.Private;
         public override bool SupportsRss => true;
@@ -24,12 +25,12 @@ namespace NzbDrone.Core.Indexers.FileList
 
         public override IIndexerRequestGenerator GetRequestGenerator()
         {
-            return new FileListRequestGenerator() { Settings = Settings, BaseUrl = BaseUrl, Capabilities = Capabilities };
+            return new FileListRequestGenerator() { Settings = Settings, Capabilities = Capabilities };
         }
 
         public override IParseIndexerResponse GetParser()
         {
-            return new FileListParser(Settings, BaseUrl, Capabilities.Categories);
+            return new FileListParser(Settings, Capabilities.Categories);
         }
 
         private IndexerCapabilities SetCapabilities()

--- a/src/NzbDrone.Core/Indexers/Definitions/FileList/FileListParser.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/FileList/FileListParser.cs
@@ -10,14 +10,12 @@ namespace NzbDrone.Core.Indexers.FileList
 {
     public class FileListParser : IParseIndexerResponse
     {
-        private readonly string _baseUrl;
         private readonly FileListSettings _settings;
         private readonly IndexerCapabilitiesCategories _categories;
 
-        public FileListParser(FileListSettings settings, string baseUrl, IndexerCapabilitiesCategories categories)
+        public FileListParser(FileListSettings settings, IndexerCapabilitiesCategories categories)
         {
             _settings = settings;
-            _baseUrl = baseUrl;
             _categories = categories;
         }
 
@@ -78,7 +76,7 @@ namespace NzbDrone.Core.Indexers.FileList
 
         private string GetDownloadUrl(string torrentId)
         {
-            var url = new HttpUri(_baseUrl)
+            var url = new HttpUri(_settings.BaseUrl)
                 .CombinePath("/download.php")
                 .AddQueryParam("id", torrentId)
                 .AddQueryParam("passkey", _settings.Passkey);
@@ -88,7 +86,7 @@ namespace NzbDrone.Core.Indexers.FileList
 
         private string GetInfoUrl(string torrentId)
         {
-            var url = new HttpUri(_baseUrl)
+            var url = new HttpUri(_settings.BaseUrl)
                 .CombinePath("/details.php")
                 .AddQueryParam("id", torrentId);
 

--- a/src/NzbDrone.Core/Indexers/Definitions/FileList/FileListRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/FileList/FileListRequestGenerator.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Http;
 using NzbDrone.Core.IndexerSearch.Definitions;
@@ -9,7 +8,6 @@ namespace NzbDrone.Core.Indexers.FileList
 {
     public class FileListRequestGenerator : IIndexerRequestGenerator
     {
-        public string BaseUrl { get; set; }
         public FileListSettings Settings { get; set; }
         public IndexerCapabilities Capabilities { get; set; }
         public Func<IDictionary<string, string>> GetCookies { get; set; }
@@ -109,7 +107,7 @@ namespace NzbDrone.Core.Indexers.FileList
         {
             var categoriesQuery = string.Join(",", Capabilities.Categories.MapTorznabCapsToTrackers(categories));
 
-            var baseUrl = string.Format("{0}/api.php?action={1}&category={2}&username={3}&passkey={4}{5}", BaseUrl.TrimEnd('/'), searchType, categoriesQuery, Settings.Username.Trim(), Settings.Passkey.Trim(), parameters);
+            var baseUrl = string.Format("{0}/api.php?action={1}&category={2}&username={3}&passkey={4}{5}", Settings.BaseUrl.TrimEnd('/'), searchType, categoriesQuery, Settings.Username.Trim(), Settings.Passkey.Trim(), parameters);
 
             yield return new IndexerRequest(baseUrl, HttpAccept.Json);
         }

--- a/src/NzbDrone.Core/Indexers/Definitions/FileList/FileListSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/FileList/FileListSettings.cs
@@ -1,6 +1,5 @@
 using FluentValidation;
 using NzbDrone.Core.Annotations;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.FileList
@@ -14,18 +13,22 @@ namespace NzbDrone.Core.Indexers.FileList
         }
     }
 
-    public class FileListSettings : IProviderConfig
+    public class FileListSettings : IIndexerSettings
     {
         private static readonly FileListSettingsValidator Validator = new FileListSettingsValidator();
 
         public FileListSettings()
         {
+            BaseUrl = "https://filelist.io";
         }
 
-        [FieldDefinition(0, Label = "Username", HelpText = "Site Username", Type = FieldType.Textbox, Privacy = PrivacyLevel.UserName)]
+        [FieldDefinition(1, Label = "Base Url", Type = FieldType.Select, SelectOptionsProviderAction = "getUrls", HelpText = "Select which baseurl Prowlarr will use for requests to the site")]
+        public string BaseUrl { get; set; }
+
+        [FieldDefinition(2, Label = "Username", Privacy = PrivacyLevel.UserName)]
         public string Username { get; set; }
 
-        [FieldDefinition(1, Label = "Passkey", Privacy = PrivacyLevel.ApiKey)]
+        [FieldDefinition(3, Label = "Passkey", Privacy = PrivacyLevel.ApiKey)]
         public string Passkey { get; set; }
 
         public NzbDroneValidationResult Validate()

--- a/src/NzbDrone.Core/Indexers/Definitions/Gazelle/Gazelle.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Gazelle/Gazelle.cs
@@ -10,8 +10,8 @@ namespace NzbDrone.Core.Indexers.Gazelle
     public abstract class Gazelle : TorrentIndexerBase<GazelleSettings>
     {
         public override DownloadProtocol Protocol => DownloadProtocol.Torrent;
-        public override string BaseUrl => "";
-        protected virtual string LoginUrl => BaseUrl + "login.php";
+        public override string[] IndexerUrls => new string[] { "" };
+        protected virtual string LoginUrl => Settings.BaseUrl + "login.php";
         public override bool SupportsRss => true;
         public override bool SupportsSearch => true;
         public override int PageSize => 50;
@@ -33,14 +33,13 @@ namespace NzbDrone.Core.Indexers.Gazelle
                 Settings = Settings,
                 HttpClient = _httpClient,
                 Logger = _logger,
-                Capabilities = Capabilities,
-                BaseUrl = BaseUrl
+                Capabilities = Capabilities
             };
         }
 
         public override IParseIndexerResponse GetParser()
         {
-            return new GazelleParser(Settings, Capabilities, BaseUrl);
+            return new GazelleParser(Settings, Capabilities);
         }
 
         protected virtual IndexerCapabilities SetCapabilities()

--- a/src/NzbDrone.Core/Indexers/Definitions/Gazelle/GazelleParser.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Gazelle/GazelleParser.cs
@@ -13,13 +13,11 @@ namespace NzbDrone.Core.Indexers.Gazelle
     {
         protected readonly GazelleSettings _settings;
         protected readonly IndexerCapabilities _capabilities;
-        protected readonly string _baseUrl;
 
-        public GazelleParser(GazelleSettings settings, IndexerCapabilities capabilities, string baseUrl)
+        public GazelleParser(GazelleSettings settings, IndexerCapabilities capabilities)
         {
             _settings = settings;
             _capabilities = capabilities;
-            _baseUrl = baseUrl;
         }
 
         public Action<IDictionary<string, string>, DateTime?> CookiesUpdater { get; set; }
@@ -140,7 +138,7 @@ namespace NzbDrone.Core.Indexers.Gazelle
 
         protected virtual string GetDownloadUrl(int torrentId)
         {
-            var url = new HttpUri(_baseUrl)
+            var url = new HttpUri(_settings.BaseUrl)
                 .CombinePath("/torrents.php")
                 .AddQueryParam("action", "download")
                 .AddQueryParam("useToken", _settings.UseFreeleechToken ? "1" : "0")
@@ -151,7 +149,7 @@ namespace NzbDrone.Core.Indexers.Gazelle
 
         private string GetInfoUrl(string groupId, int torrentId)
         {
-            var url = new HttpUri(_baseUrl)
+            var url = new HttpUri(_settings.BaseUrl)
                 .CombinePath("/torrents.php")
                 .AddQueryParam("id", groupId)
                 .AddQueryParam("torrentid", torrentId);

--- a/src/NzbDrone.Core/Indexers/Definitions/Gazelle/GazelleRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Gazelle/GazelleRequestGenerator.cs
@@ -9,14 +9,13 @@ namespace NzbDrone.Core.Indexers.Gazelle
     public class GazelleRequestGenerator : IIndexerRequestGenerator
     {
         public GazelleSettings Settings { get; set; }
-        public string BaseUrl { get; set; }
 
         public IDictionary<string, string> AuthCookieCache { get; set; }
         public IHttpClient HttpClient { get; set; }
         public IndexerCapabilities Capabilities { get; set; }
         public Logger Logger { get; set; }
 
-        protected virtual string APIUrl => BaseUrl + "ajax.php";
+        protected virtual string APIUrl => Settings.BaseUrl + "ajax.php";
         protected virtual bool ImdbInTags => false;
 
         public Func<IDictionary<string, string>> GetCookies { get; set; }

--- a/src/NzbDrone.Core/Indexers/Definitions/Gazelle/GazelleSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Gazelle/GazelleSettings.cs
@@ -1,6 +1,5 @@
 using FluentValidation;
 using NzbDrone.Core.Annotations;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.Gazelle
@@ -14,7 +13,7 @@ namespace NzbDrone.Core.Indexers.Gazelle
         }
     }
 
-    public class GazelleSettings : IProviderConfig
+    public class GazelleSettings : IIndexerSettings
     {
         private static readonly GazelleSettingsValidator Validator = new GazelleSettingsValidator();
 
@@ -25,13 +24,16 @@ namespace NzbDrone.Core.Indexers.Gazelle
         public string AuthKey;
         public string PassKey;
 
-        [FieldDefinition(1, Label = "Username", HelpText = "Site Username", Type = FieldType.Textbox, Privacy = PrivacyLevel.UserName)]
+        [FieldDefinition(1, Label = "Base Url", Type = FieldType.Select, SelectOptionsProviderAction = "getUrls", HelpText = "Select which baseurl Prowlarr will use for requests to the site")]
+        public string BaseUrl { get; set; }
+
+        [FieldDefinition(2, Label = "Username", HelpText = "Username", Privacy = PrivacyLevel.UserName)]
         public string Username { get; set; }
 
-        [FieldDefinition(2, Label = "Password", HelpText = "Site Password", Type = FieldType.Password, Privacy = PrivacyLevel.Password)]
+        [FieldDefinition(3, Label = "Password", Type = FieldType.Password, HelpText = "Password", Privacy = PrivacyLevel.Password)]
         public string Password { get; set; }
 
-        [FieldDefinition(3, Type = FieldType.Checkbox, Label = "Use Freeleech Token", HelpText = "Use Freeleech Token")]
+        [FieldDefinition(4, Type = FieldType.Checkbox, Label = "Use Freeleech Token", HelpText = "Use Freeleech Token")]
         public bool UseFreeleechToken { get; set; }
 
         public NzbDroneValidationResult Validate()

--- a/src/NzbDrone.Core/Indexers/Definitions/HDBits/HDBits.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/HDBits/HDBits.cs
@@ -9,7 +9,8 @@ namespace NzbDrone.Core.Indexers.HDBits
     public class HDBits : TorrentIndexerBase<HDBitsSettings>
     {
         public override string Name => "HDBits";
-        public override string BaseUrl => "https://hdbits.org";
+        public override string[] IndexerUrls => new string[] { "https://hdbits.org" };
+        public override string Description => "Best HD Tracker";
         public override DownloadProtocol Protocol => DownloadProtocol.Torrent;
         public override IndexerPrivacy Privacy => IndexerPrivacy.Private;
         public override IndexerCapabilities Capabilities => SetCapabilities();
@@ -24,12 +25,12 @@ namespace NzbDrone.Core.Indexers.HDBits
 
         public override IIndexerRequestGenerator GetRequestGenerator()
         {
-            return new HDBitsRequestGenerator() { Settings = Settings, BaseUrl = BaseUrl, Capabilities = Capabilities };
+            return new HDBitsRequestGenerator() { Settings = Settings, Capabilities = Capabilities };
         }
 
         public override IParseIndexerResponse GetParser()
         {
-            return new HDBitsParser(Settings, BaseUrl);
+            return new HDBitsParser(Settings);
         }
 
         private IndexerCapabilities SetCapabilities()

--- a/src/NzbDrone.Core/Indexers/Definitions/HDBits/HDBitsParser.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/HDBits/HDBitsParser.cs
@@ -11,13 +11,11 @@ namespace NzbDrone.Core.Indexers.HDBits
 {
     public class HDBitsParser : IParseIndexerResponse
     {
-        private readonly string _baseUrl;
         private readonly HDBitsSettings _settings;
 
-        public HDBitsParser(HDBitsSettings settings, string baseUrl)
+        public HDBitsParser(HDBitsSettings settings)
         {
             _settings = settings;
-            _baseUrl = baseUrl;
         }
 
         public IList<ReleaseInfo> ParseResponse(IndexerResponse indexerResponse)
@@ -91,7 +89,7 @@ namespace NzbDrone.Core.Indexers.HDBits
 
         private string GetDownloadUrl(string torrentId)
         {
-            var url = new HttpUri(_baseUrl)
+            var url = new HttpUri(_settings.BaseUrl)
                 .CombinePath("/download.php")
                 .AddQueryParam("id", torrentId)
                 .AddQueryParam("passkey", _settings.ApiKey);
@@ -101,7 +99,7 @@ namespace NzbDrone.Core.Indexers.HDBits
 
         private string GetInfoUrl(string torrentId)
         {
-            var url = new HttpUri(_baseUrl)
+            var url = new HttpUri(_settings.BaseUrl)
                 .CombinePath("/details.php")
                 .AddQueryParam("id", torrentId);
 

--- a/src/NzbDrone.Core/Indexers/Definitions/HDBits/HDBitsRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/HDBits/HDBitsRequestGenerator.cs
@@ -12,7 +12,6 @@ namespace NzbDrone.Core.Indexers.HDBits
     {
         public IndexerCapabilities Capabilities { get; set; }
         public HDBitsSettings Settings { get; set; }
-        public string BaseUrl { get; set; }
 
         public virtual IndexerPageableRequestChain GetSearchRequests(MovieSearchCriteria searchCriteria)
         {
@@ -50,7 +49,7 @@ namespace NzbDrone.Core.Indexers.HDBits
 
         private IEnumerable<IndexerRequest> GetRequest(TorrentQuery query)
         {
-            var request = new HttpRequestBuilder(BaseUrl)
+            var request = new HttpRequestBuilder(Settings.BaseUrl)
                 .Resource("/api/torrents")
                 .Build();
 

--- a/src/NzbDrone.Core/Indexers/Definitions/HDBits/HDBitsSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/HDBits/HDBitsSettings.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using FluentValidation;
 using NzbDrone.Core.Annotations;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.HDBits
@@ -14,7 +13,7 @@ namespace NzbDrone.Core.Indexers.HDBits
         }
     }
 
-    public class HDBitsSettings : IProviderConfig
+    public class HDBitsSettings : IIndexerSettings
     {
         private static readonly HDBitsSettingsValidator Validator = new HDBitsSettingsValidator();
 
@@ -24,16 +23,19 @@ namespace NzbDrone.Core.Indexers.HDBits
             Mediums = System.Array.Empty<int>();
         }
 
-        [FieldDefinition(0, Label = "Username", HelpText = "Site Username", Type = FieldType.Textbox, Privacy = PrivacyLevel.UserName)]
+        [FieldDefinition(1, Label = "Base Url", Type = FieldType.Select, SelectOptionsProviderAction = "getUrls", HelpText = "Select which baseurl Prowlarr will use for requests to the site")]
+        public string BaseUrl { get; set; }
+
+        [FieldDefinition(2, Label = "Username", Privacy = PrivacyLevel.UserName)]
         public string Username { get; set; }
 
-        [FieldDefinition(2, Label = "API Key", Privacy = PrivacyLevel.ApiKey)]
+        [FieldDefinition(3, Label = "API Key", Privacy = PrivacyLevel.ApiKey)]
         public string ApiKey { get; set; }
 
-        [FieldDefinition(5, Label = "Codecs", Type = FieldType.TagSelect, SelectOptions = typeof(HdBitsCodec), Advanced = true, HelpText = "Options: h264, Mpeg2, VC1, Xvid. If unspecified, all options are used.")]
+        [FieldDefinition(4, Label = "Codecs", Type = FieldType.TagSelect, SelectOptions = typeof(HdBitsCodec), Advanced = true, HelpText = "Options: h264, Mpeg2, VC1, Xvid. If unspecified, all options are used.")]
         public IEnumerable<int> Codecs { get; set; }
 
-        [FieldDefinition(6, Label = "Mediums", Type = FieldType.TagSelect, SelectOptions = typeof(HdBitsMedium), Advanced = true, HelpText = "Options: BluRay, Encode, Capture, Remux, WebDL. If unspecified, all options are used.")]
+        [FieldDefinition(5, Label = "Mediums", Type = FieldType.TagSelect, SelectOptions = typeof(HdBitsMedium), Advanced = true, HelpText = "Options: BluRay, Encode, Capture, Remux, WebDL. If unspecified, all options are used.")]
         public IEnumerable<int> Mediums { get; set; }
 
         public NzbDroneValidationResult Validate()

--- a/src/NzbDrone.Core/Indexers/Definitions/HDTorrents.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/HDTorrents.cs
@@ -15,7 +15,6 @@ using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Messaging.Events;
 using NzbDrone.Core.Parser;
 using NzbDrone.Core.Parser.Model;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.Definitions
@@ -24,8 +23,9 @@ namespace NzbDrone.Core.Indexers.Definitions
     {
         public override string Name => "HD-Torrents";
 
-        public override string BaseUrl => "https://hdts.ru/";
-        private string LoginUrl => BaseUrl + "login.php";
+        public override string[] IndexerUrls => new string[] { "https://hdts.ru/" };
+        public override string Description => "HD-Torrents is a private torrent website with HD torrents and strict rules on their content.";
+        private string LoginUrl => Settings.BaseUrl + "login.php";
         public override DownloadProtocol Protocol => DownloadProtocol.Torrent;
         public override IndexerPrivacy Privacy => IndexerPrivacy.Private;
         public override IndexerCapabilities Capabilities => SetCapabilities();
@@ -37,12 +37,12 @@ namespace NzbDrone.Core.Indexers.Definitions
 
         public override IIndexerRequestGenerator GetRequestGenerator()
         {
-            return new HDTorrentsRequestGenerator() { Settings = Settings, Capabilities = Capabilities, BaseUrl = BaseUrl };
+            return new HDTorrentsRequestGenerator() { Settings = Settings, Capabilities = Capabilities };
         }
 
         public override IParseIndexerResponse GetParser()
         {
-            return new HDTorrentsParser(Settings, Capabilities.Categories, BaseUrl);
+            return new HDTorrentsParser(Settings, Capabilities.Categories);
         }
 
         protected override async Task DoLogin()
@@ -141,7 +141,6 @@ namespace NzbDrone.Core.Indexers.Definitions
     {
         public HDTorrentsSettings Settings { get; set; }
         public IndexerCapabilities Capabilities { get; set; }
-        public string BaseUrl { get; set; }
 
         public HDTorrentsRequestGenerator()
         {
@@ -149,7 +148,7 @@ namespace NzbDrone.Core.Indexers.Definitions
 
         private IEnumerable<IndexerRequest> GetPagedRequests(string term, int[] categories, string imdbId = null)
         {
-            var searchUrl = BaseUrl + "torrents.php?" + string.Join(string.Empty, Capabilities.Categories.MapTorznabCapsToTrackers(categories).Select(cat => $"category[]={cat}&"));
+            var searchUrl = Settings.BaseUrl + "torrents.php?" + string.Join(string.Empty, Capabilities.Categories.MapTorznabCapsToTrackers(categories).Select(cat => $"category[]={cat}&"));
 
             var queryCollection = new NameValueCollection
             {
@@ -219,7 +218,6 @@ namespace NzbDrone.Core.Indexers.Definitions
     {
         private readonly HDTorrentsSettings _settings;
         private readonly IndexerCapabilitiesCategories _categories;
-        private readonly string _baseUrl;
 
         private readonly Regex _posterRegex = new Regex(@"src=\\'./([^']+)\\'", RegexOptions.IgnoreCase);
         private readonly HashSet<string> _freeleechRanks = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
@@ -232,11 +230,10 @@ namespace NzbDrone.Core.Indexers.Definitions
             "Owner"
         };
 
-        public HDTorrentsParser(HDTorrentsSettings settings, IndexerCapabilitiesCategories categories, string baseUrl)
+        public HDTorrentsParser(HDTorrentsSettings settings, IndexerCapabilitiesCategories categories)
         {
             _settings = settings;
             _categories = categories;
-            _baseUrl = baseUrl;
         }
 
         public IList<ReleaseInfo> ParseResponse(IndexerResponse indexerResponse)
@@ -255,12 +252,12 @@ namespace NzbDrone.Core.Indexers.Definitions
             {
                 var mainLink = row.Children[2].QuerySelector("a");
                 var title = mainLink.TextContent;
-                var details = new Uri(_baseUrl + mainLink.GetAttribute("href"));
+                var details = new Uri(_settings.BaseUrl + mainLink.GetAttribute("href"));
 
                 var posterMatch = _posterRegex.Match(mainLink.GetAttribute("onmouseover"));
-                var poster = posterMatch.Success ? new Uri(_baseUrl + posterMatch.Groups[1].Value.Replace("\\", "/")) : null;
+                var poster = posterMatch.Success ? new Uri(_settings.BaseUrl + posterMatch.Groups[1].Value.Replace("\\", "/")) : null;
 
-                var link = new Uri(_baseUrl + row.Children[4].FirstElementChild.GetAttribute("href"));
+                var link = new Uri(_settings.BaseUrl + row.Children[4].FirstElementChild.GetAttribute("href"));
                 var description = row.Children[2].QuerySelector("span").TextContent;
                 var size = ReleaseInfo.GetBytes(row.Children[7].TextContent);
 
@@ -365,7 +362,7 @@ namespace NzbDrone.Core.Indexers.Definitions
         }
     }
 
-    public class HDTorrentsSettings : IProviderConfig
+    public class HDTorrentsSettings : IIndexerSettings
     {
         private static readonly HDTorrentsSettingsValidator Validator = new HDTorrentsSettingsValidator();
 
@@ -375,10 +372,13 @@ namespace NzbDrone.Core.Indexers.Definitions
             Password = "";
         }
 
-        [FieldDefinition(1, Label = "Username", HelpText = "Site Username", Type = FieldType.Textbox, Privacy = PrivacyLevel.UserName)]
+        [FieldDefinition(1, Label = "Base Url", Type = FieldType.Select, SelectOptionsProviderAction = "getUrls", HelpText = "Select which baseurl Prowlarr will use for requests to the site")]
+        public string BaseUrl { get; set; }
+
+        [FieldDefinition(2, Label = "Username", HelpText = "Site Username", Privacy = PrivacyLevel.UserName)]
         public string Username { get; set; }
 
-        [FieldDefinition(2, Label = "Password", HelpText = "Site Password", Type = FieldType.Password, Privacy = PrivacyLevel.Password)]
+        [FieldDefinition(3, Label = "Password", Type = FieldType.Password, HelpText = "Site Password", Privacy = PrivacyLevel.Password)]
         public string Password { get; set; }
 
         public NzbDroneValidationResult Validate()

--- a/src/NzbDrone.Core/Indexers/Definitions/Headphones/Headphones.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Headphones/Headphones.cs
@@ -17,7 +17,8 @@ namespace NzbDrone.Core.Indexers.Headphones
 
         public override DownloadProtocol Protocol => DownloadProtocol.Usenet;
         public override IndexerPrivacy Privacy => IndexerPrivacy.Private;
-        public override string BaseUrl => "https://indexer.codeshy.com";
+        public override string[] IndexerUrls => new string[] { "https://indexer.codeshy.com" };
+        public override string Description => "";
         public override IndexerCapabilities Capabilities => SetCapabilities();
 
         public override IIndexerRequestGenerator GetRequestGenerator()
@@ -26,8 +27,7 @@ namespace NzbDrone.Core.Indexers.Headphones
             {
                 PageSize = PageSize,
                 Settings = Settings,
-                Capabilities = Capabilities,
-                BaseUrl = BaseUrl
+                Capabilities = Capabilities
             };
         }
 

--- a/src/NzbDrone.Core/Indexers/Definitions/Headphones/HeadphonesRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Headphones/HeadphonesRequestGenerator.cs
@@ -15,7 +15,7 @@ namespace NzbDrone.Core.Indexers.Headphones
         public int PageSize { get; set; }
         public HeadphonesSettings Settings { get; set; }
         public IndexerCapabilities Capabilities { get; set; }
-        public string BaseUrl { get; set; }
+
         public Func<IDictionary<string, string>> GetCookies { get; set; }
         public Action<IDictionary<string, string>, DateTime?> CookiesUpdater { get; set; }
 
@@ -106,7 +106,7 @@ namespace NzbDrone.Core.Indexers.Headphones
 
         private IEnumerable<IndexerRequest> GetPagedRequests(SearchCriteriaBase searchCriteria, NameValueCollection parameters)
         {
-            var baseUrl = string.Format("{0}{1}?t={2}&extended=1", BaseUrl.TrimEnd('/'), Settings.ApiPath.TrimEnd('/'), searchCriteria.SearchType);
+            var baseUrl = string.Format("{0}{1}?t={2}&extended=1", Settings.BaseUrl.TrimEnd('/'), Settings.ApiPath.TrimEnd('/'), searchCriteria.SearchType);
             var categories = searchCriteria.Categories;
 
             if (categories != null && categories.Any())

--- a/src/NzbDrone.Core/Indexers/Definitions/Headphones/HeadphonesSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Headphones/HeadphonesSettings.cs
@@ -1,6 +1,5 @@
 using FluentValidation;
 using NzbDrone.Core.Annotations;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.Headphones
@@ -14,7 +13,7 @@ namespace NzbDrone.Core.Indexers.Headphones
         }
     }
 
-    public class HeadphonesSettings : IProviderConfig
+    public class HeadphonesSettings : IIndexerSettings
     {
         private static readonly HeadphonesSettingsValidator Validator = new HeadphonesSettingsValidator();
 
@@ -28,10 +27,13 @@ namespace NzbDrone.Core.Indexers.Headphones
 
         public string ApiKey { get; set; }
 
-        [FieldDefinition(1, Label = "Username", HelpText = "Site Username", Type = FieldType.Textbox, Privacy = PrivacyLevel.UserName)]
+        [FieldDefinition(1, Label = "Base Url", Type = FieldType.Select, SelectOptionsProviderAction = "getUrls", HelpText = "Select which baseurl Prowlarr will use for requests to the site")]
+        public string BaseUrl { get; set; }
+
+        [FieldDefinition(2, Label = "Username", Privacy = PrivacyLevel.UserName)]
         public string Username { get; set; }
 
-        [FieldDefinition(2, Label = "Password", HelpText = "Site Password", Type = FieldType.Password, Privacy = PrivacyLevel.Password)]
+        [FieldDefinition(3, Label = "Password", Type = FieldType.Password, Privacy = PrivacyLevel.Password)]
         public string Password { get; set; }
 
         public virtual NzbDroneValidationResult Validate()

--- a/src/NzbDrone.Core/Indexers/Definitions/Newznab/Newznab.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Newznab/Newznab.cs
@@ -19,7 +19,8 @@ namespace NzbDrone.Core.Indexers.Newznab
         private readonly INewznabCapabilitiesProvider _capabilitiesProvider;
 
         public override string Name => "Newznab";
-        public override string BaseUrl => GetBaseUrlFromSettings();
+        public override string[] IndexerUrls => GetBaseUrlFromSettings();
+        public override string Description => "";
         public override bool FollowRedirect => true;
         public override bool SupportsRedirect => true;
 
@@ -44,16 +45,16 @@ namespace NzbDrone.Core.Indexers.Newznab
             return new NewznabRssParser(Settings);
         }
 
-        public string GetBaseUrlFromSettings()
+        public string[] GetBaseUrlFromSettings()
         {
             var baseUrl = "";
 
             if (Definition == null || Settings == null || Settings.Categories == null)
             {
-                return baseUrl;
+                return new string[] { baseUrl };
             }
 
-            return Settings.BaseUrl;
+            return new string[] { Settings.BaseUrl };
         }
 
         public IndexerCapabilities GetCapabilitiesFromSettings()

--- a/src/NzbDrone.Core/Indexers/Definitions/Newznab/NewznabSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Newznab/NewznabSettings.cs
@@ -4,7 +4,6 @@ using System.Text.RegularExpressions;
 using FluentValidation;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Annotations;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.Newznab
@@ -52,7 +51,7 @@ namespace NzbDrone.Core.Indexers.Newznab
         }
     }
 
-    public class NewznabSettings : IProviderConfig
+    public class NewznabSettings : IIndexerSettings
     {
         private static readonly NewznabSettingsValidator Validator = new NewznabSettingsValidator();
 

--- a/src/NzbDrone.Core/Indexers/Definitions/NotWhatCD.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/NotWhatCD.cs
@@ -9,7 +9,8 @@ namespace NzbDrone.Core.Indexers.Definitions
     public class NotWhatCD : Gazelle.Gazelle
     {
         public override string Name => "notwhat.cd";
-        public override string BaseUrl => "https://notwhat.cd/";
+        public override string[] IndexerUrls => new string[] { "https://notwhat.cd/" };
+        public override string Description => "";
         public override IndexerPrivacy Privacy => IndexerPrivacy.Private;
 
         public NotWhatCD(IHttpClient httpClient, IEventAggregator eventAggregator, IIndexerStatusService indexerStatusService, IConfigService configService, Logger logger)

--- a/src/NzbDrone.Core/Indexers/Definitions/Orpheus.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Orpheus.cs
@@ -9,7 +9,8 @@ namespace NzbDrone.Core.Indexers.Definitions
     public class Orpheus : Gazelle.Gazelle
     {
         public override string Name => "Orpheus";
-        public override string BaseUrl => "https://orpheus.network/";
+        public override string[] IndexerUrls => new string[] { "https://orpheus.network/" };
+        public override string Description => "";
         public override IndexerPrivacy Privacy => IndexerPrivacy.Private;
 
         public Orpheus(IHttpClient httpClient, IEventAggregator eventAggregator, IIndexerStatusService indexerStatusService, IConfigService configService, Logger logger)

--- a/src/NzbDrone.Core/Indexers/Definitions/PassThePopcorn/PassThePopcorn.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/PassThePopcorn/PassThePopcorn.cs
@@ -10,7 +10,8 @@ namespace NzbDrone.Core.Indexers.PassThePopcorn
     public class PassThePopcorn : TorrentIndexerBase<PassThePopcornSettings>
     {
         public override string Name => "PassThePopcorn";
-        public override string BaseUrl => "https://passthepopcorn.me";
+        public override string[] IndexerUrls => new string[] { "https://passthepopcorn.me" };
+        public override string Description => "";
         public override DownloadProtocol Protocol => DownloadProtocol.Torrent;
         public override IndexerPrivacy Privacy => IndexerPrivacy.Private;
         public override bool SupportsRss => true;
@@ -36,8 +37,7 @@ namespace NzbDrone.Core.Indexers.PassThePopcorn
             {
                 Settings = Settings,
                 HttpClient = _httpClient,
-                Logger = _logger,
-                BaseUrl = BaseUrl
+                Logger = _logger
             };
         }
 
@@ -80,7 +80,7 @@ namespace NzbDrone.Core.Indexers.PassThePopcorn
 
         public override IParseIndexerResponse GetParser()
         {
-            return new PassThePopcornParser(BaseUrl, Capabilities, _logger);
+            return new PassThePopcornParser(Settings, Capabilities, _logger);
         }
     }
 

--- a/src/NzbDrone.Core/Indexers/Definitions/PassThePopcorn/PassThePopcornParser.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/PassThePopcorn/PassThePopcornParser.cs
@@ -12,12 +12,12 @@ namespace NzbDrone.Core.Indexers.PassThePopcorn
 {
     public class PassThePopcornParser : IParseIndexerResponse
     {
-        private readonly string _baseUrl;
         private readonly IndexerCapabilities _capabilities;
+        private readonly PassThePopcornSettings _settings;
         private readonly Logger _logger;
-        public PassThePopcornParser(string baseUrl, IndexerCapabilities capabilities, Logger logger)
+        public PassThePopcornParser(PassThePopcornSettings settings, IndexerCapabilities capabilities, Logger logger)
         {
-            _baseUrl = baseUrl;
+            _settings = settings;
             _capabilities = capabilities;
             _logger = logger;
         }
@@ -133,7 +133,7 @@ namespace NzbDrone.Core.Indexers.PassThePopcorn
 
         private string GetDownloadUrl(int torrentId, string authKey, string passKey)
         {
-            var url = new HttpUri(_baseUrl)
+            var url = new HttpUri(_settings.BaseUrl)
                 .CombinePath("/torrents.php")
                 .AddQueryParam("action", "download")
                 .AddQueryParam("id", torrentId)
@@ -145,7 +145,7 @@ namespace NzbDrone.Core.Indexers.PassThePopcorn
 
         private string GetInfoUrl(string groupId, int torrentId)
         {
-            var url = new HttpUri(_baseUrl)
+            var url = new HttpUri(_settings.BaseUrl)
                 .CombinePath("/torrents.php")
                 .AddQueryParam("id", groupId)
                 .AddQueryParam("torrentid", torrentId);

--- a/src/NzbDrone.Core/Indexers/Definitions/PassThePopcorn/PassThePopcornRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/PassThePopcorn/PassThePopcornRequestGenerator.cs
@@ -9,7 +9,6 @@ namespace NzbDrone.Core.Indexers.PassThePopcorn
 {
     public class PassThePopcornRequestGenerator : IIndexerRequestGenerator
     {
-        public string BaseUrl { get; set; }
         public PassThePopcornSettings Settings { get; set; }
 
         public IDictionary<string, string> Cookies { get; set; }
@@ -40,7 +39,7 @@ namespace NzbDrone.Core.Indexers.PassThePopcorn
         {
             var request =
                 new IndexerRequest(
-                    $"{BaseUrl.Trim().TrimEnd('/')}/torrents.php?action=advanced&json=noredirect&searchstr={searchParameters}",
+                    $"{Settings.BaseUrl.Trim().TrimEnd('/')}/torrents.php?action=advanced&json=noredirect&searchstr={searchParameters}",
                     HttpAccept.Json);
 
             request.HttpRequest.Headers["ApiUser"] = Settings.APIUser;

--- a/src/NzbDrone.Core/Indexers/Definitions/PassThePopcorn/PassThePopcornSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/PassThePopcorn/PassThePopcornSettings.cs
@@ -1,6 +1,5 @@
 using FluentValidation;
 using NzbDrone.Core.Annotations;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.PassThePopcorn
@@ -14,7 +13,7 @@ namespace NzbDrone.Core.Indexers.PassThePopcorn
         }
     }
 
-    public class PassThePopcornSettings : IProviderConfig
+    public class PassThePopcornSettings : IIndexerSettings
     {
         private static readonly PassThePopcornSettingsValidator Validator = new PassThePopcornSettingsValidator();
 
@@ -22,10 +21,13 @@ namespace NzbDrone.Core.Indexers.PassThePopcorn
         {
         }
 
-        [FieldDefinition(0, Label = "APIUser", HelpText = "These settings are found in your PassThePopcorn security settings (Edit Profile > Security).", Privacy = PrivacyLevel.UserName)]
+        [FieldDefinition(1, Label = "Base Url", Type = FieldType.Select, SelectOptionsProviderAction = "getUrls", HelpText = "Select which baseurl Prowlarr will use for requests to the site")]
+        public string BaseUrl { get; set; }
+
+        [FieldDefinition(2, Label = "APIUser", HelpText = "These settings are found in your PassThePopcorn security settings (Edit Profile > Security).", Privacy = PrivacyLevel.UserName)]
         public string APIUser { get; set; }
 
-        [FieldDefinition(1, Label = "APIKey", Type = FieldType.Password, Privacy = PrivacyLevel.Password)]
+        [FieldDefinition(3, Label = "APIKey", Type = FieldType.Password, Privacy = PrivacyLevel.Password)]
         public string APIKey { get; set; }
 
         public NzbDroneValidationResult Validate()

--- a/src/NzbDrone.Core/Indexers/Definitions/PrivateHD.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/PrivateHD.cs
@@ -10,7 +10,8 @@ namespace NzbDrone.Core.Indexers.Definitions
     public class PrivateHD : Avistaz.AvistazBase
     {
         public override string Name => "PrivateHD";
-        public override string BaseUrl => "https://privatehd.to/";
+        public override string[] IndexerUrls => new string[] { "https://privatehd.to/" };
+        public override string Description => "";
         public override IndexerPrivacy Privacy => IndexerPrivacy.Private;
 
         public PrivateHD(IIndexerRepository indexerRepository, IHttpClient httpClient, IEventAggregator eventAggregator, IIndexerStatusService indexerStatusService, IConfigService configService, Logger logger)
@@ -25,8 +26,7 @@ namespace NzbDrone.Core.Indexers.Definitions
                 Settings = Settings,
                 HttpClient = _httpClient,
                 Logger = _logger,
-                Capabilities = Capabilities,
-                BaseUrl = BaseUrl
+                Capabilities = Capabilities
             };
         }
 

--- a/src/NzbDrone.Core/Indexers/Definitions/Rarbg/Rarbg.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Rarbg/Rarbg.cs
@@ -16,7 +16,8 @@ namespace NzbDrone.Core.Indexers.Rarbg
         private readonly IRarbgTokenProvider _tokenProvider;
 
         public override string Name => "Rarbg";
-        public override string BaseUrl => "https://torrentapi.org";
+        public override string[] IndexerUrls => new string[] { "https://torrentapi.org" };
+        public override string Description => "RARBG is a Public torrent site for MOVIES / TV / GENERAL";
 
         public override DownloadProtocol Protocol => DownloadProtocol.Torrent;
 
@@ -34,7 +35,7 @@ namespace NzbDrone.Core.Indexers.Rarbg
 
         public override IIndexerRequestGenerator GetRequestGenerator()
         {
-            return new RarbgRequestGenerator(_tokenProvider) { Settings = Settings, Categories = Capabilities.Categories, BaseUrl = BaseUrl };
+            return new RarbgRequestGenerator(_tokenProvider) { Settings = Settings, Categories = Capabilities.Categories };
         }
 
         public override IParseIndexerResponse GetParser()
@@ -105,7 +106,7 @@ namespace NzbDrone.Core.Indexers.Rarbg
 
                 try
                 {
-                    var request = new HttpRequestBuilder(BaseUrl.Trim('/'))
+                    var request = new HttpRequestBuilder(Settings.BaseUrl.Trim('/'))
                            .Resource("/pubapi_v2.php?get_token=get_token")
                            .Accept(HttpAccept.Json)
                            .Build();

--- a/src/NzbDrone.Core/Indexers/Definitions/Rarbg/RarbgRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Rarbg/RarbgRequestGenerator.cs
@@ -12,7 +12,6 @@ namespace NzbDrone.Core.Indexers.Rarbg
     {
         private readonly IRarbgTokenProvider _tokenProvider;
 
-        public string BaseUrl { get; set; }
         public RarbgSettings Settings { get; set; }
         public IndexerCapabilitiesCategories Categories { get; set; }
 
@@ -23,7 +22,7 @@ namespace NzbDrone.Core.Indexers.Rarbg
 
         private IEnumerable<IndexerRequest> GetRequest(string term, int[] categories, string imdbId = null, int? tmdbId = null)
         {
-            var requestBuilder = new HttpRequestBuilder(BaseUrl)
+            var requestBuilder = new HttpRequestBuilder(Settings.BaseUrl)
                 .Resource("/pubapi_v2.php")
                 .Accept(HttpAccept.Json);
 
@@ -62,7 +61,7 @@ namespace NzbDrone.Core.Indexers.Rarbg
             }
 
             requestBuilder.AddQueryParam("limit", "100");
-            requestBuilder.AddQueryParam("token", _tokenProvider.GetToken(Settings, BaseUrl));
+            requestBuilder.AddQueryParam("token", _tokenProvider.GetToken(Settings, Settings.BaseUrl));
             requestBuilder.AddQueryParam("format", "json_extended");
             requestBuilder.AddQueryParam("app_id", BuildInfo.AppName);
 

--- a/src/NzbDrone.Core/Indexers/Definitions/Rarbg/RarbgSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Rarbg/RarbgSettings.cs
@@ -1,6 +1,5 @@
 using FluentValidation;
 using NzbDrone.Core.Annotations;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.Rarbg
@@ -12,7 +11,7 @@ namespace NzbDrone.Core.Indexers.Rarbg
         }
     }
 
-    public class RarbgSettings : IProviderConfig
+    public class RarbgSettings : IIndexerSettings
     {
         private static readonly RarbgSettingsValidator Validator = new RarbgSettingsValidator();
 
@@ -21,10 +20,13 @@ namespace NzbDrone.Core.Indexers.Rarbg
             RankedOnly = false;
         }
 
-        [FieldDefinition(1, Type = FieldType.Checkbox, Label = "Ranked Only", HelpText = "Only include ranked results.")]
+        [FieldDefinition(1, Label = "Base Url", Type = FieldType.Select, SelectOptionsProviderAction = "getUrls", HelpText = "Select which baseurl Prowlarr will use for requests to the site")]
+        public string BaseUrl { get; set; }
+
+        [FieldDefinition(2, Type = FieldType.Checkbox, Label = "Ranked Only", HelpText = "Only include ranked results.")]
         public bool RankedOnly { get; set; }
 
-        [FieldDefinition(2, Type = FieldType.Captcha, Label = "CAPTCHA Token", HelpText = "CAPTCHA Clearance token used to handle CloudFlare Anti-DDOS measures on shared-ip VPNs.")]
+        [FieldDefinition(3, Type = FieldType.Captcha, Label = "CAPTCHA Token", HelpText = "CAPTCHA Clearance token used to handle CloudFlare Anti-DDOS measures on shared-ip VPNs.")]
         public string CaptchaToken { get; set; }
 
         public NzbDroneValidationResult Validate()

--- a/src/NzbDrone.Core/Indexers/Definitions/Redacted.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Redacted.cs
@@ -9,7 +9,8 @@ namespace NzbDrone.Core.Indexers.Definitions
     public class Redacted : Gazelle.Gazelle
     {
         public override string Name => "Redacted";
-        public override string BaseUrl => "https://redacted.ch/";
+        public override string[] IndexerUrls => new string[] { "https://redacted.ch/" };
+        public override string Description => "";
         public override IndexerPrivacy Privacy => IndexerPrivacy.Private;
 
         public Redacted(IHttpClient httpClient, IEventAggregator eventAggregator, IIndexerStatusService indexerStatusService, IConfigService configService, Logger logger)

--- a/src/NzbDrone.Core/Indexers/Definitions/RevolutionTT.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/RevolutionTT.cs
@@ -16,7 +16,6 @@ using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Messaging.Events;
 using NzbDrone.Core.Parser;
 using NzbDrone.Core.Parser.Model;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.Definitions
@@ -25,8 +24,9 @@ namespace NzbDrone.Core.Indexers.Definitions
     {
         public override string Name => "RevolutionTT";
 
-        public override string BaseUrl => "https://revolutiontt.me/";
-        private string LoginUrl => BaseUrl + "takelogin.php";
+        public override string[] IndexerUrls => new string[] { "https://revolutiontt.me/" };
+        public override string Description => "The Revolution has begun";
+        private string LoginUrl => Settings.BaseUrl + "takelogin.php";
         public override DownloadProtocol Protocol => DownloadProtocol.Torrent;
         public override IndexerPrivacy Privacy => IndexerPrivacy.Private;
         public override IndexerCapabilities Capabilities => SetCapabilities();
@@ -38,12 +38,12 @@ namespace NzbDrone.Core.Indexers.Definitions
 
         public override IIndexerRequestGenerator GetRequestGenerator()
         {
-            return new RevolutionTTRequestGenerator() { Settings = Settings, Capabilities = Capabilities, BaseUrl = BaseUrl };
+            return new RevolutionTTRequestGenerator() { Settings = Settings, Capabilities = Capabilities };
         }
 
         public override IParseIndexerResponse GetParser()
         {
-            return new RevolutionTTParser(Settings, Capabilities.Categories, BaseUrl);
+            return new RevolutionTTParser(Settings, Capabilities.Categories);
         }
 
         protected override async Task DoLogin()
@@ -56,7 +56,7 @@ namespace NzbDrone.Core.Indexers.Definitions
                 AllowAutoRedirect = true
             };
 
-            var loginPage = await _httpClient.ExecuteAsync(new HttpRequest(BaseUrl + "login.php"));
+            var loginPage = await _httpClient.ExecuteAsync(new HttpRequest(Settings.BaseUrl + "login.php"));
 
             requestBuilder.Method = HttpMethod.POST;
             requestBuilder.PostProcess += r => r.RequestTimeout = TimeSpan.FromSeconds(15);
@@ -155,7 +155,6 @@ namespace NzbDrone.Core.Indexers.Definitions
     {
         public RevolutionTTSettings Settings { get; set; }
         public IndexerCapabilities Capabilities { get; set; }
-        public string BaseUrl { get; set; }
 
         public RevolutionTTRequestGenerator()
         {
@@ -189,7 +188,7 @@ namespace NzbDrone.Core.Indexers.Definitions
                 }
             }
 
-            var searchUrl = BaseUrl + "browse.php?" + qc.GetQueryString();
+            var searchUrl = Settings.BaseUrl + "browse.php?" + qc.GetQueryString();
 
             var request = new IndexerRequest(searchUrl, HttpAccept.Html);
 
@@ -249,13 +248,11 @@ namespace NzbDrone.Core.Indexers.Definitions
     {
         private readonly RevolutionTTSettings _settings;
         private readonly IndexerCapabilitiesCategories _categories;
-        private readonly string _baseUrl;
 
-        public RevolutionTTParser(RevolutionTTSettings settings, IndexerCapabilitiesCategories categories, string baseUrl)
+        public RevolutionTTParser(RevolutionTTSettings settings, IndexerCapabilitiesCategories categories)
         {
             _settings = settings;
             _categories = categories;
-            _baseUrl = baseUrl;
         }
 
         public IList<ReleaseInfo> ParseResponse(IndexerResponse indexerResponse)
@@ -269,7 +266,7 @@ namespace NzbDrone.Core.Indexers.Definitions
             foreach (var row in rows.Skip(1))
             {
                 var qDetails = row.QuerySelector(".br_right > a");
-                var details = _baseUrl + qDetails.GetAttribute("href");
+                var details = _settings.BaseUrl + qDetails.GetAttribute("href");
                 var title = qDetails.QuerySelector("b").TextContent;
 
                 var qLink = row.QuerySelector("td:nth-child(4) > a");
@@ -278,7 +275,7 @@ namespace NzbDrone.Core.Indexers.Definitions
                     continue; // support/donation banner
                 }
 
-                var link = _baseUrl + qLink.GetAttribute("href");
+                var link = _settings.BaseUrl + qLink.GetAttribute("href");
 
                 // dateString format "yyyy-MMM-dd hh:mm:ss" => eg "2015-04-25 23:38:12"
                 var dateString = row.QuerySelector("td:nth-child(6) nobr").TextContent.Trim();
@@ -333,7 +330,7 @@ namespace NzbDrone.Core.Indexers.Definitions
         }
     }
 
-    public class RevolutionTTSettings : IProviderConfig
+    public class RevolutionTTSettings : IIndexerSettings
     {
         private static readonly RevolutionTTSettingsValidator Validator = new RevolutionTTSettingsValidator();
 
@@ -343,10 +340,13 @@ namespace NzbDrone.Core.Indexers.Definitions
             Password = "";
         }
 
-        [FieldDefinition(1, Label = "Username", HelpText = "Site Username", Type = FieldType.Textbox, Privacy = PrivacyLevel.UserName)]
+        [FieldDefinition(1, Label = "Base Url", Type = FieldType.Select, SelectOptionsProviderAction = "getUrls", HelpText = "Select which baseurl Prowlarr will use for requests to the site")]
+        public string BaseUrl { get; set; }
+
+        [FieldDefinition(2, Label = "Username", HelpText = "Site Username", Privacy = PrivacyLevel.UserName)]
         public string Username { get; set; }
 
-        [FieldDefinition(2, Label = "Password", HelpText = "Site Password", Type = FieldType.Password, Privacy = PrivacyLevel.Password)]
+        [FieldDefinition(3, Label = "Password", Type = FieldType.Password, HelpText = "Site Password", Privacy = PrivacyLevel.Password)]
         public string Password { get; set; }
 
         public NzbDroneValidationResult Validate()

--- a/src/NzbDrone.Core/Indexers/Definitions/ShareIsland.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/ShareIsland.cs
@@ -10,7 +10,7 @@ namespace NzbDrone.Core.Indexers.Definitions
     public class ShareIsland : Unit3dBase
     {
         public override string Name => "ShareIsland";
-        public override string BaseUrl => "https://shareisland.org/";
+        public override string[] IndexerUrls => new string[] { "https://shareisland.org/" };
         public override string Description => "A general italian tracker";
         public override string Language => "it-it";
         public override IndexerPrivacy Privacy => IndexerPrivacy.Private;

--- a/src/NzbDrone.Core/Indexers/Definitions/TorrentLeech.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/TorrentLeech.cs
@@ -16,7 +16,6 @@ using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Messaging.Events;
 using NzbDrone.Core.Parser;
 using NzbDrone.Core.Parser.Model;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.Definitions
@@ -25,8 +24,9 @@ namespace NzbDrone.Core.Indexers.Definitions
     {
         public override string Name => "TorrentLeech";
 
-        public override string BaseUrl => "https://www.torrentleech.org/";
-        private string LoginUrl => BaseUrl + "user/account/login/";
+        public override string[] IndexerUrls => new string[] { "https://www.torrentleech.org/" };
+        public override string Description => "This is what happens when you seed";
+        private string LoginUrl => Settings.BaseUrl + "user/account/login/";
         public override DownloadProtocol Protocol => DownloadProtocol.Torrent;
         public override IndexerPrivacy Privacy => IndexerPrivacy.Private;
         public override IndexerCapabilities Capabilities => SetCapabilities();
@@ -38,12 +38,12 @@ namespace NzbDrone.Core.Indexers.Definitions
 
         public override IIndexerRequestGenerator GetRequestGenerator()
         {
-            return new TorrentLeechRequestGenerator() { Settings = Settings, Capabilities = Capabilities, BaseUrl = BaseUrl };
+            return new TorrentLeechRequestGenerator() { Settings = Settings, Capabilities = Capabilities };
         }
 
         public override IParseIndexerResponse GetParser()
         {
-            return new TorrentLeechParser(Settings, Capabilities.Categories, BaseUrl);
+            return new TorrentLeechParser(Settings, Capabilities.Categories);
         }
 
         protected override async Task DoLogin()
@@ -166,7 +166,6 @@ namespace NzbDrone.Core.Indexers.Definitions
     {
         public TorrentLeechSettings Settings { get; set; }
         public IndexerCapabilities Capabilities { get; set; }
-        public string BaseUrl { get; set; }
 
         public TorrentLeechRequestGenerator()
         {
@@ -176,7 +175,7 @@ namespace NzbDrone.Core.Indexers.Definitions
         {
             var searchString = Regex.Replace(term, @"(^|\s)-", " ");
 
-            var searchUrl = BaseUrl + "torrents/browse/list/";
+            var searchUrl = Settings.BaseUrl + "torrents/browse/list/";
 
             if (Settings.FreeLeechOnly)
             {
@@ -260,13 +259,11 @@ namespace NzbDrone.Core.Indexers.Definitions
     {
         private readonly TorrentLeechSettings _settings;
         private readonly IndexerCapabilitiesCategories _categories;
-        private readonly string _baseUrl;
 
-        public TorrentLeechParser(TorrentLeechSettings settings, IndexerCapabilitiesCategories categories, string baseUrl)
+        public TorrentLeechParser(TorrentLeechSettings settings, IndexerCapabilitiesCategories categories)
         {
             _settings = settings;
             _categories = categories;
-            _baseUrl = baseUrl;
         }
 
         public IList<ReleaseInfo> ParseResponse(IndexerResponse indexerResponse)
@@ -279,8 +276,8 @@ namespace NzbDrone.Core.Indexers.Definitions
                 var title = row.name.ToString();
 
                 var torrentId = row.fid.ToString();
-                var details = new Uri(_baseUrl + "torrent/" + torrentId);
-                var link = new Uri(_baseUrl + "download/" + torrentId + "/" + row.filename);
+                var details = new Uri(_settings.BaseUrl + "torrent/" + torrentId);
+                var link = new Uri(_settings.BaseUrl + "download/" + torrentId + "/" + row.filename);
                 var publishDate = DateTime.ParseExact(row.addedTimestamp.ToString(), "yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
                 var seeders = (int)row.seeders;
                 var leechers = (int)row.leechers;
@@ -335,7 +332,7 @@ namespace NzbDrone.Core.Indexers.Definitions
         }
     }
 
-    public class TorrentLeechSettings : IProviderConfig
+    public class TorrentLeechSettings : IIndexerSettings
     {
         private static readonly TorrentLeechSettingsValidator Validator = new TorrentLeechSettingsValidator();
 
@@ -345,13 +342,16 @@ namespace NzbDrone.Core.Indexers.Definitions
             Password = "";
         }
 
-        [FieldDefinition(1, Label = "Username", HelpText = "Site Username", Type = FieldType.Textbox, Privacy = PrivacyLevel.UserName)]
+        [FieldDefinition(1, Label = "Base Url", Type = FieldType.Select, SelectOptionsProviderAction = "getUrls", HelpText = "Select which baseurl Prowlarr will use for requests to the site")]
+        public string BaseUrl { get; set; }
+
+        [FieldDefinition(2, Label = "Username", HelpText = "Site Username", Privacy = PrivacyLevel.UserName)]
         public string Username { get; set; }
 
-        [FieldDefinition(2, Label = "Password", HelpText = "Site Password", Type = FieldType.Password, Privacy = PrivacyLevel.Password)]
+        [FieldDefinition(3, Label = "Password", Type = FieldType.Password, HelpText = "Site Password", Privacy = PrivacyLevel.Password)]
         public string Password { get; set; }
 
-        [FieldDefinition(3, Label = "FreeLeech Only", Type = FieldType.Checkbox, Advanced = true, HelpText = "Search Freeleech torrents only")]
+        [FieldDefinition(4, Label = "FreeLeech Only", Type = FieldType.Checkbox, Advanced = true, HelpText = "Search Freeleech torrents only")]
         public bool FreeLeechOnly { get; set; }
 
         public NzbDroneValidationResult Validate()

--- a/src/NzbDrone.Core/Indexers/Definitions/TorrentPotato/TorrentPotato.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/TorrentPotato/TorrentPotato.cs
@@ -9,7 +9,8 @@ namespace NzbDrone.Core.Indexers.TorrentPotato
     public class TorrentPotato : TorrentIndexerBase<TorrentPotatoSettings>
     {
         public override string Name => "TorrentPotato";
-        public override string BaseUrl => "http://127.0.0.1";
+        public override string[] IndexerUrls => new string[] { "http://127.0.0.1" };
+        public override string Description => "";
 
         public override DownloadProtocol Protocol => DownloadProtocol.Torrent;
         public override IndexerPrivacy Privacy => IndexerPrivacy.Private;
@@ -37,7 +38,7 @@ namespace NzbDrone.Core.Indexers.TorrentPotato
 
         public override IIndexerRequestGenerator GetRequestGenerator()
         {
-            return new TorrentPotatoRequestGenerator() { Settings = Settings, BaseUrl = BaseUrl };
+            return new TorrentPotatoRequestGenerator() { Settings = Settings };
         }
 
         public override IParseIndexerResponse GetParser()

--- a/src/NzbDrone.Core/Indexers/Definitions/TorrentPotato/TorrentPotatoRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/TorrentPotato/TorrentPotatoRequestGenerator.cs
@@ -8,7 +8,6 @@ namespace NzbDrone.Core.Indexers.TorrentPotato
 {
     public class TorrentPotatoRequestGenerator : IIndexerRequestGenerator
     {
-        public string BaseUrl { get; set; }
         public TorrentPotatoSettings Settings { get; set; }
 
         public TorrentPotatoRequestGenerator()
@@ -26,7 +25,7 @@ namespace NzbDrone.Core.Indexers.TorrentPotato
 
         private IEnumerable<IndexerRequest> GetPagedRequests(string mode, int? tvdbId, string query, params object[] args)
         {
-            var requestBuilder = new HttpRequestBuilder(BaseUrl)
+            var requestBuilder = new HttpRequestBuilder(Settings.BaseUrl)
                 .Accept(HttpAccept.Json);
 
             requestBuilder.AddQueryParam("passkey", Settings.Passkey);
@@ -46,7 +45,7 @@ namespace NzbDrone.Core.Indexers.TorrentPotato
 
         private IEnumerable<IndexerRequest> GetMovieRequest(MovieSearchCriteria searchCriteria)
         {
-            var requestBuilder = new HttpRequestBuilder(BaseUrl)
+            var requestBuilder = new HttpRequestBuilder(Settings.BaseUrl)
                  .Accept(HttpAccept.Json);
 
             requestBuilder.AddQueryParam("passkey", Settings.Passkey);

--- a/src/NzbDrone.Core/Indexers/Definitions/TorrentPotato/TorrentPotatoSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/TorrentPotato/TorrentPotatoSettings.cs
@@ -1,6 +1,5 @@
 using FluentValidation;
 using NzbDrone.Core.Annotations;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.TorrentPotato
@@ -12,7 +11,7 @@ namespace NzbDrone.Core.Indexers.TorrentPotato
         }
     }
 
-    public class TorrentPotatoSettings : IProviderConfig
+    public class TorrentPotatoSettings : IIndexerSettings
     {
         private static readonly TorrentPotatoSettingsValidator Validator = new TorrentPotatoSettingsValidator();
 
@@ -20,10 +19,13 @@ namespace NzbDrone.Core.Indexers.TorrentPotato
         {
         }
 
-        [FieldDefinition(1, Label = "Username", HelpText = "Site Username", Type = FieldType.Textbox, Privacy = PrivacyLevel.UserName)]
+        [FieldDefinition(1, Label = "Base Url", Type = FieldType.Select, SelectOptionsProviderAction = "getUrls", HelpText = "Select which baseurl Prowlarr will use for requests to the site")]
+        public string BaseUrl { get; set; }
+
+        [FieldDefinition(2, Label = "Username", HelpText = "The username you use at your indexer.", Privacy = PrivacyLevel.UserName)]
         public string User { get; set; }
 
-        [FieldDefinition(2, Label = "Password", HelpText = "Site Password", Type = FieldType.Password, Privacy = PrivacyLevel.Password)]
+        [FieldDefinition(3, Label = "Passkey", HelpText = "The password you use at your Indexer.", Type = FieldType.Password, Privacy = PrivacyLevel.Password)]
         public string Passkey { get; set; }
 
         public NzbDroneValidationResult Validate()

--- a/src/NzbDrone.Core/Indexers/Definitions/Torznab/Torznab.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Torznab/Torznab.cs
@@ -19,7 +19,8 @@ namespace NzbDrone.Core.Indexers.Torznab
         private readonly INewznabCapabilitiesProvider _capabilitiesProvider;
 
         public override string Name => "Torznab";
-        public override string BaseUrl => GetBaseUrlFromSettings();
+        public override string[] IndexerUrls => GetBaseUrlFromSettings();
+        public override string Description => "";
         public override bool FollowRedirect => true;
         public override bool SupportsRedirect => true;
 
@@ -43,16 +44,16 @@ namespace NzbDrone.Core.Indexers.Torznab
             return new TorznabRssParser(Settings);
         }
 
-        public string GetBaseUrlFromSettings()
+        public string[] GetBaseUrlFromSettings()
         {
             var baseUrl = "";
 
             if (Definition == null || Settings == null || Settings.Categories == null)
             {
-                return baseUrl;
+                return new string[] { baseUrl };
             }
 
-            return Settings.BaseUrl;
+            return new string[] { Settings.BaseUrl };
         }
 
         public IndexerCapabilities GetCapabilitiesFromSettings()

--- a/src/NzbDrone.Core/Indexers/Definitions/UNIT3D/Unit3dBase.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/UNIT3D/Unit3dBase.cs
@@ -8,7 +8,7 @@ namespace NzbDrone.Core.Indexers.Definitions.UNIT3D
     public abstract class Unit3dBase : TorrentIndexerBase<Unit3dSettings>
     {
         public override DownloadProtocol Protocol => DownloadProtocol.Torrent;
-        public override string BaseUrl => "";
+        public override string[] IndexerUrls => new string[] { "" };
         public override bool SupportsRss => true;
         public override bool SupportsSearch => true;
         public override int PageSize => 50;
@@ -30,14 +30,13 @@ namespace NzbDrone.Core.Indexers.Definitions.UNIT3D
                 Settings = Settings,
                 HttpClient = _httpClient,
                 Logger = _logger,
-                Capabilities = Capabilities,
-                BaseUrl = BaseUrl
+                Capabilities = Capabilities
             };
         }
 
         public override IParseIndexerResponse GetParser()
         {
-            return new Unit3dParser(Capabilities.Categories, BaseUrl);
+            return new Unit3dParser(Settings, Capabilities.Categories);
         }
 
         protected virtual IndexerCapabilities SetCapabilities()

--- a/src/NzbDrone.Core/Indexers/Definitions/UNIT3D/Unit3dParser.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/UNIT3D/Unit3dParser.cs
@@ -13,15 +13,15 @@ namespace NzbDrone.Core.Indexers.Definitions.UNIT3D
 {
     public class Unit3dParser : IParseIndexerResponse
     {
-        private readonly string _baseUrl;
         private readonly IndexerCapabilitiesCategories _categories;
+        private readonly Unit3dSettings _settings;
 
-        protected virtual string TorrentUrl => _baseUrl + "torrents";
+        protected virtual string TorrentUrl => _settings.BaseUrl + "torrents";
 
-        public Unit3dParser(IndexerCapabilitiesCategories categories, string baseUrl)
+        public Unit3dParser(Unit3dSettings settings, IndexerCapabilitiesCategories categories)
         {
+            _settings = settings;
             _categories = categories;
-            _baseUrl = baseUrl;
         }
 
         public Action<IDictionary<string, string>, DateTime?> CookiesUpdater { get; set; }

--- a/src/NzbDrone.Core/Indexers/Definitions/UNIT3D/Unit3dRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/UNIT3D/Unit3dRequestGenerator.cs
@@ -11,13 +11,12 @@ namespace NzbDrone.Core.Indexers.Definitions.UNIT3D
     public class Unit3dRequestGenerator : IIndexerRequestGenerator
     {
         public Unit3dSettings Settings { get; set; }
-        public string BaseUrl { get; set; }
 
         public IHttpClient HttpClient { get; set; }
         public IndexerCapabilities Capabilities { get; set; }
         public Logger Logger { get; set; }
 
-        protected virtual string SearchUrl => BaseUrl + "api/torrents/filter";
+        protected virtual string SearchUrl => Settings.BaseUrl + "api/torrents/filter";
         protected virtual bool ImdbInTags => false;
 
         public Func<IDictionary<string, string>> GetCookies { get; set; }

--- a/src/NzbDrone.Core/Indexers/Definitions/UNIT3D/Unit3dSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/UNIT3D/Unit3dSettings.cs
@@ -1,6 +1,5 @@
 using FluentValidation;
 using NzbDrone.Core.Annotations;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.Definitions.UNIT3D
@@ -13,7 +12,7 @@ namespace NzbDrone.Core.Indexers.Definitions.UNIT3D
         }
     }
 
-    public class Unit3dSettings : IProviderConfig
+    public class Unit3dSettings : IIndexerSettings
     {
         private static readonly Unit3dSettingsValidator Validator = new Unit3dSettingsValidator();
 
@@ -21,7 +20,10 @@ namespace NzbDrone.Core.Indexers.Definitions.UNIT3D
         {
         }
 
-        [FieldDefinition(1, Label = "Api Key", HelpText = "Api key generated in My Security", Privacy = PrivacyLevel.ApiKey)]
+        [FieldDefinition(1, Label = "Base Url", Type = FieldType.Select, SelectOptionsProviderAction = "getUrls", HelpText = "Select which baseurl Prowlarr will use for requests to the site")]
+        public string BaseUrl { get; set; }
+
+        [FieldDefinition(2, Label = "Api Key", HelpText = "Api key generated in My Security", Privacy = PrivacyLevel.ApiKey)]
         public string ApiKey { get; set; }
 
         public NzbDroneValidationResult Validate()

--- a/src/NzbDrone.Core/Indexers/HttpIndexerBase.cs
+++ b/src/NzbDrone.Core/Indexers/HttpIndexerBase.cs
@@ -20,7 +20,7 @@ using NzbDrone.Core.ThingiProvider;
 namespace NzbDrone.Core.Indexers
 {
     public abstract class HttpIndexerBase<TSettings> : IndexerBase<TSettings>
-        where TSettings : IProviderConfig, new()
+        where TSettings : IIndexerSettings, new()
     {
         protected const int MaxNumResultsPerQuery = 1000;
 
@@ -34,9 +34,6 @@ namespace NzbDrone.Core.Indexers
 
         public override Encoding Encoding => Encoding.UTF8;
         public override string Language => "en-US";
-
-        //TODO Remove this once we catch up on individual indexers
-        public override string Description => "";
 
         public override bool FollowRedirect => false;
         public override IndexerCapabilities Capabilities { get; protected set; }

--- a/src/NzbDrone.Core/Indexers/IIndexer.cs
+++ b/src/NzbDrone.Core/Indexers/IIndexer.cs
@@ -13,7 +13,7 @@ namespace NzbDrone.Core.Indexers
         bool SupportsRedirect { get; }
         IndexerCapabilities Capabilities { get; }
 
-        string BaseUrl { get; }
+        string[] IndexerUrls { get; }
         string Description { get; }
         Encoding Encoding { get; }
         string Language { get; }

--- a/src/NzbDrone.Core/Indexers/IIndexerSettings.cs
+++ b/src/NzbDrone.Core/Indexers/IIndexerSettings.cs
@@ -1,0 +1,9 @@
+using NzbDrone.Core.ThingiProvider;
+
+namespace NzbDrone.Core.Indexers
+{
+    public interface IIndexerSettings : IProviderConfig
+    {
+        string BaseUrl { get; set; }
+    }
+}

--- a/src/NzbDrone.Core/Indexers/IndexerBase.cs
+++ b/src/NzbDrone.Core/Indexers/IndexerBase.cs
@@ -14,14 +14,14 @@ using NzbDrone.Core.ThingiProvider;
 namespace NzbDrone.Core.Indexers
 {
     public abstract class IndexerBase<TSettings> : IIndexer
-        where TSettings : IProviderConfig, new()
+        where TSettings : IIndexerSettings, new()
     {
         protected readonly IIndexerStatusService _indexerStatusService;
         protected readonly IConfigService _configService;
         protected readonly Logger _logger;
 
         public abstract string Name { get; }
-        public abstract string BaseUrl { get; }
+        public abstract string[] IndexerUrls { get; }
         public abstract string Description { get; }
         public abstract Encoding Encoding { get; }
         public abstract string Language { get; }
@@ -67,10 +67,20 @@ namespace NzbDrone.Core.Indexers
 
         public virtual object RequestAction(string action, IDictionary<string, string> query)
         {
+            if (action == "getUrls")
+            {
+                var links = IndexerUrls;
+
+                return new
+                {
+                    options = links.Select(d => new { Value = d, Name = d })
+                };
+            }
+
             return null;
         }
 
-        protected TSettings Settings => (TSettings)Definition.Settings;
+        protected TSettings Settings => GetDefaultBaseUrl((TSettings)Definition.Settings);
 
         public abstract Task<IndexerPageableQueryResult> Fetch(MovieSearchCriteria searchCriteria);
         public abstract Task<IndexerPageableQueryResult> Fetch(MusicSearchCriteria searchCriteria);
@@ -100,6 +110,16 @@ namespace NzbDrone.Core.Indexers
             });
 
             return result;
+        }
+
+        protected TSettings GetDefaultBaseUrl(TSettings settings)
+        {
+            if (settings.BaseUrl.IsNullOrWhiteSpace() && IndexerUrls.First().IsNotNullOrWhiteSpace())
+            {
+                settings.BaseUrl = IndexerUrls.First();
+            }
+
+            return settings;
         }
 
         public ValidationResult Test()

--- a/src/NzbDrone.Core/Indexers/IndexerDefinition.cs
+++ b/src/NzbDrone.Core/Indexers/IndexerDefinition.cs
@@ -10,7 +10,7 @@ namespace NzbDrone.Core.Indexers
 {
     public class IndexerDefinition : ProviderDefinition
     {
-        public string BaseUrl { get; set; }
+        public string[] IndexerUrls { get; set; }
         public string Description { get; set; }
         public Encoding Encoding { get; set; }
         public string Language { get; set; }

--- a/src/NzbDrone.Core/Indexers/IndexerFactory.cs
+++ b/src/NzbDrone.Core/Indexers/IndexerFactory.cs
@@ -90,7 +90,7 @@ namespace NzbDrone.Core.Indexers
                 });
             }
 
-            definition.BaseUrl = defFile.Links.First();
+            definition.IndexerUrls = defFile.Links.ToArray();
             definition.Description = defFile.Description;
             definition.Language = defFile.Language;
             definition.Encoding = Encoding.GetEncoding(defFile.Encoding);
@@ -174,7 +174,7 @@ namespace NzbDrone.Core.Indexers
             //We want to use the definition Caps and Privacy for Cardigann instead of the provider.
             if (definition.Implementation != typeof(Cardigann.Cardigann).Name)
             {
-                definition.BaseUrl = provider.BaseUrl;
+                definition.IndexerUrls = provider.IndexerUrls;
                 definition.Privacy = provider.Privacy;
                 definition.Description = provider.Description;
                 definition.Encoding = provider.Encoding;

--- a/src/NzbDrone.Core/Indexers/IndexerFlag.cs
+++ b/src/NzbDrone.Core/Indexers/IndexerFlag.cs
@@ -1,8 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace NzbDrone.Core.Indexers
 {

--- a/src/NzbDrone.Core/Indexers/TorrentIndexerBase.cs
+++ b/src/NzbDrone.Core/Indexers/TorrentIndexerBase.cs
@@ -8,12 +8,11 @@ using NzbDrone.Common.Http;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Exceptions;
 using NzbDrone.Core.Messaging.Events;
-using NzbDrone.Core.ThingiProvider;
 
 namespace NzbDrone.Core.Indexers
 {
     public abstract class TorrentIndexerBase<TSettings> : HttpIndexerBase<TSettings>
-        where TSettings : IProviderConfig, new()
+        where TSettings : IIndexerSettings, new()
     {
         protected TorrentIndexerBase(IHttpClient httpClient, IEventAggregator eventAggregator, IIndexerStatusService indexerStatusService, IConfigService configService, Logger logger)
             : base(httpClient, eventAggregator, indexerStatusService, configService, logger)

--- a/src/NzbDrone.Core/Indexers/UsenetIndexerBase.cs
+++ b/src/NzbDrone.Core/Indexers/UsenetIndexerBase.cs
@@ -7,12 +7,11 @@ using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Download;
 using NzbDrone.Core.Exceptions;
 using NzbDrone.Core.Messaging.Events;
-using NzbDrone.Core.ThingiProvider;
 
 namespace NzbDrone.Core.Indexers
 {
     public abstract class UsenetIndexerBase<TSettings> : HttpIndexerBase<TSettings>
-        where TSettings : IProviderConfig, new()
+        where TSettings : IIndexerSettings, new()
     {
         private readonly IValidateNzbs _nzbValidationService;
 

--- a/src/NzbDrone.Core/Profiles/AppSyncProfileRepository.cs
+++ b/src/NzbDrone.Core/Profiles/AppSyncProfileRepository.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 using NzbDrone.Core.Datastore;
 using NzbDrone.Core.Messaging.Events;
 

--- a/src/NzbDrone.Core/Update/History/UpdateHistoryRepository.cs
+++ b/src/NzbDrone.Core/Update/History/UpdateHistoryRepository.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using NzbDrone.Core.Datastore;
 using NzbDrone.Core.Messaging.Events;
 

--- a/src/NzbDrone.Core/Update/RecentUpdateProvider.cs
+++ b/src/NzbDrone.Core/Update/RecentUpdateProvider.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using NzbDrone.Common.EnvironmentInfo;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Update.History;

--- a/src/Prowlarr.Api.V1/Indexers/IndexerResource.cs
+++ b/src/Prowlarr.Api.V1/Indexers/IndexerResource.cs
@@ -14,7 +14,7 @@ namespace Prowlarr.Api.V1.Indexers
 {
     public class IndexerResource : ProviderResource<IndexerResource>
     {
-        public string BaseUrl { get; set; }
+        public string[] IndexerUrls { get; set; }
         public string Description { get; set; }
         public string Language { get; set; }
         public string Encoding { get; set; }
@@ -74,7 +74,7 @@ namespace Prowlarr.Api.V1.Indexers
 
             resource.InfoLink = string.Format("https://wiki.servarr.com/prowlarr/supported-indexers#{0}", infoLinkName.ToLower().Replace(' ', '-'));
             resource.AppProfileId = definition.AppProfileId;
-            resource.BaseUrl = definition.BaseUrl;
+            resource.IndexerUrls = definition.IndexerUrls;
             resource.Description = definition.Description;
             resource.Language = definition.Language;
             resource.Encoding = definition.Encoding?.EncodingName ?? null;
@@ -130,7 +130,7 @@ namespace Prowlarr.Api.V1.Indexers
             definition.AppProfileId = resource.AppProfileId;
             definition.Enable = resource.Enable;
             definition.Redirect = resource.Redirect;
-            definition.BaseUrl = resource.BaseUrl;
+            definition.IndexerUrls = resource.IndexerUrls;
             definition.Priority = resource.Priority;
             definition.Privacy = resource.Privacy;
             definition.Added = resource.Added;


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This PR turns moves `BaseUrl` from the Indexer to IndexerSettings and adds IndexerUrls to Indexer. IndexerUrls defines the list of possible domains for a given indexer. The user can now select a domain from said list or leave blank to always use the first (default). 

This also completes some description data for for multi indexers. 

#### Screenshot (if UI related)

#### Todos
- [ ] Tests

#### Issues Fixed or Closed by this PR

* Fixes #87 