### PR TITLE
Fixed: (Indexer) TPB Missing Magnet Download Link & No Results for *arr Torznab

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/ThePirateBay.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/ThePirateBay.cs
@@ -252,6 +252,11 @@ namespace NzbDrone.Core.Indexers.Definitions
                     ImdbId = imdbId.GetValueOrDefault()
                 };
 
+                if (item.InfoHash != null)
+                {
+                    torrentItem.MagnetUrl = MagnetLinkBuilder.BuildPublicMagnetLink(item.InfoHash, item.Name);
+                }
+
                 torrentInfos.Add(torrentItem);
             }
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
- we were not generating a magnetlink from the infolink for TPB; thus TPB downloads were N/A

#### Screenshot (if UI related)

#### Todos
- N/A Tests
- N/A Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- N/A [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes Discord Issue