### PR TITLE
Fixed: (Indexer) BroadcastheNet - Report TvdbId and RId capability

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/BroadcastheNet/BroadcastheNet.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/BroadcastheNet/BroadcastheNet.cs
@@ -55,7 +55,7 @@ namespace NzbDrone.Core.Indexers.BroadcastheNet
                 LimitsMax = 1000,
                 TvSearchParams = new List<TvSearchParam>
                        {
-                           TvSearchParam.Q, TvSearchParam.Season, TvSearchParam.Ep
+                           TvSearchParam.Q, TvSearchParam.Season, TvSearchParam.Ep, TvSearchParam.TvdbId, TvSearchParam.RId
                        }
             };
 


### PR DESCRIPTION
#### Database Migration

NO

#### Description

The BroadcastTheNet indexer supports searching by Tvdb ids (and that support is already implemented in the code), but it didn't report that as a capability for tv search params.

This PR adds the TvSearchParams.TvdbId to the indexer, as well as TvSearchParams.RId (rage id).

#### Screenshot (if UI related)

#### Todos

- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

- No issue reported

