### PR TITLE
[BugFix] (Tracker) Internet Archive: Add handling of missing result fields.

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/InternetArchive.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/InternetArchive.cs
@@ -219,7 +219,7 @@ namespace NzbDrone.Core.Indexers.Definitions
                 var downloadUrl = string.Format("{0}/download/{1}/{1}_archive.torrent", _settings.BaseUrl.TrimEnd('/'), searchResult.Identifier);
                 var detailsUrl = string.Format("{0}/details/{1}", _settings.BaseUrl.TrimEnd('/'), searchResult.Identifier);
 
-                var category = _categories.MapTrackerCatToNewznab(searchResult.MediaType);
+                var category = _categories.MapTrackerCatToNewznab(searchResult.MediaType ?? "other");
 
                 var release = new TorrentInfo
                 {
@@ -231,7 +231,6 @@ namespace NzbDrone.Core.Indexers.Definitions
                     Grabs = searchResult.Downloads,
                     InfoHash = searchResult.InfoHash,
                     InfoUrl = detailsUrl,
-                    MagnetUrl = MagnetLinkBuilder.BuildPublicMagnetLink(searchResult.InfoHash, title),
                     Peers = 2,
                     PublishDate = searchResult.PublicDate,
                     Seeders = 1,
@@ -239,6 +238,11 @@ namespace NzbDrone.Core.Indexers.Definitions
                     Title = title,
                     UploadVolumeFactor = 1
                 };
+
+                if (searchResult.InfoHash != null)
+                {
+                    release.MagnetUrl = MagnetLinkBuilder.BuildPublicMagnetLink(searchResult.InfoHash, title);
+                }
 
                 torrentInfos.Add(release);
             }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Internet Archive might return results with some missing fields - this PR will solve those cases in the following way:

- if the InfoHash (btih) is missing: don't try to build and set a magnet url
- if the mediatype is missing (should not happen/never happened to me): assign "Other" category

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #401