### PR TITLE
Fixed: (PrivateHD) Drop support for IMDB search

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/PrivateHD.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/PrivateHD.cs
@@ -36,7 +36,7 @@ namespace NzbDrone.Core.Indexers.Definitions
             {
                 TvSearchParams = new List<TvSearchParam>
                        {
-                           TvSearchParam.Q, TvSearchParam.Season, TvSearchParam.Ep, TvSearchParam.ImdbId
+                           TvSearchParam.Q, TvSearchParam.Season, TvSearchParam.Ep
                        },
                 MovieSearchParams = new List<MovieSearchParam>
                        {


### PR DESCRIPTION
imdb search does not support S/E params
this matches the behavior for TorrentLeech
Fixes #119

#### Database Migration
 NO

#### Description
title
#### Screenshot (if UI related)

#### Todos


#### Issues Fixed or Closed by this PR

* Fixes #XXXX