### PR TITLE
Reworked the Search Page for mobile to improve speed & usability

### DIFF
--- a/frontend/src/Search/SearchIndex.js
+++ b/frontend/src/Search/SearchIndex.js
@@ -49,6 +49,16 @@ class SearchIndex extends Component {
   }
 
   componentDidMount() {
+    const { isSmallScreen, columns, onTableOptionChange } = this.props;
+    if (isSmallScreen) {
+      const mobileColumns = _.cloneDeep(columns);
+
+      for (const columnName of ['protocol', 'age', 'size', 'grabs', 'peers', 'category', 'indexerFlags']) {
+        const column = _.find(mobileColumns, { name: columnName });
+        column.isVisible = false;
+      }
+      onTableOptionChange({ columns: mobileColumns });
+    }
     this.setJumpBarItems();
 
     window.addEventListener('keyup', this.onKeyUp);
@@ -328,7 +338,8 @@ SearchIndex.propTypes = {
   onFilterSelect: PropTypes.func.isRequired,
   onSearchPress: PropTypes.func.isRequired,
   onScroll: PropTypes.func.isRequired,
-  hasIndexers: PropTypes.bool.isRequired
+  hasIndexers: PropTypes.bool.isRequired,
+  onTableOptionChange: PropTypes.func.isRequired
 };
 
 export default SearchIndex;


### PR DESCRIPTION
#### Database Migration
NO

#### Description
On the mount of the search page, untick "non-essential" columns, leaving the user with the title and which indexer.
During testing of performance, we go from a previous average of 30ms~ per VirtualTableRow to 16ms~ when using the Mid-Tier Mobile preset which slows my CPU by 4x

#### Screenshot (if UI related)
Example of the changed options
![image](https://user-images.githubusercontent.com/24227350/124519442-39152800-dde1-11eb-9939-8425a7924d70.png)
Example of the search results using Chrome's Pixel 2 XL preset
![image](https://user-images.githubusercontent.com/24227350/124519532-82657780-dde1-11eb-8d07-f15e733a22d2.png)

