### PR TITLE
Update Indexers to Indexer Proxies

### DIFF
--- a/frontend/src/Settings/Settings.js
+++ b/frontend/src/Settings/Settings.js
@@ -18,7 +18,7 @@ function Settings() {
           className={styles.link}
           to="/settings/indexers"
         >
-          {translate('Indexers')}
+          {translate('IndexerProxies')}
         </Link>
 
         <div className={styles.summary}>


### PR DESCRIPTION
the settings submenu said "Indexers" whereas this is actually the settings for Indexer Proxies - updating the translate link to correct this

#### Database Migration
NO

#### Description
Clarifying the menue for a better user experience

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [X] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR
