### PR TITLE
Fixed: Download limit check was using the query limit instead of the …

### DIFF
--- a/src/NzbDrone.Core/Indexers/IndexerLimitService.cs
+++ b/src/NzbDrone.Core/Indexers/IndexerLimitService.cs
@@ -29,7 +29,7 @@ namespace NzbDrone.Core.Indexers
             if (indexer.Id > 0 && ((IIndexerSettings)indexer.Settings).BaseSettings.GrabLimit.HasValue)
             {
                 var grabCount = _historyService.CountSince(indexer.Id, DateTime.Now.AddHours(-24), new List<HistoryEventType> { HistoryEventType.ReleaseGrabbed });
-                var grabLimit = ((IIndexerSettings)indexer.Settings).BaseSettings.QueryLimit;
+                var grabLimit = ((IIndexerSettings)indexer.Settings).BaseSettings.GrabLimit;
 
                 if (grabCount > grabLimit)
                 {


### PR DESCRIPTION
…grab limit.

#### Database Migration
NO

#### Description
The at download limit check was looking at the query limit setting instead of the grab limit setting.

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX