### PR TITLE
[BugFix] (Indexer) Internet Archive: Follow redirects.

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/InternetArchive.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/InternetArchive.cs
@@ -31,6 +31,8 @@ namespace NzbDrone.Core.Indexers.Definitions
 
         public override IndexerCapabilities Capabilities => SetCapabilities();
 
+        public override bool FollowRedirect => true;
+
         public InternetArchive(IHttpClient httpClient, IEventAggregator eventAggregator, IIndexerStatusService indexerStatusService, IConfigService configService, Logger logger)
             : base(httpClient, eventAggregator, indexerStatusService, configService, logger)
         {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Sorry for the inconvenience - I really hope I found it all now:

My implementation was missing the _FollowRedirect_ parameter (therefore Prowlarr missing the torrent file as it requires a redirect to the correct InternetArchive server).
This PR adds this parameter and lets Prowlarr fetch the file.



#### Screenshot (if UI related)

#### Todos

#### Issues Fixed or Closed by this PR