### PR TITLE
New: (FlareSolverr Proxy) Configurable Request Timeout

### DIFF
--- a/src/NzbDrone.Core/IndexerProxies/FlareSolverr/FlareSolverr.cs
+++ b/src/NzbDrone.Core/IndexerProxies/FlareSolverr/FlareSolverr.cs
@@ -113,7 +113,7 @@ namespace NzbDrone.Core.IndexerProxies.FlareSolverr
 
             var url = request.Url.ToString();
             var userAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Safari/537.36";
-            var maxTimeout = 60000;
+            var maxTimeout = Settings.RequestTimeout * 1000;
 
             if (request.Method == HttpMethod.GET)
             {

--- a/src/NzbDrone.Core/IndexerProxies/FlareSolverr/FlareSolverrSettings.cs
+++ b/src/NzbDrone.Core/IndexerProxies/FlareSolverr/FlareSolverrSettings.cs
@@ -1,4 +1,5 @@
 using FluentValidation;
+using NLog.Config;
 using NzbDrone.Core.Annotations;
 using NzbDrone.Core.Validation;
 
@@ -9,6 +10,7 @@ namespace NzbDrone.Core.IndexerProxies.FlareSolverr
         public FlareSolverrSettingsValidator()
         {
             RuleFor(c => c.Host).NotEmpty();
+            RuleFor(c => c.RequestTimeout).InclusiveBetween(1, 180);
         }
     }
 
@@ -19,10 +21,14 @@ namespace NzbDrone.Core.IndexerProxies.FlareSolverr
         public FlareSolverrSettings()
         {
             Host = "http://localhost:8191/";
+            RequestTimeout = 60;
         }
 
         [FieldDefinition(0, Label = "Host")]
         public string Host { get; set; }
+
+        [FieldDefinition(2, Label = "Request Timeout", Advanced = true, HelpText = "FlareSolverr maxTimeout Request Parameter", Unit = "seconds")]
+        public int RequestTimeout { get; set; }
 
         public NzbDroneValidationResult Validate()
         {


### PR DESCRIPTION
Closes #696

#### Database Migration
NO

#### Description
Allows a user configurable timeout value between 1 and 180 seconds for Flaresolverr `maxTimeout` requests parameter

#### Screenshot (if UI related)

#### Todos
- Tests
- Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [X] [Wiki Updates](https://wiki.servarr.com)
  -  https://github.com/Servarr/Wiki/commit/5005a63c5ba92a4700dc74f83cd882d0fb2c80d3

#### Issues Fixed or Closed by this PR

* Fixes #XXXX