### PR TITLE
Fixed: (Immortalseed) Keywordless Search

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/ImmortalSeed.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/ImmortalSeed.cs
@@ -170,16 +170,21 @@ namespace NzbDrone.Core.Indexers.Definitions
 
         private IEnumerable<IndexerRequest> GetPagedRequests(string term, int[] categories, string imdbId = null)
         {
-            var searchUrl = Settings.BaseUrl + "browse.php";
+            var searchUrl = Settings.BaseUrl + "browse.php?";
 
             if (term.IsNotNullOrWhiteSpace())
             {
-                searchUrl += string.Format("?do=search&keywords={0}&search_type=t_name&category=0&include_dead_torrents=no", WebUtility.UrlEncode(term));
+                searchUrl += string.Format("do=search&keywords={0}&search_type=t_name&category=0&include_dead_torrents=no", WebUtility.UrlEncode(term));
             }
 
             if (categories != null && categories.Length > 0)
             {
-                searchUrl += "&selectedcats2=" + string.Join(",", Capabilities.Categories.MapTorznabCapsToTrackers(categories));
+                if (term.IsNotNullOrWhiteSpace())
+                {
+                     searchUrl += "&";
+                }
+
+                searchUrl += "selectedcats2=" + string.Join(",", Capabilities.Categories.MapTorznabCapsToTrackers(categories));
             }
 
             var request = new IndexerRequest(searchUrl, HttpAccept.Html);


### PR DESCRIPTION
#### Database Migration
 NO

#### Description

fixes discord report of current URL being 404 if search term is empty 

https://discord.com/channels/767843854736949299/767843854824374281/937155386664955946

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX