### PR TITLE
Fixed: (SpeedApp) correct categories in query string of requests

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/SpeedApp.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/SpeedApp.cs
@@ -335,7 +335,7 @@ namespace NzbDrone.Core.Indexers.Definitions
                 }
             }
 
-            var searchUrl = Settings.BaseUrl + "/api/torrent?" + qc.GetQueryString();
+            var searchUrl = Settings.BaseUrl + "/api/torrent?" + qc.GetQueryString(duplicateKeysIfMulti: true);
 
             var request = new IndexerRequest(searchUrl, HttpAccept.Json);
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fixes SpeedApp categories in requests by using NameValueCollection#GetQueryString `duplicateKeysIfMulti` parameter when building the query string

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

Mentioned on Discord by a User to me