### PR TITLE
Fixed: (Indexer) Rutracker - multiple languages support

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/RuTracker.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/RuTracker.cs
@@ -1635,6 +1635,12 @@ namespace NzbDrone.Core.Indexers.Definitions
                     release.Title += " rus";
                 }
 
+                // language fix: if releases contains Original track, add "multi"
+                if (release.Title.IndexOf("Original", StringComparison.OrdinalIgnoreCase) > 0)
+                {
+                    release.Title += " multi";
+                }
+
                 // remove russian letters
                 if (_settings.RussianLetters == true)
                 {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
We already add "rus" to all release names in Rutracker as all releases have Russian audio (see line 1635). However, a lot of releases also include the original language in either the format "Original xxx" where xxx is the language code, but also just "Original". This PR handles that latter scenario. By adding "multi" in the release name, *arr correctly identifies them as multi-language releases. For increased precision, the user can in *arr configure the "Multi Language" option on the indexer to "Original" (see screenshot) and get a correct language mapping for Rutracker releases. If the user does not select any option here, this PR has no effect other than indicating to *arr that this is a multi-language release, which is still correct.

#### Screenshot (if UI related)
![image](https://user-images.githubusercontent.com/2836099/128025666-999a5313-e88d-42ae-8fb6-56a8a291c2e8.png)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* No issue reported.