### PR TITLE
Iptorrents tv episode search fix

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/IPTorrents.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/IPTorrents.cs
@@ -174,11 +174,14 @@ namespace NzbDrone.Core.Indexers.Definitions
 
             if (imdbId.IsNotNullOrWhiteSpace())
             {
-                qc.Add("q", imdbId);
+                // ipt uses sphinx, which supports boolean operators and grouping
+                qc.Add("q", "+(" + imdbId + ")");
             }
-            else if (!string.IsNullOrWhiteSpace(term))
+
+            if (!string.IsNullOrWhiteSpace(term))
             {
-                qc.Add("q", term);
+                // similar to above
+                qc.Add("q", "+(" + term + ")");
             }
 
             if (Settings.FreeLeechOnly)

--- a/src/NzbDrone.Core/Indexers/Definitions/IPTorrents.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/IPTorrents.cs
@@ -178,6 +178,7 @@ namespace NzbDrone.Core.Indexers.Definitions
                 qc.Add("q", "+(" + imdbId + ")");
             }
 
+            // changed from else if to if to support searching imdbid + season/episode in the same query
             if (!string.IsNullOrWhiteSpace(term))
             {
                 // similar to above


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fixing individual episode searches from Sonarr with IPTorrents, making the results more accurate. A search will now take the shape of `+(imdbid) +(season/episode/search-term)`. I've tested that this does not exclude results, which it does not. However, without support for  for the season/episode format `SxY` (Example: `Title 1x10`) in `TvSearchCriteria.cs`, results will be partially incomplete. But only a minor subset of releases are labeled this way, and I believe that if this format is common enough to warrant inclusion in all TV episode searches, this should be handled in TvSearchCriteria, not per indexer.

I tried to apply a similar fix to TorrentLeech, but they don't allow searches that combine IMDbID and search term, like Iptorrents does so that didn't work out.

Note: 

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #231 