### PR TITLE
Update AltHub API URL

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/Newznab/Newznab.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Newznab/Newznab.cs
@@ -90,7 +90,7 @@ namespace NzbDrone.Core.Indexers.Newznab
             get
             {
                 yield return GetDefinition("abNZB", GetSettings("https://abnzb.com"));
-                yield return GetDefinition("altHUB", GetSettings("https://althub.co.za"));
+                yield return GetDefinition("altHUB", GetSettings("https://api.althub.co.za"));
                 yield return GetDefinition("AnimeTosho (Usenet)", GetSettings("https://feed.animetosho.org"));
                 yield return GetDefinition("DOGnzb", GetSettings("https://api.dognzb.cr"));
                 yield return GetDefinition("DrunkenSlug", GetSettings("https://drunkenslug.com"));


### PR DESCRIPTION
#### Database Migration
NO

#### Description
The AltHub NZB indexer recently underwent some changes.  The existing URL returns a 403 error.
This commit updates the URL definition.

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX