### PR TITLE
Fixed: (MoreThanTV) use www url to fix cookie/redirect issues

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/MoreThanTV.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/MoreThanTV.cs
@@ -25,7 +25,7 @@ namespace NzbDrone.Core.Indexers.Definitions;
 public class MoreThanTV : TorrentIndexerBase<MoreThanTVSettings>
 {
     public override string Name => "MoreThanTV";
-    public override string[] IndexerUrls => new[] { "https://morethantv.me/" };
+    public override string[] IndexerUrls => new[] { "https://www.morethantv.me/" };
     public override string Description => "Private torrent tracker for TV / MOVIES";
     public override DownloadProtocol Protocol => DownloadProtocol.Torrent;
     public override IndexerPrivacy Privacy => IndexerPrivacy.Private;


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Somehow when using the non www domain it gets redirected which breaks the cookie, unsure exactly why but updating the url to the final redirect fixed the issue for me locally

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

