### PR TITLE
Fixing HDBits not parsing the search term

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/HDBits/HDBitsRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/HDBits/HDBitsRequestGenerator.cs
@@ -66,9 +66,6 @@ namespace NzbDrone.Core.Indexers.HDBits
 
             request.SetContent(query.ToJson());
 
-            var json = query.ToJson();
-            var a = new IndexerRequest(request);
-
             yield return new IndexerRequest(request);
         }
 

--- a/src/NzbDrone.Core/Indexers/Definitions/HDBits/HDBitsRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/HDBits/HDBitsRequestGenerator.cs
@@ -78,18 +78,17 @@ namespace NzbDrone.Core.Indexers.HDBits
         {
             var pageableRequests = new IndexerPageableRequestChain();
             var query = new TorrentQuery();
+            var tvdbId = searchCriteria.TvdbId.GetValueOrDefault(0);
 
             if (searchCriteria.Categories?.Length > 0)
             {
                 query.Category = Capabilities.Categories.MapTorznabCapsToTrackers(searchCriteria.Categories).Select(int.Parse).ToArray();
             }
 
-            if (searchCriteria.SearchTerm.IsNotNullOrWhiteSpace())
+            if (tvdbId == 0 && searchCriteria.SearchTerm.IsNotNullOrWhiteSpace())
             {
                 query.Search = searchCriteria.SanitizedTvSearchString;
             }
-
-            var tvdbId = searchCriteria.TvdbId;
 
             if (tvdbId != 0)
             {

--- a/src/NzbDrone.Core/Indexers/Definitions/HDBits/HDBitsRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/HDBits/HDBitsRequestGenerator.cs
@@ -66,6 +66,9 @@ namespace NzbDrone.Core.Indexers.HDBits
 
             request.SetContent(query.ToJson());
 
+            var json = query.ToJson();
+            var a = new IndexerRequest(request);
+
             yield return new IndexerRequest(request);
         }
 
@@ -84,7 +87,7 @@ namespace NzbDrone.Core.Indexers.HDBits
                 query.Category = Capabilities.Categories.MapTorznabCapsToTrackers(searchCriteria.Categories).Select(int.Parse).ToArray();
             }
 
-            if (searchCriteria.TvdbId == 0 && searchCriteria.SearchTerm.IsNotNullOrWhiteSpace())
+            if (searchCriteria.SearchTerm.IsNotNullOrWhiteSpace())
             {
                 query.Search = searchCriteria.SanitizedTvSearchString;
             }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
When sonarr searches for a tvshow, sometimes the tvdb might be null. The code today checks if tvdb == 0.. which means the search term is never applied as tvdb is null.

This fixed handles the searching properly.

#### Issues Fixed or Closed by this PR

* Fixes https://github.com/Prowlarr/Prowlarr/issues/437