### PR TITLE
Fixed (Anime Tosho): Only include Releases which have a NZB

### DIFF
--- a/src/NzbDrone.Core/Indexers/RssParser.cs
+++ b/src/NzbDrone.Core/Indexers/RssParser.cs
@@ -82,12 +82,7 @@ namespace NzbDrone.Core.Indexers
                 }
             }
 
-            if (!PostProcess(indexerResponse, items, releases))
-            {
-                return new List<ReleaseInfo>();
-            }
-
-            return releases;
+            return !PostProcess(indexerResponse, items, releases) ? new List<ReleaseInfo>() : releases;
         }
 
         public Action<IDictionary<string, string>, DateTime?> CookiesUpdater { get; set; }
@@ -146,6 +141,11 @@ namespace NzbDrone.Core.Indexers
             var releaseInfo = CreateNewReleaseInfo();
 
             releaseInfo = ProcessItem(item, releaseInfo);
+
+            if (releaseInfo == null)
+            {
+                return null;
+            }
 
             _logger.Trace("Parsed: {0}", releaseInfo.Title);
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
The Newsnab API of Anime Tosho also includes releases which have no NZB (either because its not processed yet or because it was handled before they started uploading to Usenet), i added filters which filter the releaes out if the Newsnab provider gives a type (which Anime Tosho does)

I tested it locally and it seems to not break any other Usenet indexer (tested with DrunkenSlug, NZBCat, SimplyNZBs)

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #200