### PR TITLE
Fixed: (RarBG) Remove Book Category & Support

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/Rarbg/Rarbg.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Rarbg/Rarbg.cs
@@ -59,10 +59,6 @@ namespace NzbDrone.Core.Indexers.Rarbg
                 MusicSearchParams = new List<MusicSearchParam>
                        {
                            MusicSearchParam.Q
-                       },
-                BookSearchParams = new List<BookSearchParam>
-                       {
-                           BookSearchParam.Q
                        }
             };
 
@@ -76,7 +72,6 @@ namespace NzbDrone.Core.Indexers.Rarbg
             caps.Categories.AddCategoryMapping(28, NewznabStandardCategory.PCGames, "Games/PC RIP");
             caps.Categories.AddCategoryMapping(32, NewznabStandardCategory.ConsoleXBox360, "Games/XBOX-360");
             caps.Categories.AddCategoryMapping(33, NewznabStandardCategory.PCISO, "Software/PC ISO");
-            caps.Categories.AddCategoryMapping(35, NewznabStandardCategory.BooksEBook, "e-Books");
             caps.Categories.AddCategoryMapping(40, NewznabStandardCategory.ConsolePS3, "Games/PS3");
             caps.Categories.AddCategoryMapping(41, NewznabStandardCategory.TVHD, "TV HD Episodes");
             caps.Categories.AddCategoryMapping(42, NewznabStandardCategory.MoviesBluRay, "Movies/Full BD");


### PR DESCRIPTION
based on Jackett f018470d6951a496b3d274fdda825c26ae8f6425

#### Database Migration
NO

#### Description
jackett commit
```
rarbg: drop cat 35 ebook #12550
as the rarbg torrent search page no longer list this.
also drop book-search as there are not books anylonger to find.
```
#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX