### PR TITLE
Allow categories to be null on indexer search

### DIFF
--- a/frontend/src/Search/Table/CategoryLabel.js
+++ b/frontend/src/Search/Table/CategoryLabel.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Label from 'Components/Label';
 
-function CategoryLabel({ categories }) {
+function CategoryLabel({ categories = [] }) {
   const sortedCategories = categories.filter((cat) => cat.name !== undefined).sort((c) => c.id);
 
   return (
@@ -21,7 +21,7 @@ function CategoryLabel({ categories }) {
 }
 
 CategoryLabel.propTypes = {
-  categories: PropTypes.arrayOf(PropTypes.object).isRequired
+  categories: PropTypes.arrayOf(PropTypes.object)
 };
 
 export default CategoryLabel;


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Not all results come back with a category so ui throws error since it's required for filtering 

#### Screenshot (if UI related)

example in AB: this result comes back with no category. there's a number of results that dont come back with one:
![image](https://user-images.githubusercontent.com/62021344/124037168-1f34a900-d9cd-11eb-95e9-dcea2031ca84.png)
![image](https://user-images.githubusercontent.com/62021344/124037176-22c83000-d9cd-11eb-8899-44a9989af47b.png)

#### Todos
- [ ] Tests
- [ ] Translation Keys
- [ ] Wiki Updates

#### Issues Fixed or Closed by this PR

* Fixes #XXXX