### PR TITLE
Fixed: (GazelleGames) Parsing Errors

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/GazelleGames.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/GazelleGames.cs
@@ -359,7 +359,7 @@ namespace NzbDrone.Core.Indexers.Definitions
                         DateTime.ParseExact(time, "MMM dd yyyy, HH:mm", CultureInfo.InvariantCulture),
                         DateTimeKind.Unspecified).ToLocalTime();
                     var details = _settings.BaseUrl + qDetailsLink.GetAttribute("href");
-                    var grabs = ParseUtil.CoerceInt(qGrabs.TextContent);
+                    var grabs = ParseUtil.CoerceLong(qGrabs.TextContent);
                     var leechers = ParseUtil.CoerceInt(qLeechers.TextContent);
                     var size = ParseUtil.GetBytes(sizeString);
 


### PR DESCRIPTION
Bump Grabs to long from int to match Jackett

#### Database Migration
 NO

#### Description

#### Screenshot (if UI related)

#### Todos
-  Tests
-  Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #568 
```
2021-12-27 12:18:54.3|Warn|ProwlarrErrorPipeline|Invalid request Validation failed: 
 -- : Query successful, but no results were returned from your indexer. This may be an issue with the indexer or your indexer category settings.
2021-12-27 12:28:54.5|Info|ReleaseSearchService|Searching indexer(s): [GazelleGames] for Term: [mario party], Offset: 0, Limit: 0, Categories: []
2021-12-27 12:28:55.9|Error|GazelleGames|An error occurred while processing indexer feed. https://gazellegames.net/torrents.php?searchstr=mario+party&order_by=time&order_way=desc&action=basic&searchsubmit=1

[v0.1.9.1276] System.OverflowException: Value was either too large or too small for an Int32.
   at System.Number.ThrowOverflowOrFormatException(ParsingStatus status, TypeCode type)
   at NzbDrone.Core.Parser.ParseUtil.CoerceInt(String str) in D:\a\1\s\src\NzbDrone.Core\Parser\ParseUtil.cs:line 42
   at NzbDrone.Core.Indexers.Definitions.GazelleGamesParser.ParseResponse(IndexerResponse indexerResponse) in D:\a\1\s\src\NzbDrone.Core\Indexers\Definitions\GazelleGames.cs:line 361
   at NzbDrone.Core.Indexers.HttpIndexerBase`1.FetchPage(IndexerRequest request, IParseIndexerResponse parser) in D:\a\1\s\src\NzbDrone.Core\Indexers\HttpIndexerBase.cs:line 320
```