### PR TITLE
Fixed: (Indexer) RevolutionTT Remove [REQ] prefix from torrent title

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/RevolutionTT.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/RevolutionTT.cs
@@ -269,6 +269,12 @@ namespace NzbDrone.Core.Indexers.Definitions
                 var details = _settings.BaseUrl + qDetails.GetAttribute("href");
                 var title = qDetails.QuerySelector("b").TextContent;
 
+                // Remove auto-generated [REQ] tag from fulfilled requests
+                if (title.StartsWith("[REQ] "))
+                {
+                    title = title.Substring(6);
+                }
+
                 var qLink = row.QuerySelector("td:nth-child(4) > a");
                 if (qLink == null)
                 {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
[REQ] is an automatically generated prefix added to the torrent title of a fulfilled request, and often breaks parsing for title matching. This causes it to not be picked up via RSS, and appears to be a mismatch with manual searches.

#### Todos
- [ ] Tests