### PR TITLE
New: (TvVault) Mark as Obsolete per Site Bot Ban

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/TVVault.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/TVVault.cs
@@ -22,6 +22,7 @@ using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.Definitions
 {
+    [Obsolete("Remove per Site Request Prowlarr Issue 573")]
     public class TVVault : TorrentIndexerBase<TVVaultSettings>
     {
         public override string Name => "TVVault";


### PR DESCRIPTION
Closes #573

#### Database Migration
NO

#### Description
TV Vault does not support scraping

#### Screenshot (if UI related)

#### Todos
- Tests
- Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)
  - https://github.com/Servarr/Wiki/commit/51b60a5eac450a46adf87f51ab186fc5c584d6c3

#### Issues Fixed or Closed by this PR

* Fixes #XXXX