### PR TITLE
If no categories are passed in, flag up a unknown error

### DIFF
--- a/frontend/src/Search/Table/CategoryLabel.js
+++ b/frontend/src/Search/Table/CategoryLabel.js
@@ -7,7 +7,7 @@ import Tooltip from '../../Components/Tooltip/Tooltip';
 function CategoryLabel({ categories }) {
   const sortedCategories = categories.filter((cat) => cat.name !== undefined).sort((c) => c.id);
 
-  if (categories.length === 0) {
+  if (categories?.length === 0) {
     return (
       <Tooltip
         anchor={<Label kind={kinds.DANGER}>Unknown</Label>}
@@ -31,6 +31,10 @@ function CategoryLabel({ categories }) {
     </span>
   );
 }
+
+CategoryLabel.defaultProps = {
+  categories: []
+};
 
 CategoryLabel.propTypes = {
   categories: PropTypes.arrayOf(PropTypes.object).isRequired

--- a/frontend/src/Search/Table/CategoryLabel.js
+++ b/frontend/src/Search/Table/CategoryLabel.js
@@ -1,9 +1,21 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import Label from 'Components/Label';
+import { kinds, tooltipPositions } from 'Helpers/Props';
+import Tooltip from '../../Components/Tooltip/Tooltip';
 
-function CategoryLabel({ categories = [] }) {
+function CategoryLabel({ categories }) {
   const sortedCategories = categories.filter((cat) => cat.name !== undefined).sort((c) => c.id);
+
+  if (categories.length === 0) {
+    return (
+      <Tooltip
+        anchor={<Label kind={kinds.DANGER}>Unknown</Label>}
+        tooltip="Please report this issue to the GitHub as this shouldn't be happening"
+        position={tooltipPositions.LEFT}
+      />
+    );
+  }
 
   return (
     <span>
@@ -21,7 +33,7 @@ function CategoryLabel({ categories = [] }) {
 }
 
 CategoryLabel.propTypes = {
-  categories: PropTypes.arrayOf(PropTypes.object)
+  categories: PropTypes.arrayOf(PropTypes.object).isRequired
 };
 
 export default CategoryLabel;


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Builds off previous work in #301 , but instead of just displaying nothing, it instead shows a placeholder category that has a tooltip explaining to the user that they should report it, so it can get fixed.

#### Screenshot (if UI related)
![image](https://user-images.githubusercontent.com/24227350/124259562-8d40b380-db26-11eb-8d85-0dbfc82ad4e4.png)
![image](https://user-images.githubusercontent.com/24227350/124259601-9762b200-db26-11eb-8272-3be809392a9b.png)


#### Todos
- [ ] Translation Keys