### PR TITLE
Fixed: (Cardigann) Poster & tmbid are Optional by default

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/Cardigann/CardigannBase.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Cardigann/CardigannBase.cs
@@ -28,7 +28,7 @@ namespace NzbDrone.Core.Indexers.Cardigann
         protected readonly List<CategoryMapping> _categoryMapping = new List<CategoryMapping>();
         protected readonly List<string> _defaultCategories = new List<string>();
 
-        protected readonly string[] OptionalFields = new string[] { "imdb", "imdbid", "rageid", "tvdbid", "banner", "description" };
+        protected readonly string[] OptionalFields = new string[] { "imdb", "imdbid", "rageid", "tmdbid", "tvdbid", "poster", "banner", "description" };
 
         protected static readonly string[] _SupportedLogicFunctions =
         {


### PR DESCRIPTION
missed jackett commit https://github.com/Jackett/Jackett/commit/f5802306fa1fe4edb4c7f997100a6caebe71e989
Fixes #629

#### Database Migration
NO

#### Description
@Qstick 
technically jackett has
`protected readonly string[] OptionalFields = { "imdb", "imdbid", "rageid", "tmdbid", "tvdbid", "poster", "description" };`

we have 
`protected readonly string[] OptionalFields = new string[] { "imdb", "imdbid", "rageid", "tmdbid", "tvdbid", "poster", "banner", "description" };`

should we be in sync or keep our extra for banner?

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX