### PR TITLE
Fixed: (AnimeBytes) Do not paginate requests

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/AnimeBytes.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/AnimeBytes.cs
@@ -106,7 +106,37 @@ namespace NzbDrone.Core.Indexers.Definitions
         {
         }
 
-        private IEnumerable<IndexerRequest> GetPagedRequests(string searchType, string term, int[] categories)
+        public IndexerPageableRequestChain GetSearchRequests(MovieSearchCriteria searchCriteria)
+            => GetRequestWithSearchType(searchCriteria, "anime");
+
+        public IndexerPageableRequestChain GetSearchRequests(MusicSearchCriteria searchCriteria)
+            => GetRequestWithSearchType(searchCriteria, "music");
+
+        public IndexerPageableRequestChain GetSearchRequests(TvSearchCriteria searchCriteria)
+            => GetRequestWithSearchType(searchCriteria, "anime");
+
+        public IndexerPageableRequestChain GetSearchRequests(BookSearchCriteria searchCriteria)
+            => GetRequestWithSearchType(searchCriteria, "anime");
+
+        public IndexerPageableRequestChain GetSearchRequests(BasicSearchCriteria searchCriteria)
+            => GetRequestWithSearchType(searchCriteria, "anime");
+
+        private IndexerPageableRequestChain GetRequestWithSearchType(SearchCriteriaBase searchCriteria, string searchType)
+        {
+            var pageableRequests = new IndexerPageableRequestChain();
+
+            // TODO: Remove this once Prowlarr has proper support for non Pageable Indexers and can tell Sonarr that indexer doesn't support pagination in a proper way, for now just return empty release list on all request containing an offset
+            if (searchCriteria.Offset is > 0)
+            {
+                return pageableRequests;
+            }
+
+            pageableRequests.Add(GetRequest(searchType, searchCriteria.SanitizedSearchTerm, searchCriteria.Categories));
+
+            return pageableRequests;
+        }
+
+        private IEnumerable<IndexerRequest> GetRequest(string searchType, string term, int[] categories)
         {
             var searchUrl = string.Format("{0}/scrape.php", Settings.BaseUrl.TrimEnd('/'));
 
@@ -133,51 +163,6 @@ namespace NzbDrone.Core.Indexers.Definitions
             var request = new IndexerRequest(queryUrl, HttpAccept.Json);
 
             yield return request;
-        }
-
-        public IndexerPageableRequestChain GetSearchRequests(MovieSearchCriteria searchCriteria)
-        {
-            var pageableRequests = new IndexerPageableRequestChain();
-
-            pageableRequests.Add(GetPagedRequests("anime", searchCriteria.SanitizedSearchTerm, searchCriteria.Categories));
-
-            return pageableRequests;
-        }
-
-        public IndexerPageableRequestChain GetSearchRequests(MusicSearchCriteria searchCriteria)
-        {
-            var pageableRequests = new IndexerPageableRequestChain();
-
-            pageableRequests.Add(GetPagedRequests("music", searchCriteria.SanitizedSearchTerm, searchCriteria.Categories));
-
-            return pageableRequests;
-        }
-
-        public IndexerPageableRequestChain GetSearchRequests(TvSearchCriteria searchCriteria)
-        {
-            var pageableRequests = new IndexerPageableRequestChain();
-
-            pageableRequests.Add(GetPagedRequests("anime", searchCriteria.SanitizedSearchTerm, searchCriteria.Categories));
-
-            return pageableRequests;
-        }
-
-        public IndexerPageableRequestChain GetSearchRequests(BookSearchCriteria searchCriteria)
-        {
-            var pageableRequests = new IndexerPageableRequestChain();
-
-            pageableRequests.Add(GetPagedRequests("anime", searchCriteria.SanitizedSearchTerm, searchCriteria.Categories));
-
-            return pageableRequests;
-        }
-
-        public IndexerPageableRequestChain GetSearchRequests(BasicSearchCriteria searchCriteria)
-        {
-            var pageableRequests = new IndexerPageableRequestChain();
-
-            pageableRequests.Add(GetPagedRequests("anime", searchCriteria.SanitizedSearchTerm, searchCriteria.Categories));
-
-            return pageableRequests;
         }
 
         public Func<IDictionary<string, string>> GetCookies { get; set; }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
AnimeBytes API does not support pagination, when a *arr now sends a request with an Offset Prowlarr normally would do paginate until it won't return any more results and then the *arr would stop, for AnimeBytes it would continue sending request with different Offsets but we would not include that in the request and always return the same response resulting in a lot of unnecessary requests to there api

This PR changes it so that if Offset in the request is provided and bigger than 0 it will not make an Request to AB but instead just return an empty list so that the *arr thinks Page 2 has no results anymore

In the future Prowlarr should have a mechanism like this build in for other Indexer which do not support pagination too, i've noted that down with a TODO comment above the line explaining why i implemented this.

(I've also renamed GetPagedRequests to GetRequest since well we never did paginated requests in that method)

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

Mentioned on Discord by a User to me