### PR TITLE
Add RuTracker.org mirror rutracker.net

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/RuTracker.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/RuTracker.cs
@@ -25,7 +25,7 @@ namespace NzbDrone.Core.Indexers.Definitions
     public class RuTracker : TorrentIndexerBase<RuTrackerSettings>
     {
         public override string Name => "RuTracker";
-        public override string[] IndexerUrls => new string[] { "https://rutracker.org/" };
+        public override string[] IndexerUrls => new string[] { "https://rutracker.org/", "https://rutracker.net/" };
 
         private string LoginUrl => Settings.BaseUrl + "forum/login.php";
         public override string Description => "RuTracker is a Semi-Private Russian torrent site with a thriving file-sharing community";


### PR DESCRIPTION
#### Database Migration
NO

#### Description
The main rutracker.org is down at the time of writing. I am adding the official mirror rutracker.net, which is still up.

#### Screenshot (if UI related)
N/A

#### Todos
N/A

#### Issues Fixed or Closed by this PR
N/A