### PR TITLE
Fixed: (Cardigann) Add support for Cardigann path for attribute (UNIT3D)

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/Cardigann/CardigannParser.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Cardigann/CardigannParser.cs
@@ -91,8 +91,8 @@ namespace NzbDrone.Core.Indexers.Cardigann
 
                 foreach (var row in rowsObj.Value<JArray>())
                 {
-                    var selObj = request.SearchPath.Response.Attribute != null ? row.SelectToken(request.SearchPath.Response.Attribute).Value<JToken>() : row;
-                    var mulRows = request.SearchPath.Response.Multiple == true ? selObj.Values<JObject>() : new List<JObject> { selObj.Value<JObject>() };
+                    var selObj = request.Attributes != null ? row.SelectToken(request.Attributes).Value<JToken>() : row;
+                    var mulRows = request.SearchPath.Response.Multiple ? selObj.Values<JObject>() : new List<JObject> { selObj.Value<JObject>() };
 
                     foreach (var mulRow in mulRows)
                     {

--- a/src/NzbDrone.Core/Indexers/Definitions/Cardigann/CardigannRequest.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Cardigann/CardigannRequest.cs
@@ -8,18 +8,22 @@ namespace NzbDrone.Core.Indexers.Cardigann
         public Dictionary<string, object> Variables { get; private set; }
         public SearchPathBlock SearchPath { get; private set; }
 
-        public CardigannRequest(string url, HttpAccept httpAccept, Dictionary<string, object> variables, SearchPathBlock searchPath)
+        public string Attributes { get; set; }
+
+        public CardigannRequest(string url, HttpAccept httpAccept, Dictionary<string, object> variables, SearchPathBlock searchPath, string attributes)
             : base(url, httpAccept)
         {
             Variables = variables;
             SearchPath = searchPath;
+            Attributes = attributes;
         }
 
-        public CardigannRequest(HttpRequest httpRequest, Dictionary<string, object> variables, SearchPathBlock searchPath)
+        public CardigannRequest(HttpRequest httpRequest, Dictionary<string, object> variables, SearchPathBlock searchPath, string attributes)
             : base(httpRequest)
         {
             Variables = variables;
             SearchPath = searchPath;
+            Attributes = attributes;
         }
     }
 }

--- a/src/NzbDrone.Core/Indexers/Definitions/Cardigann/CardigannRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Cardigann/CardigannRequestGenerator.cs
@@ -1106,7 +1106,7 @@ namespace NzbDrone.Core.Indexers.Cardigann
                     requestbuilder.SetHeaders(headers ?? new Dictionary<string, string>());
                 }
 
-                var request = new CardigannRequest(requestbuilder.SetEncoding(_encoding).Build(), variables, searchPath);
+                var request = new CardigannRequest(requestbuilder.SetEncoding(_encoding).Build(), variables, searchPath, searchPath.Response.Attribute ?? search.Rows.Attribute);
 
                 yield return request;
             }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This fixes a bug which was introduced with a breaking change of definitions here https://github.com/Prowlarr/Indexers/commit/6c2070d49de474c542ef31c9108151f1302a23ce the Cardigann Parser wasn't updated for, this adds non breaking support for this new place of Attribute

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

Issue was mentioned to me in Discord
* Closes https://github.com/Prowlarr/Prowlarr/pull/851