### PR TITLE
Fixed: (Orpheus) Drop Book Support due to invalid Responses

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/Orpheus.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Orpheus.cs
@@ -26,20 +26,16 @@ namespace NzbDrone.Core.Indexers.Definitions
                 MusicSearchParams = new List<MusicSearchParam>
                        {
                            MusicSearchParam.Q, MusicSearchParam.Album, MusicSearchParam.Artist, MusicSearchParam.Label, MusicSearchParam.Year
-                       },
-                BookSearchParams = new List<BookSearchParam>
-                       {
-                           BookSearchParam.Q
                        }
+
+            // Removed Book Categories (3 and 7) and dropped book search support due to Prowlarr GHI #773 and Orpheus returning invalid dates in books.
             };
 
             caps.Categories.AddCategoryMapping(1, NewznabStandardCategory.Audio, "Music");
             caps.Categories.AddCategoryMapping(2, NewznabStandardCategory.PC, "Applications");
-            caps.Categories.AddCategoryMapping(3, NewznabStandardCategory.Books, "E-Books");
             caps.Categories.AddCategoryMapping(4, NewznabStandardCategory.AudioAudiobook, "Audiobooks");
             caps.Categories.AddCategoryMapping(5, NewznabStandardCategory.Other, "E-Learning Videos");
             caps.Categories.AddCategoryMapping(6, NewznabStandardCategory.Other, "Comedy");
-            caps.Categories.AddCategoryMapping(7, NewznabStandardCategory.Books, "Comics");
 
             return caps;
         }


### PR DESCRIPTION
#### Database Migration
NO

#### Description

drops book support for Orpheus to work around invalid - non gazelle standard - responses.
Orpheus has yet to indicate if their non-standard changes are intentional or not.

#### Screenshot (if UI related)

#### Todos
- Tests
- Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #773
