### PR TITLE
Fixed: Gazelle search using full IMDb ID

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/AlphaRatio.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/AlphaRatio.cs
@@ -39,7 +39,7 @@ namespace NzbDrone.Core.Indexers.Definitions
                        },
                 MovieSearchParams = new List<MovieSearchParam>
                        {
-                           MovieSearchParam.Q, MovieSearchParam.ImdbId
+                           MovieSearchParam.Q
                        }
             };
 

--- a/src/NzbDrone.Core/Indexers/Definitions/Gazelle/GazelleRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Gazelle/GazelleRequestGenerator.cs
@@ -75,11 +75,11 @@ namespace NzbDrone.Core.Indexers.Gazelle
             {
                 if (ImdbInTags)
                 {
-                    parameters += string.Format("&taglist={0}", searchCriteria.ImdbId);
+                    parameters += string.Format("&taglist={0}", searchCriteria.FullImdbId);
                 }
                 else
                 {
-                    parameters += string.Format("&cataloguenumber={0}", searchCriteria.ImdbId);
+                    parameters += string.Format("&cataloguenumber={0}", searchCriteria.FullImdbId);
                 }
             }
 
@@ -120,11 +120,11 @@ namespace NzbDrone.Core.Indexers.Gazelle
             {
                 if (ImdbInTags)
                 {
-                    parameters += string.Format("&taglist={0}", searchCriteria.ImdbId);
+                    parameters += string.Format("&taglist={0}", searchCriteria.FullImdbId);
                 }
                 else
                 {
-                    parameters += string.Format("&cataloguenumber={0}", searchCriteria.ImdbId);
+                    parameters += string.Format("&cataloguenumber={0}", searchCriteria.FullImdbId);
                 }
             }
 

--- a/src/NzbDrone.Core/Indexers/Definitions/SecretCinema.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/SecretCinema.cs
@@ -47,7 +47,7 @@ namespace NzbDrone.Core.Indexers.Definitions
             {
                 MovieSearchParams = new List<MovieSearchParam>
                        {
-                           MovieSearchParam.Q
+                           MovieSearchParam.Q, MovieSearchParam.ImdbId
                        },
                 MusicSearchParams = new List<MusicSearchParam>
                        {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Changed the Gazelle Request Generator so all Gazelle based indexers search using the full IMDB ID (tt1234567) where they previously used only the code without "tt" in front. I've verified that this is the de-facto standard across a range of Gazelle based indexers and confirmed this is the format Jackett have used for their indexers.

Other minor, but related fix includes removing the IMDB search capabiltiy for the Alpharatio indexer (Gazelle based) as this resulted in very poor results due to this tracker not tagging most releases with IMDb ID. Another fix was to add the IMDb capabilty for the Secret Cinema indexer (also Gazelle based).

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* No issue reported. I noticed IMDb search was broken for the Secret Cinema indexer.