### PR TITLE
Fixed: (Indexer) AnimeBytes improve sonarr compatibility and make optional

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/AnimeBytes.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/AnimeBytes.cs
@@ -507,7 +507,7 @@ namespace NzbDrone.Core.Indexers.Definitions
         [FieldDefinition(4, Label = "Enable Sonarr Compatibility", Type = FieldType.Checkbox,  HelpText = "Makes Prowlarr try to add Season information into Release names, without this Sonarr can't match any Seasons, but it has a lot of false positives as well")]
         public bool EnableSonarrCompatibility { get; set; }
 
-        [FieldDefinition(4)]
+        [FieldDefinition(5)]
         public IndexerBaseSettings BaseSettings { get; set; } = new IndexerBaseSettings();
 
         public NzbDroneValidationResult Validate()


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This PR changes two things

1. If an Episode is found, ignore the Season matching since it confuses Sonarr too much and Episodes are going by Absolute Numbering anyway
2. Makes all the Season guessing optional with an by default enabled Checkbox, since its really only working in 70% of all cases and still has a lot of false positives when Anime have Seasonal names with no Season number in it (Jojo for example with  stardust crusaders)

Before:

`TSUKIPRO THE ANIMATION 2 S2 4`
`Tensei Shitara Slime Datta Ken 2nd Season Part 2 S2 40`

Now:

`TSUKIPRO THE ANIMATION 2 04`
`Tensei Shitara Slime Datta Ken 2nd Season Part 2 40`

#### Screenshot (if UI related)
Not needed

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR
None