### PR TITLE
Fixed: (Indexer) PTP IMDB search

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/PassThePopcorn/PassThePopcornRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/PassThePopcorn/PassThePopcornRequestGenerator.cs
@@ -22,7 +22,7 @@ namespace NzbDrone.Core.Indexers.PassThePopcorn
 
             if (searchCriteria.ImdbId.IsNotNullOrWhiteSpace())
             {
-                pageableRequests.Add(GetRequest(searchCriteria.ImdbId));
+                pageableRequests.Add(GetRequest(searchCriteria.FullImdbId));
             }
             else
             {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
IMDBid search did not work because prowlarr was searching using the 1234567 imdbid instead of the "full" imdb id with tt in front, like tt1234567. I've modified it to use the latter, and tested that it works using radarr and the prowlarr search bar.

Similar issue to https://github.com/Prowlarr/Prowlarr/pull/389 but PTP is not Gazelle based so either fix do not affect each other.

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* No reported issue. Only noticed by me.