### PR TITLE
Fixed: Increased Xthor Rate Limit Time

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/Xthor/Xthor.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Xthor/Xthor.cs
@@ -18,7 +18,7 @@ namespace NzbDrone.Core.Indexers.Definitions.Xthor
         public override DownloadProtocol Protocol => DownloadProtocol.Torrent;
         public override IndexerPrivacy Privacy => IndexerPrivacy.Private;
 
-        public override TimeSpan RateLimit => TimeSpan.FromSeconds(2.1);
+        public override TimeSpan RateLimit => TimeSpan.FromSeconds(2.5);
         public override IndexerCapabilities Capabilities => SetCapabilities();
 
         public Xthor(IIndexerHttpClient httpClient,


### PR DESCRIPTION
#### Database Migration
NO

#### Description
2.1s => 2.5s

#### Screenshot (if UI related)

#### Todos
- N/A Tests
- N/A Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- N/A [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes Logs of #472

```
2021-08-28 05:59:47.8|Error|Xthor|An error occurred while processing indexer feed. https://api.xthor.tk?passkey=(removed)&category=12%2B125%2B104%2B13%2B15%2B14%2B98%2B17%2B16%2B101%2B32%2B110%2B123%2B109%2B34%2B30&accent=1

[v0.1.1.875] System.Exception: Triggered AntiSpam Protection, please delay your requests!
   at NzbDrone.Core.Indexers.Definitions.Xthor.XthorParser.CheckApiState(XthorError state) in D:\a\1\s\src\NzbDrone.Core\Indexers\Definitions\Xthor\XthorParser.cs:line 112
   at NzbDrone.Core.Indexers.Definitions.Xthor.XthorParser.ParseResponse(IndexerResponse indexerResponse) in D:\a\1\s\src\NzbDrone.Core\Indexers\Definitions\Xthor\XthorParser.cs:line 32
   at NzbDrone.Core.Indexers.HttpIndexerBase`1.FetchPage(IndexerRequest request, IParseIndexerResponse parser) in D:\a\1\s\src\NzbDrone.Core\Indexers\HttpIndexerBase.cs:line 321
   at NzbDrone.Core.Indexers.HttpIndexerBase`1.FetchReleases(Func`2 pageableRequestChainSelector, Boolean isRecent) in D:\a\1\s\src\NzbDrone.Core\Indexers\HttpIndexerBase.cs:line 174
RequestUri: https://api.xthor.tk?passkey=(removed)&category=12%2B125%2B104%2B13%2B15%2B14%2B98%2B17%2B16%2B101%2B32%2B110%2B123%2B109%2B34%2B30&accent=1;StatusCode: OK;ContentType: application/json;ContentLength: 133;ContentSample: {
    "error": {
        "code": 8,
        "descr": "Protection Anti-Spam: A.P.I limitee a 1 requete toutes les 2 secondes."
    }
};FeedUrl: https://api.xthor.tk?passkey=(removed)&category=12%2B125%2B104%2B13%2B15%2B14%2B98%2B17%2B16%2B101%2B32%2B110%2B123%2B109%2B34%2B30&accent=1
```

