### PR TITLE
TorrentSeeds is now using UNIT3D

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/TorrentSeeds.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/TorrentSeeds.cs
@@ -21,6 +21,7 @@ using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.Definitions
 {
+    [Obsolete("Moved to YML for Cardigann v3")]
     public class TorrentSeeds : TorrentIndexerBase<TorrentSeedsSettings>
     {
         public override string Name => "TorrentSeeds";


### PR DESCRIPTION
No need to C# implementation anymore

#### Database Migration
NO

#### Description
Deprecate the TorrentSeeds' C# implementation, now that it uses UNIT3D

#### Issues Fixed or Closed by this PR

* Ref #732