### PR TITLE
(indexers) various - standardized language format with `{ISO 639-1}-{ISO 3166-1 alpha-2}`

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/Aither.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Aither.cs
@@ -12,7 +12,7 @@ namespace NzbDrone.Core.Indexers.Definitions
         public override string Name => "Aither";
         public override string[] IndexerUrls => new string[] { "https://aither.cc/" };
         public override string Description => "Aither is a Private Torrent Tracker for HD MOVIES / TV";
-        public override string Language => "en-us";
+        public override string Language => "en-US";
         public override IndexerPrivacy Privacy => IndexerPrivacy.Private;
 
         public Aither(IIndexerHttpClient httpClient, IEventAggregator eventAggregator, IIndexerStatusService indexerStatusService, IConfigService configService, Logger logger)

--- a/src/NzbDrone.Core/Indexers/Definitions/Anidub.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Anidub.cs
@@ -27,7 +27,7 @@ namespace NzbDrone.Core.Indexers.Definitions
         public override string Name => "Anidub";
         public override string[] IndexerUrls => new string[] { "https://tr.anidub.com/" };
         public override string Description => "Anidub is russian anime voiceover group and eponymous anime tracker.";
-        public override string Language => "ru-ru";
+        public override string Language => "ru-RU";
         public override Encoding Encoding => Encoding.UTF8;
         public override DownloadProtocol Protocol => DownloadProtocol.Torrent;
         public override IndexerPrivacy Privacy => IndexerPrivacy.SemiPublic;

--- a/src/NzbDrone.Core/Indexers/Definitions/Anilibria.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Anilibria.cs
@@ -22,7 +22,7 @@ namespace NzbDrone.Core.Indexers.Definitions
         public override string Name => "Anilibria";
         public override string[] IndexerUrls => new string[] { "https://anilibria.tv/" };
         public override string Description => "Anilibria is russian anime voiceover group and eponymous anime tracker.";
-        public override string Language => "ru-ru";
+        public override string Language => "ru-RU";
         public override Encoding Encoding => Encoding.UTF8;
         public override DownloadProtocol Protocol => DownloadProtocol.Torrent;
         public override IndexerPrivacy Privacy => IndexerPrivacy.Public;

--- a/src/NzbDrone.Core/Indexers/Definitions/AnimeBytes.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/AnimeBytes.cs
@@ -28,7 +28,7 @@ namespace NzbDrone.Core.Indexers.Definitions
         public override string Name => "AnimeBytes";
         public override string[] IndexerUrls => new string[] { "https://animebytes.tv/" };
         public override string Description => "AnimeBytes (AB) is the largest private torrent tracker that specialises in anime and anime-related content.";
-        public override string Language => "en-us";
+        public override string Language => "en-US";
         public override Encoding Encoding => Encoding.UTF8;
         public override DownloadProtocol Protocol => DownloadProtocol.Torrent;
         public override IndexerPrivacy Privacy => IndexerPrivacy.Private;

--- a/src/NzbDrone.Core/Indexers/Definitions/AnimeWorld.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/AnimeWorld.cs
@@ -12,7 +12,7 @@ namespace NzbDrone.Core.Indexers.Definitions
         public override string Name => "AnimeWorld";
         public override string[] IndexerUrls => new string[] { "https://animeworld.cx/" };
         public override string Description => "AnimeWorld (AW) is a GERMAN Private site for ANIME / MANGA / HENTAI";
-        public override string Language => "de-de";
+        public override string Language => "de-DE";
 
         public override IndexerPrivacy Privacy => IndexerPrivacy.Private;
         public AnimeWorld(IIndexerHttpClient httpClient, IEventAggregator eventAggregator, IIndexerStatusService indexerStatusService, IConfigService configService, Logger logger)

--- a/src/NzbDrone.Core/Indexers/Definitions/Animedia.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Animedia.cs
@@ -23,7 +23,7 @@ namespace NzbDrone.Core.Indexers.Definitions
         public override string Name => "Animedia";
         public override string[] IndexerUrls => new string[] { "https://tt.animedia.tv/" };
         public override string Description => "Animedia is russian anime voiceover group and eponymous anime tracker.";
-        public override string Language => "ru-ru";
+        public override string Language => "ru-RU";
         public override Encoding Encoding => Encoding.UTF8;
         public override DownloadProtocol Protocol => DownloadProtocol.Torrent;
         public override IndexerPrivacy Privacy => IndexerPrivacy.Public;

--- a/src/NzbDrone.Core/Indexers/Definitions/Anthelion.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Anthelion.cs
@@ -27,7 +27,7 @@ namespace NzbDrone.Core.Indexers.Definitions
         public override string[] IndexerUrls => new string[] { "https://anthelion.me/" };
         private string LoginUrl => Settings.BaseUrl + "login.php";
         public override string Description => "A movies tracker";
-        public override string Language => "en-us";
+        public override string Language => "en-US";
         public override Encoding Encoding => Encoding.UTF8;
         public override DownloadProtocol Protocol => DownloadProtocol.Torrent;
         public override IndexerPrivacy Privacy => IndexerPrivacy.Private;

--- a/src/NzbDrone.Core/Indexers/Definitions/BB.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/BB.cs
@@ -26,7 +26,7 @@ namespace NzbDrone.Core.Indexers.Definitions
         public override string[] IndexerUrls => new string[] { StringUtil.FromBase64("aHR0cHM6Ly9iYWNvbmJpdHMub3JnLw==") };
         private string LoginUrl => Settings.BaseUrl + "login.php";
         public override string Description => "bB is a Private Torrent Tracker for 0DAY / GENERAL";
-        public override string Language => "en-us";
+        public override string Language => "en-US";
         public override Encoding Encoding => Encoding.UTF8;
         public override DownloadProtocol Protocol => DownloadProtocol.Torrent;
         public override IndexerPrivacy Privacy => IndexerPrivacy.Private;

--- a/src/NzbDrone.Core/Indexers/Definitions/BB.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/BB.cs
@@ -25,7 +25,7 @@ namespace NzbDrone.Core.Indexers.Definitions
         public override string Name => "BB";
         public override string[] IndexerUrls => new string[] { StringUtil.FromBase64("aHR0cHM6Ly9iYWNvbmJpdHMub3JnLw==") };
         private string LoginUrl => Settings.BaseUrl + "login.php";
-        public override string Description => "bB is a Private Torrent Tracker for 0DAY / GENERAL";
+        public override string Description => "BB is a Private Torrent Tracker for 0DAY / GENERAL";
         public override string Language => "en-US";
         public override Encoding Encoding => Encoding.UTF8;
         public override DownloadProtocol Protocol => DownloadProtocol.Torrent;

--- a/src/NzbDrone.Core/Indexers/Definitions/BinSearch.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/BinSearch.cs
@@ -24,7 +24,7 @@ namespace NzbDrone.Core.Indexers.Definitions
         public override string Name => "BinSearch";
         public override string[] IndexerUrls => new string[] { "https://binsearch.info/" };
         public override string Description => "The binary Usenet search engine";
-        public override string Language => "en-us";
+        public override string Language => "en-US";
         public override Encoding Encoding => Encoding.UTF8;
         public override DownloadProtocol Protocol => DownloadProtocol.Usenet;
         public override IndexerPrivacy Privacy => IndexerPrivacy.Public;

--- a/src/NzbDrone.Core/Indexers/Definitions/FileList/FileList.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/FileList/FileList.cs
@@ -10,7 +10,7 @@ namespace NzbDrone.Core.Indexers.FileList
     {
         public override string Name => "FileList.io";
         public override string[] IndexerUrls => new string[] { "https://filelist.io" };
-        public override string Description => "";
+        public override string Description => "FileList (FL) is a ROMANIAN Private Torrent Tracker for 0DAY / GENERAL";
         public override DownloadProtocol Protocol => DownloadProtocol.Torrent;
         public override IndexerPrivacy Privacy => IndexerPrivacy.Private;
         public override bool SupportsRss => true;

--- a/src/NzbDrone.Core/Indexers/Definitions/GazelleGames.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/GazelleGames.cs
@@ -24,7 +24,7 @@ namespace NzbDrone.Core.Indexers.Definitions
         public override string Name => "GazelleGames";
         public override string[] IndexerUrls => new string[] { "https://gazellegames.net/" };
         public override string Description => "GazelleGames (GGn) is a Private Torrent Tracker for GAMES";
-        public override string Language => "en-us";
+        public override string Language => "en-US";
         public override Encoding Encoding => Encoding.UTF8;
         public override DownloadProtocol Protocol => DownloadProtocol.Torrent;
         public override IndexerPrivacy Privacy => IndexerPrivacy.Private;

--- a/src/NzbDrone.Core/Indexers/Definitions/HDSpace.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/HDSpace.cs
@@ -26,7 +26,7 @@ namespace NzbDrone.Core.Indexers.Definitions
         public override string[] IndexerUrls => new string[] { "https://hd-space.org/" };
         private string LoginUrl => Settings.BaseUrl + "index.php?page=login";
         public override string Description => "HD-Space (HDS) is a Private Torrent Tracker for HD MOVIES / TV";
-        public override string Language => "en-us";
+        public override string Language => "en-US";
         public override Encoding Encoding => Encoding.UTF8;
         public override DownloadProtocol Protocol => DownloadProtocol.Torrent;
         public override IndexerPrivacy Privacy => IndexerPrivacy.Private;

--- a/src/NzbDrone.Core/Indexers/Definitions/Nebulance.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Nebulance.cs
@@ -25,7 +25,7 @@ namespace NzbDrone.Core.Indexers.Definitions
         public override string[] IndexerUrls => new string[] { "https://nebulance.io/" };
         private string LoginUrl => Settings.BaseUrl + "login.php";
         public override string Description => "Nebulance (NBL) is a ratioless Private Torrent Tracker for TV";
-        public override string Language => "en-us";
+        public override string Language => "en-US";
         public override Encoding Encoding => Encoding.UTF8;
         public override DownloadProtocol Protocol => DownloadProtocol.Torrent;
         public override IndexerPrivacy Privacy => IndexerPrivacy.Private;

--- a/src/NzbDrone.Core/Indexers/Definitions/Newznab/Newznab.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Newznab/Newznab.cs
@@ -20,7 +20,7 @@ namespace NzbDrone.Core.Indexers.Newznab
 
         public override string Name => "Newznab";
         public override string[] IndexerUrls => GetBaseUrlFromSettings();
-        public override string Description => "";
+        public override string Description => "Newznab is an API search specification for Usenet";
         public override bool FollowRedirect => true;
         public override bool SupportsRedirect => true;
 

--- a/src/NzbDrone.Core/Indexers/Definitions/PassThePopcorn/PassThePopcorn.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/PassThePopcorn/PassThePopcorn.cs
@@ -11,7 +11,7 @@ namespace NzbDrone.Core.Indexers.PassThePopcorn
     {
         public override string Name => "PassThePopcorn";
         public override string[] IndexerUrls => new string[] { "https://passthepopcorn.me" };
-        public override string Description => "";
+        public override string Description => "PassThePopcorn (PTP) is a Private site for MOVIES / TV";
         public override DownloadProtocol Protocol => DownloadProtocol.Torrent;
         public override IndexerPrivacy Privacy => IndexerPrivacy.Private;
         public override bool SupportsRss => true;

--- a/src/NzbDrone.Core/Indexers/Definitions/PreToMe.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/PreToMe.cs
@@ -26,7 +26,7 @@ namespace NzbDrone.Core.Indexers.Definitions
         public override string[] IndexerUrls => new string[] { "https://pretome.info/" };
         public override string Description => "PreToMe is a ratioless 0Day/General tracker.";
         private string LoginUrl => Settings.BaseUrl + "takelogin.php";
-        public override string Language => "en-us";
+        public override string Language => "en-US";
         public override Encoding Encoding => Encoding.GetEncoding("iso-8859-1");
         public override DownloadProtocol Protocol => DownloadProtocol.Torrent;
         public override IndexerPrivacy Privacy => IndexerPrivacy.Private;

--- a/src/NzbDrone.Core/Indexers/Definitions/Redacted.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Redacted.cs
@@ -25,7 +25,7 @@ namespace NzbDrone.Core.Indexers.Definitions
         public override string Name => "Redacted";
         public override string[] IndexerUrls => new string[] { "https://redacted.ch/" };
         public override string Description => "REDActed (Aka.PassTheHeadPhones) is one of the most well-known music trackers.";
-        public override string Language => "en-us";
+        public override string Language => "en-US";
         public override Encoding Encoding => Encoding.UTF8;
         public override DownloadProtocol Protocol => DownloadProtocol.Torrent;
         public override IndexerPrivacy Privacy => IndexerPrivacy.Private;

--- a/src/NzbDrone.Core/Indexers/Definitions/SceneTime.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/SceneTime.cs
@@ -24,7 +24,7 @@ namespace NzbDrone.Core.Indexers.Definitions
         public override string Name => "SceneTime";
         public override string[] IndexerUrls => new[] { "https://www.scenetime.com/" };
         public override string Description => "Always on time";
-        public override string Language => "en-us";
+        public override string Language => "en-US";
         public override Encoding Encoding => Encoding.GetEncoding("iso-8859-1");
         public override DownloadProtocol Protocol => DownloadProtocol.Torrent;
         public override IndexerPrivacy Privacy => IndexerPrivacy.Private;

--- a/src/NzbDrone.Core/Indexers/Definitions/ShareIsland.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/ShareIsland.cs
@@ -12,7 +12,7 @@ namespace NzbDrone.Core.Indexers.Definitions
         public override string Name => "ShareIsland";
         public override string[] IndexerUrls => new string[] { "https://shareisland.org/" };
         public override string Description => "A general italian tracker.";
-        public override string Language => "it-it";
+        public override string Language => "it-IT";
         public override IndexerPrivacy Privacy => IndexerPrivacy.Private;
 
         public ShareIsland(IIndexerHttpClient httpClient, IEventAggregator eventAggregator, IIndexerStatusService indexerStatusService, IConfigService configService, Logger logger)

--- a/src/NzbDrone.Core/Indexers/Definitions/Shizaproject.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Shizaproject.cs
@@ -23,7 +23,7 @@ namespace NzbDrone.Core.Indexers.Definitions
         public override string Name => "ShizaProject";
         public override string[] IndexerUrls => new string[] { "https://shiza-project.com/" };
         public override string Description => "Shizaproject is russian anime voiceover group and eponymous anime tracker.";
-        public override string Language => "ru-ru";
+        public override string Language => "ru-RU";
         public override Encoding Encoding => Encoding.UTF8;
         public override DownloadProtocol Protocol => DownloadProtocol.Torrent;
         public override IndexerPrivacy Privacy => IndexerPrivacy.Public;

--- a/src/NzbDrone.Core/Indexers/Definitions/ShowRSS.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/ShowRSS.cs
@@ -20,7 +20,7 @@ namespace NzbDrone.Core.Indexers.Definitions
     {
         public override string Name => "ShowRSS";
         public override string[] IndexerUrls => new string[] { "https://showrss.info/" };
-        public override string Language => "en-us";
+        public override string Language => "en-US";
         public override string Description => "showRSS is a service that allows you to keep track of your favorite TV shows";
         public override Encoding Encoding => Encoding.UTF8;
         public override DownloadProtocol Protocol => DownloadProtocol.Torrent;

--- a/src/NzbDrone.Core/Indexers/Definitions/SpeedApp.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/SpeedApp.cs
@@ -36,7 +36,7 @@ namespace NzbDrone.Core.Indexers.Definitions
 
         public override string Description => "SpeedApp is a ROMANIAN Private Torrent Tracker for MOVIES / TV / GENERAL";
 
-        public override string Language => "ro-ro";
+        public override string Language => "ro-RO";
 
         public override Encoding Encoding => Encoding.UTF8;
 

--- a/src/NzbDrone.Core/Indexers/Definitions/SubsPlease.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/SubsPlease.cs
@@ -27,7 +27,7 @@ namespace NzbDrone.Core.Indexers.Definitions
             "https://subsplease.org/",
             "https://subsplease.nocensor.space/"
         };
-        public override string Language => "en-us";
+        public override string Language => "en-US";
         public override string Description => "SubsPlease - A better HorribleSubs/Erai replacement";
         public override Encoding Encoding => Encoding.UTF8;
         public override DownloadProtocol Protocol => DownloadProtocol.Torrent;

--- a/src/NzbDrone.Core/Indexers/Definitions/TVVault.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/TVVault.cs
@@ -27,7 +27,7 @@ namespace NzbDrone.Core.Indexers.Definitions
         public override string[] IndexerUrls => new[] { "https://tv-vault.me/" };
         private string LoginUrl => Settings.BaseUrl + "login.php";
         public override string Description => "TV-Vault is a very unique tracker dedicated for old TV shows, TV movies and documentaries.";
-        public override string Language => "en-us";
+        public override string Language => "en-US";
         public override Encoding Encoding => Encoding.UTF8;
         public override DownloadProtocol Protocol => DownloadProtocol.Torrent;
         public override IndexerPrivacy Privacy => IndexerPrivacy.Private;

--- a/src/NzbDrone.Core/Indexers/Definitions/ThePirateBay.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/ThePirateBay.cs
@@ -21,7 +21,7 @@ namespace NzbDrone.Core.Indexers.Definitions
         public override string Name => "ThePirateBay";
         public override string[] IndexerUrls => new string[] { "https://thepiratebay.org/" };
         public override string Description => "Pirate Bay(TPB) is the galaxy’s most resilient Public BitTorrent site";
-        public override string Language => "en-us";
+        public override string Language => "en-US";
         public override Encoding Encoding => Encoding.UTF8;
         public override DownloadProtocol Protocol => DownloadProtocol.Torrent;
         public override IndexerPrivacy Privacy => IndexerPrivacy.Public;

--- a/src/NzbDrone.Core/Indexers/Definitions/TorrentParadiseMl.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/TorrentParadiseMl.cs
@@ -22,7 +22,7 @@ namespace NzbDrone.Core.Indexers.Definitions
     {
         public override string Name => "TorrentParadiseMl";
         public override string[] IndexerUrls => new[] { "https://torrent-paradise.ml/" };
-        public override string Language => "en-us";
+        public override string Language => "en-US";
         public override string Description => "The most innovative torrent site";
         public override Encoding Encoding => Encoding.UTF8;
         public override DownloadProtocol Protocol => DownloadProtocol.Torrent;

--- a/src/NzbDrone.Core/Indexers/Definitions/TorrentPotato/TorrentPotato.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/TorrentPotato/TorrentPotato.cs
@@ -10,7 +10,7 @@ namespace NzbDrone.Core.Indexers.TorrentPotato
     {
         public override string Name => "TorrentPotato";
         public override string[] IndexerUrls => new string[] { "http://127.0.0.1" };
-        public override string Description => "";
+        public override string Description => "A JSON based torrent provider previously developed for CouchPotato";
 
         public override DownloadProtocol Protocol => DownloadProtocol.Torrent;
         public override IndexerPrivacy Privacy => IndexerPrivacy.Private;

--- a/src/NzbDrone.Core/Indexers/Definitions/TorrentSyndikat.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/TorrentSyndikat.cs
@@ -23,7 +23,7 @@ namespace NzbDrone.Core.Indexers.Definitions
         public override string Name => "TorrentSyndikat";
         public override string[] IndexerUrls => new[] { "https://torrent-syndikat.org/" };
         public override string Description => "A German general tracker";
-        public override string Language => "de-de";
+        public override string Language => "de-DE";
         public override Encoding Encoding => Encoding.UTF8;
         public override DownloadProtocol Protocol => DownloadProtocol.Torrent;
         public override IndexerPrivacy Privacy => IndexerPrivacy.Private;

--- a/src/NzbDrone.Core/Indexers/Definitions/TorrentsCSV.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/TorrentsCSV.cs
@@ -21,7 +21,7 @@ namespace NzbDrone.Core.Indexers.Definitions
     {
         public override string Name => "TorrentsCSV";
         public override string[] IndexerUrls => new[] { "https://torrents-csv.ml/" };
-        public override string Language => "en-us";
+        public override string Language => "en-US";
         public override string Description => "Torrents.csv is a self-hostable open source torrent search engine and database";
         public override Encoding Encoding => Encoding.UTF8;
         public override DownloadProtocol Protocol => DownloadProtocol.Torrent;

--- a/src/NzbDrone.Core/Indexers/Definitions/Torznab/Torznab.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Torznab/Torznab.cs
@@ -20,7 +20,7 @@ namespace NzbDrone.Core.Indexers.Torznab
 
         public override string Name => "Torznab";
         public override string[] IndexerUrls => GetBaseUrlFromSettings();
-        public override string Description => "";
+        public override string Description => "A Newznab-like api for torrents.";
         public override bool FollowRedirect => true;
         public override bool SupportsRedirect => true;
 

--- a/src/NzbDrone.Core/Indexers/Definitions/Xthor/Xthor.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Xthor/Xthor.cs
@@ -12,7 +12,7 @@ namespace NzbDrone.Core.Indexers.Definitions.Xthor
     {
         public override string Name => "Xthor";
         public override string[] IndexerUrls => new string[] { "https://api.xthor.tk/" };
-        public override string Language => "fr-fr";
+        public override string Language => "fr-FR";
         public override string Description => "Xthor is a general Private torrent site";
         public override Encoding Encoding => Encoding.GetEncoding("windows-1252");
         public override DownloadProtocol Protocol => DownloadProtocol.Torrent;

--- a/src/NzbDrone.Core/Indexers/Definitions/YTS.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/YTS.cs
@@ -22,7 +22,7 @@ namespace NzbDrone.Core.Indexers.Definitions
     {
         public override string Name => "YTS";
         public override string[] IndexerUrls => new string[] { "https://yts.mx/" };
-        public override string Language => "en-us";
+        public override string Language => "en-US";
         public override string Description => "YTS is a Public torrent site specialising in HD movies of small size";
         public override Encoding Encoding => Encoding.GetEncoding("windows-1252");
         public override DownloadProtocol Protocol => DownloadProtocol.Torrent;

--- a/src/NzbDrone.Core/Indexers/Definitions/ZonaQ.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/ZonaQ.cs
@@ -33,7 +33,7 @@ namespace NzbDrone.Core.Indexers.Definitions
         private string Login3Url => Settings.BaseUrl + "retorno/include/puerta_8_ajax.php";
         private string Login4Url => Settings.BaseUrl + "retorno/index.php";
         public override string Description => "ZonaQ is a SPANISH Private Torrent Tracker for MOVIES / TV";
-        public override string Language => "es-es";
+        public override string Language => "es-ES";
         public override Encoding Encoding => Encoding.UTF8;
         public override DownloadProtocol Protocol => DownloadProtocol.Torrent;
         public override IndexerPrivacy Privacy => IndexerPrivacy.Private;


### PR DESCRIPTION
#### Database Migration
NO

#### Description
indexer languages were inconsistent; this standardizes them

#### Screenshot (if UI related)

#### Todos
-  Tests
-  Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX

#### Other Notes
This is also being done in Jackett / to Prowlarr YML
