### PR TITLE
Set version header to X-Application-Version (missing hyphen)

### DIFF
--- a/src/Prowlarr.Http/Middleware/VersionMiddleware.cs
+++ b/src/Prowlarr.Http/Middleware/VersionMiddleware.cs
@@ -6,7 +6,7 @@ namespace Prowlarr.Http.Middleware
 {
     public class VersionMiddleware
     {
-        private const string VERSIONHEADER = "X-ApplicationVersion";
+        private const string VERSIONHEADER = "X-Application-Version";
 
         private readonly RequestDelegate _next;
         private readonly string _version;


### PR DESCRIPTION
#### Database Migration

NO

#### Description

Not sure if this is intentional or really harms anything but to be consistent with other Arr apps like Sonarr and Radarr, this changes the version header to X-Application-Version.