### PR TITLE
Fixed: (Cardigann) Requests Failing for Definitions without LegacyLinks

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/Cardigann/CardigannBase.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Cardigann/CardigannBase.cs
@@ -827,7 +827,7 @@ namespace NzbDrone.Core.Indexers.Cardigann
                 return defaultLink;
             }
 
-            if (_definition.Legacylinks.Contains(settingsBaseUrl))
+            if (_definition?.Legacylinks?.Contains(settingsBaseUrl) ?? false)
             {
                 _logger.Trace("Changing legacy site link from {0} to {1}", settingsBaseUrl, defaultLink);
                 return defaultLink;


### PR DESCRIPTION
#### Database Migration
NO

#### Description
- fixes nullref error if users have a cardigann url selected and there are no legacy links
- tested, works

#### Screenshot (if UI related)

#### Todos
- Tests
- Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX