### PR TITLE
Fix torrentleech tv searches returning unrelated results

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/TorrentLeech.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/TorrentLeech.cs
@@ -89,7 +89,9 @@ namespace NzbDrone.Core.Indexers.Definitions
             {
                 TvSearchParams = new List<TvSearchParam>
                                    {
-                                       TvSearchParam.Q, TvSearchParam.Season, TvSearchParam.Ep, TvSearchParam.ImdbId
+                                       // Torrentleech does technically support ImdbId Search but only with no other params
+                                       // ImdbId + S/E search returns unrelated results
+                                       TvSearchParam.Q, TvSearchParam.Season, TvSearchParam.Ep
                                    },
                 MovieSearchParams = new List<MovieSearchParam>
                                    {
@@ -228,7 +230,7 @@ namespace NzbDrone.Core.Indexers.Definitions
         {
             var pageableRequests = new IndexerPageableRequestChain();
 
-            pageableRequests.Add(GetPagedRequests(string.Format("{0}", searchCriteria.SanitizedTvSearchString), searchCriteria.Categories, searchCriteria.FullImdbId));
+            pageableRequests.Add(GetPagedRequests(string.Format("{0}", searchCriteria.SanitizedTvSearchString), searchCriteria.Categories));
 
             return pageableRequests;
         }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
- Torrentleech does not support additional parameters - like season and episode - if an IMDB/ID search is used.
- This causes garbage and unrelated results for sonarr episode and season searches

Fixed: (TorrentLeech) Drop support for IMDb ID TV Searches
Fixed: (TorrentLeech) Returning unrelated results for Season/Episode Searches

#### Screenshot (if UI related)

#### Todos
- NA Tests
- NA Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- NA [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #474