### PR TITLE
Fixed: (BHD) TMDb Parsing Exception

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/BeyondHD.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/BeyondHD.cs
@@ -218,7 +218,7 @@ namespace NzbDrone.Core.Indexers.Definitions
                     Grabs = row.Grabs,
                     Seeders = row.Seeders,
                     ImdbId = ParseUtil.GetImdbID(row.ImdbId).GetValueOrDefault(),
-                    TmdbId = row.TmdbId.IsNullOrWhiteSpace() ? 0 : ParseUtil.CoerceInt(row.TmdbId.Split("/")[1]),
+                    TmdbId = row.TmdbId.IsNullOrWhiteSpace() ? 0 : (int)ParseUtil.CoerceLong(row.TmdbId.Split("/")[1]),
                     Peers = row.Leechers + row.Seeders,
                     DownloadVolumeFactor = row.Freeleech || row.Limited ? 0 : row.Promo75 ? 0.25 : row.Promo50 ? 0.5 : row.Promo25 ? 0.75 : 1,
                     UploadVolumeFactor = 1,


### PR DESCRIPTION
#### Database Migration
NO

#### Description
- Changes logic to match cardigann for parsing tmdbid as long
- Fixes the below error reported in Discord.

```
2022-04-03 11:21:13.2|Warn|BeyondHD|Unable to connect to indexer
 
[v0.2.0.1448] System.OverflowException: Value was either too large or too small for an Int32.
   at System.Number.ThrowOverflowOrFormatException(ParsingStatus status, TypeCode type)
   at NzbDrone.Core.Parser.ParseUtil.CoerceInt(String str) in D:\a\1\s\src\NzbDrone.Core\Parser\ParseUtil.cs:line 54
   at NzbDrone.Core.Indexers.Definitions.BeyondHDParser.ParseResponse(IndexerResponse indexerResponse) in D:\a\1\s\src\NzbDrone.Core\Indexers\Definitions\BeyondHD.cs:line 203
   at NzbDrone.Core.Indexers.HttpIndexerBase`1.FetchPage(IndexerRequest request, IParseIndexerResponse parser) in D:\a\1\s\src\NzbDrone.Core\Indexers\HttpIndexerBase.cs:line 301
   at NzbDrone.Core.Indexers.HttpIndexerBase`1.TestConnection() in D:\a\1\s\src\NzbDrone.Core\Indexers\HttpIndexerBase.cs:line 456
[...]
```

Refer to other comment; very long tmdbs are

`movie\/3056011961`
`tv\/12669814169816`
`movie\/3056011961`
`tv\/12669814169816`

#### Screenshot (if UI related)

#### Todos
- Tests
- Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX