### PR TITLE
Fixed: HDTorrents - remove . from searches

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/HDTorrents.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/HDTorrents.cs
@@ -158,7 +158,7 @@ namespace NzbDrone.Core.Indexers.Definitions
             };
 
             // manually url encode parenthesis to prevent "hacking" detection
-            searchUrl += queryCollection.GetQueryString().Replace("(", "%28").Replace(")", "%29");
+            searchUrl += queryCollection.GetQueryString().Replace("(", "%28").Replace(")", "%29").Replace(".", " ");
 
             var request = new IndexerRequest(searchUrl, HttpAccept.Rss);
 


### PR DESCRIPTION
#### Database Migration
YES - NO

#### Description
Removes period from HDTorrent search strings.

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #687 
* Fixes [AB#2110](https://dev.azure.com/Servarr/7ab38f4e-5a57-4d70-84f4-94dd9bc5d6df/_workitems/edit/2110)