### PR TITLE
New: Support for Prowlarr Definitions v2 | Support for Download Selectors

### DIFF
--- a/src/NzbDrone.Core/IndexerVersions/IndexerDefinitionUpdateService.cs
+++ b/src/NzbDrone.Core/IndexerVersions/IndexerDefinitionUpdateService.cs
@@ -24,7 +24,9 @@ namespace NzbDrone.Core.IndexerVersions
 
     public class IndexerDefinitionUpdateService : IIndexerDefinitionUpdateService, IExecute<IndexerDefinitionUpdateCommand>
     {
-        private const int DEFINITION_VERSION = 1;
+        /* Update Service will fall back if version # does not exist for an indexer  per Ta */
+
+        private const int DEFINITION_VERSION = 2;
         private readonly List<string> _defintionBlocklist = new List<string>()
         {
             "aither",

--- a/src/NzbDrone.Core/Indexers/Definitions/Cardigann/CardigannDefinition.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Cardigann/CardigannDefinition.cs
@@ -167,10 +167,15 @@ namespace NzbDrone.Core.Indexers.Cardigann
 
     public class DownloadBlock
     {
+        public List<DownloadsField> Selectors { get; set; }
+        public string Method { get; set; }
+        public RequestBlock Before { get; set; }
+    }
+
+    public class DownloadsField
+    {
         public string Selector { get; set; }
         public string Attribute { get; set; }
         public List<FilterBlock> Filters { get; set; }
-        public string Method { get; set; }
-        public RequestBlock Before { get; set; }
     }
 }


### PR DESCRIPTION
#### Database Migration
 NO

#### Description

New: Support for Prowlarr Definitions v2
New: Support for Download Selectors (prev Selector) due to Jackett yml changes

#### Screenshot (if UI related)

#### Todos
-  Tests
-  Translation Keys
-  Wiki Updates
- [x] ToDo: Update IndexerDefinitionUpdateService to V2 [(pending /Indexers) merge](https://github.com/Prowlarr/Indexers/pull/3/)
- [x] ToDo: Figure out why the links aren't working


#### Issues Fixed or Closed by this PR

* Fixes: #298