### PR TITLE
indexer(xthor): moved to YAML definition v5

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/Xthor/Xthor.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Xthor/Xthor.cs
@@ -8,6 +8,7 @@ using NzbDrone.Core.Messaging.Events;
 
 namespace NzbDrone.Core.Indexers.Definitions.Xthor
 {
+    [Obsolete("Moved to YML for Cardigann v5")]
     public class Xthor : TorrentIndexerBase<XthorSettings>
     {
         public override string Name => "Xthor";


### PR DESCRIPTION
#### Database Migration
**NO**

#### Description
Moved C# definition to Cardigan YAML v5 definition (https://github.com/Prowlarr/Indexers/pull/107)