### PR TITLE
(Internet Archive) Add Torrent File Only option.

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/InternetArchive.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/InternetArchive.cs
@@ -241,7 +241,7 @@ namespace NzbDrone.Core.Indexers.Definitions
                     UploadVolumeFactor = 1
                 };
 
-                if (searchResult.InfoHash != null)
+                if (!_settings.TorrentFileOnly && searchResult.InfoHash != null)
                 {
                     release.MagnetUrl = MagnetLinkBuilder.BuildPublicMagnetLink(searchResult.InfoHash, title);
                 }
@@ -292,7 +292,10 @@ namespace NzbDrone.Core.Indexers.Definitions
         [FieldDefinition(4, Label = "Title Only", Type = FieldType.Checkbox, Advanced = true, HelpText = "Whether to search in title only.")]
         public bool TitleOnly { get; set; }
 
-        [FieldDefinition(5)]
+        [FieldDefinition(5, Label = "Torrent File Only", Type = FieldType.Checkbox, Advanced = true, HelpText = "Only use torrent files, not magnet links.")]
+        public bool TorrentFileOnly { get; set; }
+
+        [FieldDefinition(6)]
         public IndexerBaseSettings BaseSettings { get; set; } = new IndexerBaseSettings();
 
         public InternetArchiveSettings()
@@ -300,6 +303,7 @@ namespace NzbDrone.Core.Indexers.Definitions
             SortBy = (int)InternetArchiveSort.PublicDate;
             SortOrder = (int)InternetArchiveSortOrder.Descending;
             TitleOnly = false;
+            TorrentFileOnly = false;
         }
 
         public NzbDroneValidationResult Validate()


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Adds a Torrent File Only option to the Internet Archive indexer.
If this option is enabled and a InfoHash is available for a search result, Prowlarr will not construct a magnet link.

#### Issues Fixed or Closed by this PR

* Addresses https://github.com/Prowlarr/Prowlarr/issues/457