### PR TITLE
Fixed: Support older glibc in libMonoPosixHelper

### DIFF
--- a/src/NzbDrone.Mono.Test/Prowlarr.Mono.Test.csproj
+++ b/src/NzbDrone.Mono.Test/Prowlarr.Mono.Test.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net6.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Mono.Posix.NETStandard" Version="5.20.1.34-servarr17" />
+    <PackageReference Include="Mono.Posix.NETStandard" Version="5.20.1.34-servarr18" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NzbDrone.Common.Test\Prowlarr.Common.Test.csproj" />

--- a/src/NzbDrone.Mono/Prowlarr.Mono.csproj
+++ b/src/NzbDrone.Mono/Prowlarr.Mono.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net6.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Mono.Posix.NETStandard" Version="5.20.1.34-servarr17" />
+    <PackageReference Include="Mono.Posix.NETStandard" Version="5.20.1.34-servarr18" />
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Use libMonoPosixHelper compiled against older glibc

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX