### PR TITLE
Add a filter bar to the "Add Indexers" modal

### DIFF
--- a/frontend/src/Indexer/Add/AddIndexerModalContent.css
+++ b/frontend/src/Indexer/Add/AddIndexerModalContent.css
@@ -16,7 +16,7 @@
   composes: input from '~Components/Form/TextInput.css';
 
   flex: 0 0 auto;
-  margin-bottom: 20px;
+  margin-bottom: 16px;
 }
 
 .alert {
@@ -27,4 +27,43 @@
 
 .scroller {
   flex: 1 1 auto;
+}
+
+.filterRow {
+  display: flex;
+  margin-bottom: 20px;
+}
+
+.filterContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  flex: 1;
+  margin-right: 12px;
+}
+
+.filterContainer:last-child {
+  margin-right: 0;
+}
+
+.filterLabel {
+  font-weight: bold;
+  margin-bottom: 3px;
+}
+
+@media only screen and (max-width: $breakpointSmall) {
+  .filterRow {
+    flex-direction: column;
+  }
+
+  .filterContainer {
+    margin-right: 0;
+    margin-bottom: 12px;
+  }
+
+  .scroller {
+    margin-left: -30px;
+    margin-right: -30px;
+    margin-bottom: -30px;
+  }
 }

--- a/frontend/src/Indexer/Add/AddIndexerModalContent.css
+++ b/frontend/src/Indexer/Add/AddIndexerModalContent.css
@@ -36,9 +36,9 @@
 
 .filterContainer {
   display: flex;
-  flex-direction: column;
   align-items: stretch;
   flex: 1;
+  flex-direction: column;
   margin-right: 12px;
 }
 
@@ -47,8 +47,8 @@
 }
 
 .filterLabel {
-  font-weight: bold;
   margin-bottom: 3px;
+  font-weight: bold;
 }
 
 @media only screen and (max-width: $breakpointSmall) {
@@ -62,8 +62,8 @@
   }
 
   .scroller {
-    margin-left: -30px;
     margin-right: -30px;
     margin-bottom: -30px;
+    margin-left: -30px;
   }
 }

--- a/frontend/src/Indexer/Add/AddIndexerModalContent.css
+++ b/frontend/src/Indexer/Add/AddIndexerModalContent.css
@@ -52,6 +52,10 @@
 }
 
 @media only screen and (max-width: $breakpointSmall) {
+  .alert {
+    display: none;
+  }
+
   .filterRow {
     flex-direction: column;
   }


### PR DESCRIPTION
**EDIT:** I just noticed #178 existed, this is realistically a duplicate of that.  It looks like that one is further along too so I can close this if its unnecessary.

#### Database Migration
NO

#### Description
This PR adds a filter bar to the "Add Indexer" modal, which gives options for filtering the list by Protocol, Language, and Privacy Level.

This is my first PR to a *arr project, so I'm not sure if my coding style matches the rest of what the project is expecting. I am a React developer by trade, but I haven't used class components in a couple years. If you want to make big changes to how I did this, or just nix it and build this feature up from scratch, by all means go for it. The way I implemented it, the languages and privacy types are just built up from the list of indexers coming back, and I'm not sure if it would be better to pull those lists from the backend directly but .net is a little outside my scope.

So please, tear this apart and I'll try and fix it!

#### Screenshot (if UI related)

![image](https://user-images.githubusercontent.com/9214195/142037699-faafbe8b-1e98-474d-9913-9e15f7934810.png)

![image](https://user-images.githubusercontent.com/9214195/142037782-b9a4ff80-c107-4e93-b9e8-4722fba71cd4.png)

#### Todos
- [ ] Figure out how to fit the filters and table in a mobile layout (perhaps move into the scroller?)
- [ ] Change coding style (component structure and whatnot) to match the rest of the project?

#### Issues Fixed or Closed by this PR

* Closes #94