### PR TITLE
Fixed: Respect categories for ImmortalSeed in search

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/ImmortalSeed.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/ImmortalSeed.cs
@@ -171,10 +171,14 @@ namespace NzbDrone.Core.Indexers.Definitions
         {
             var searchUrl = Settings.BaseUrl + "browse.php";
 
-            //TODO - Actually map some categories here
             if (term.IsNotNullOrWhiteSpace())
             {
                 searchUrl += string.Format("?do=search&keywords={0}&search_type=t_name&category=0&include_dead_torrents=no", WebUtility.UrlEncode(term));
+            }
+
+            if (categories != null && categories.Length > 0)
+            {
+                searchUrl += "&selectedcats2=" + string.Join(",", Capabilities.Categories.MapTorznabCapsToTrackers(categories));
             }
 
             var request = new IndexerRequest(searchUrl, HttpAccept.Html);


### PR DESCRIPTION
#### Database Migration
NO

#### Description
ImmortalSeed was returning results from all categories, but now respects category selection in Prowlarr searches.

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

