### PR TITLE
Stats : diversify chartcolors for doughnut & stackedbar

### DIFF
--- a/frontend/src/Components/Chart/DoughnutChart.js
+++ b/frontend/src/Components/Chart/DoughnutChart.js
@@ -29,7 +29,7 @@ class DoughnutChart extends Component {
         datasets: [{
           label: this.props.title,
           data: this.props.data.map((d) => d.value),
-          backgroundColor: colors.chartColors
+          backgroundColor: colors.chartColorsDiversified
         }]
       }
     });

--- a/frontend/src/Components/Chart/StackedBarChart.js
+++ b/frontend/src/Components/Chart/StackedBarChart.js
@@ -41,7 +41,7 @@ class StackedBarChart extends Component {
           return {
             label: d.label,
             data: d.data,
-            backgroundColor: colors.chartColors[index]
+            backgroundColor: colors.chartColorsDiversified[index]
           };
         })
       }
@@ -54,7 +54,7 @@ class StackedBarChart extends Component {
       return {
         label: d.label,
         data: d.data,
-        backgroundColor: colors.chartColors[index]
+        backgroundColor: colors.chartColorsDiversified[index]
       };
     });
     this.myChart.update();

--- a/frontend/src/Styles/Variables/colors.js
+++ b/frontend/src/Styles/Variables/colors.js
@@ -187,5 +187,6 @@ module.exports = {
   // Charts
 
   failedColors: ['#ffbeb2', '#feb4a6', '#fdab9b', '#fca290', '#fb9984', '#fa8f79', '#f9856e', '#f77b66', '#f5715d', '#f36754', '#f05c4d', '#ec5049', '#e74545', '#e13b42', '#da323f', '#d3293d', '#ca223c', '#c11a3b', '#b8163a', '#ae123a'],
+  chartColorsDiversified: ['#90caf9', '#f4d166', '#ff8a65', '#ce93d8', '#80cba9', '#ffab91', '#8097ea', '#bcaaa4', '#a57583', '#e4e498', '#9e96af', '#c6ab81', '#6972c6', '#619fc6', '#81ad81', '#f48fb1', '#82afca', '#b5b071', '#8b959b', '#7ec0b4'],
   chartColors: ['#f4d166', '#f6c760', '#f8bc58', '#f8b252', '#f7a84a', '#f69e41', '#f49538', '#f38b2f', '#f28026', '#f0751e', '#eb6c1c', '#e4641e', '#de5d1f', '#d75521', '#cf4f22', '#c64a22', '#bc4623', '#b24223', '#a83e24', '#9e3a26']
 };


### PR DESCRIPTION
#### Database Migration
NO

#### Description

On the Stats page, doughnut charts and stackedbar charts are currently unreadable because of the almost same yellow color for all items.
This PR brings a full range of differents colors for the items of those kind of charts.

![image](https://user-images.githubusercontent.com/10365746/168435207-b5543449-f484-403b-937d-a6e5b47b6186.png)

Bar charts are not changed, they remain yellow with all bars the same color (maybe differents colors could be added in the futur when the order of items will be identical in all bar charts).

#### Issue improved by this PR (but not totally fixed yet)
#232 