### PR TITLE
Jackett Pulls Anthelion and HDSpace

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/Anthelion.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Anthelion.cs
@@ -148,7 +148,7 @@ namespace NzbDrone.Core.Indexers.Definitions
                 { "order_way", "desc" },
                 { "action", "basic" },
                 { "searchsubmit", "1" },
-                { "searchstr", imdbId.IsNotNullOrWhiteSpace() ? imdbId : term }
+                { "searchstr", imdbId.IsNotNullOrWhiteSpace() ? imdbId : term.Replace(".", " ") }
             };
 
             var catList = Capabilities.Categories.MapTorznabCapsToTrackers(categories);

--- a/src/NzbDrone.Core/Indexers/Definitions/Gazelle/GazelleRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Gazelle/GazelleRequestGenerator.cs
@@ -53,7 +53,7 @@ namespace NzbDrone.Core.Indexers.Gazelle
 
             if (!string.IsNullOrWhiteSpace(searchString))
             {
-                parameters += string.Format("&searchstr={0}", searchString);
+                parameters += string.Format("&searchstr={0}", searchString.Replace(".", " "));
             }
 
             if (categories != null)

--- a/src/NzbDrone.Core/Indexers/Definitions/HDSpace.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/HDSpace.cs
@@ -171,7 +171,7 @@ namespace NzbDrone.Core.Indexers.Definitions
             else
             {
                 queryCollection.Add("options", "0");
-                queryCollection.Add("search", term);
+                queryCollection.Add("search", term.Replace(".", " "));
             }
 
             searchUrl += queryCollection.GetQueryString();


### PR DESCRIPTION
based on jackett 22efff93e7f1df858b341b3c2756d8204cae6f4a

#### Database Migration
NO

#### Description
Fixed: (Anthelion) Replace Periods for Space in Search Term

based on jackett 22efff93e7f1df858b341b3c2756d8204cae6f4a
Fixed: (HDSpace) Replace Periods for Space in Search Term

based on jackett 22efff93e7f1df858b341b3c2756d8204cae6f4a
Fixed: (Gazelle) Replace Periods for Space in Search Term

based on Jackett b8b816f953ad9d0508f95a9c31f9ff4385ebdd73
#### Screenshot (if UI related)

#### Todos
- Tests
- Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX