### PR TITLE
Jackett pulls - PornoLab and DanishBytes

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/DanishBytes.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/DanishBytes.cs
@@ -22,7 +22,7 @@ namespace NzbDrone.Core.Indexers.Definitions
     public class DanishBytes : TorrentIndexerBase<DanishBytesSettings>
     {
         public override string Name => "DanishBytes";
-        public override string[] IndexerUrls => new string[] { "https://danishbytes.org/" };
+        public override string[] IndexerUrls => new string[] { "https://danishbytes.club/" };
         public override string Description => "DanishBytes is a Private Danish Tracker";
         public override DownloadProtocol Protocol => DownloadProtocol.Torrent;
         public override IndexerPrivacy Privacy => IndexerPrivacy.Private;

--- a/src/NzbDrone.Core/Indexers/Definitions/PornoLab.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/PornoLab.cs
@@ -142,6 +142,7 @@ namespace NzbDrone.Core.Indexers.Definitions
             caps.Categories.AddCategoryMapping(1836, NewznabStandardCategory.XXX, "Сайтрипы 2019 (HD Video) / SiteRip's 2019 (HD Video)");
             caps.Categories.AddCategoryMapping(1842, NewznabStandardCategory.XXX, "Сайтрипы 2020 (HD Video) / SiteRip's 2020 (HD Video)");
             caps.Categories.AddCategoryMapping(1846, NewznabStandardCategory.XXX, "Сайтрипы 2021 (HD Video) / SiteRip's 2021 (HD Video)");
+            caps.Categories.AddCategoryMapping(1857, NewznabStandardCategory.XXX, "Сайтрипы 2022 (HD Video) / SiteRip's 2022 (HD Video)");
 
             caps.Categories.AddCategoryMapping(1451, NewznabStandardCategory.XXX, "Сайтрипы 1991-2010 / SiteRip's 1991-2010");
             caps.Categories.AddCategoryMapping(1788, NewznabStandardCategory.XXX, "Сайтрипы 2011-2012 / SiteRip's 2011-2012");
@@ -154,6 +155,7 @@ namespace NzbDrone.Core.Indexers.Definitions
             caps.Categories.AddCategoryMapping(1837, NewznabStandardCategory.XXX, "Сайтрипы 2019 / SiteRip's 2019");
             caps.Categories.AddCategoryMapping(1843, NewznabStandardCategory.XXX, "Сайтрипы 2020 / SiteRip's 2020");
             caps.Categories.AddCategoryMapping(1847, NewznabStandardCategory.XXX, "Сайтрипы 2021 / SiteRip's 2021");
+            caps.Categories.AddCategoryMapping(1856, NewznabStandardCategory.XXX, "Сайтрипы 2022 / SiteRip's 2022");
 
             caps.Categories.AddCategoryMapping(1707, NewznabStandardCategory.XXX, "Сцены из фильмов / Movie Scenes");
             caps.Categories.AddCategoryMapping(284, NewznabStandardCategory.XXX, "Порноролики Разное / Clips (various)");


### PR DESCRIPTION
#### Database Migration
NO

#### Description
- Fixed: (DanishBytes) Update Domain to .club
  - Based on Jackett f890ddd119a35eb4ba40b407aa65461c713b5e5d
- Fixed: (PornoLab) Add new 2022 Categories
  - Based on Jackett f61a2b47400e68422ba6620a5ef2f5b4d0a929a3
#### Screenshot (if UI related)

#### Todos
-  Tests
-  Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
-  [Wiki Updates](https://wiki.servarr.com)
-  **We do not have Legacylinks supported for C# indexers it appears; do we need to do anything with the URL change?  DB Migration?  If we add support for Legacylinks for C#, I'll need some guidance for what to do.**

#### Issues Fixed or Closed by this PR
