### PR TITLE
Fixed: (Indexer) Changed BakaBT to default to SFW content

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/BakaBT.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/BakaBT.cs
@@ -170,7 +170,11 @@ namespace NzbDrone.Core.Indexers.Definitions
         private IEnumerable<IndexerRequest> GetPagedRequests(string term)
         {
             var searchString = term;
-            var searchUrl = Settings.BaseUrl + "browse.php?only=0&hentai=1&incomplete=1&lossless=1&hd=1&multiaudio=1&bonus=1&reorder=1&q=";
+            var searchUrl = Settings.BaseUrl + " browse.php?only=0&incomplete=1&lossless=1&hd=1&multiaudio=1&bonus=1&reorder=1&q=";
+            if (Settings.AdultContent)
+            {
+                searchUrl = Settings.BaseUrl + "browse.php?only=0&hentai=1&incomplete=1&lossless=1&hd=1&multiaudio=1&bonus=1&reorder=1&q=";
+            }
 
             var match = Regex.Match(term, @".*(?=\s(?:[Ee]\d+|\d+)$)");
             if (match.Success)
@@ -440,7 +444,10 @@ namespace NzbDrone.Core.Indexers.Definitions
         [FieldDefinition(5, Label = "Append Season", Type = FieldType.Checkbox, HelpText = "Append Season for Sonarr Compatibility")]
         public bool AppendSeason { get; set; }
 
-        [FieldDefinition(6)]
+        [FieldDefinition(6, Label = "Adult Content", Type = FieldType.Checkbox, HelpText = "Allow Adult Content (Must be enabled in BakaBT settings)")]
+        public bool AdultContent { get; set; }
+
+        [FieldDefinition(7)]
         public IndexerBaseSettings BaseSettings { get; set; } = new IndexerBaseSettings();
 
         public NzbDroneValidationResult Validate()


### PR DESCRIPTION
#### Database Migration
NO?

#### Description
As it stands the base url for BakaBT has &hentai=1
This breaks if a user does not have AdultContent enabled  in their bakabt settings.

Link to conversation in the discord
https://discord.com/channels/767843854736949299/767843854824374281/894437145849266176

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

None