### PR TITLE
Let Prowlarr use TvdbIds when searching for tv releases on TorrentSyndikat

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/TorrentSyndikat.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/TorrentSyndikat.cs
@@ -51,7 +51,7 @@ namespace NzbDrone.Core.Indexers.Definitions
             {
                 TvSearchParams = new List<TvSearchParam>
                                    {
-                                       TvSearchParam.Q, TvSearchParam.Season, TvSearchParam.Ep
+                                       TvSearchParam.Q, TvSearchParam.Season, TvSearchParam.Ep, TvSearchParam.TvdbId
                                    },
                 MovieSearchParams = new List<MovieSearchParam>
                                    {
@@ -125,7 +125,7 @@ namespace NzbDrone.Core.Indexers.Definitions
         {
         }
 
-        private IEnumerable<IndexerRequest> GetPagedRequests(string term, int[] categories, string imdbId = null)
+        private IEnumerable<IndexerRequest> GetPagedRequests(string term, int[] categories, string imdbId = null, int? tvdbId =  null)
         {
             var searchString = term;
             var queryCollection = new NameValueCollection { { "apikey", Settings.ApiKey } };
@@ -140,6 +140,10 @@ namespace NzbDrone.Core.Indexers.Definitions
             if (imdbId != null)
             {
                 queryCollection.Add("imdbId", imdbId);
+            }
+            else if (tvdbId != null)
+            {
+                queryCollection.Add("tvdbId", string.Format("{0}", tvdbId));
             }
             else if (!string.IsNullOrWhiteSpace(searchString))
             {
@@ -184,7 +188,7 @@ namespace NzbDrone.Core.Indexers.Definitions
         {
             var pageableRequests = new IndexerPageableRequestChain();
 
-            pageableRequests.Add(GetPagedRequests(string.Format("{0}", searchCriteria.SanitizedTvSearchString), searchCriteria.Categories, searchCriteria.ImdbId));
+            pageableRequests.Add(GetPagedRequests(searchCriteria.TvdbId != null ? null : string.Format("{0}", searchCriteria.SanitizedSearchTerm), searchCriteria.Categories, searchCriteria.ImdbId, searchCriteria.TvdbId));
 
             return pageableRequests;
         }

--- a/src/NzbDrone.Core/Indexers/Definitions/TorrentSyndikat.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/TorrentSyndikat.cs
@@ -188,7 +188,7 @@ namespace NzbDrone.Core.Indexers.Definitions
         {
             var pageableRequests = new IndexerPageableRequestChain();
 
-            pageableRequests.Add(GetPagedRequests(string.Format("{0}", searchCriteria.SanitizedSearchTerm), searchCriteria.Categories, searchCriteria.ImdbId, searchCriteria.TvdbId));
+            pageableRequests.Add(GetPagedRequests(string.Format("{0}", searchCriteria.SanitizedTvSearchString), searchCriteria.Categories, searchCriteria.ImdbId, searchCriteria.TvdbId));
 
             return pageableRequests;
         }

--- a/src/NzbDrone.Core/Indexers/Definitions/TorrentSyndikat.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/TorrentSyndikat.cs
@@ -355,7 +355,7 @@ namespace NzbDrone.Core.Indexers.Definitions
         public IEnumerable<int> ReleaseTypes { get; set; }
 
         [FieldDefinition(5, Label = "Prefer TVDBId", Type = FieldType.Checkbox,  HelpText = "Only Search TVDBId and ignore Season/Episode parameters")]
-        public bool PreferTvDbId { get; set; }
+        public bool PreferTVDBId { get; set; }
 
         public override NzbDroneValidationResult Validate()
         {

--- a/src/NzbDrone.Core/Indexers/Definitions/TorrentSyndikat.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/TorrentSyndikat.cs
@@ -354,7 +354,7 @@ namespace NzbDrone.Core.Indexers.Definitions
         [FieldDefinition(4, Label = "Release Types", Type = FieldType.Select, SelectOptions = typeof(TorrentSyndikatReleaseTypes))]
         public IEnumerable<int> ReleaseTypes { get; set; }
 
-        [FieldDefinition(5, Label = "Prefer TvDbIds", Type = FieldType.Checkbox,  HelpText = "When TvDbId is set the searchstring gets omitted")]
+        [FieldDefinition(5, Label = "Prefer TVDBId", Type = FieldType.Checkbox,  HelpText = "Only Search TVDBId and ignore Season/Episode parameters")]
         public bool PreferTvDbId { get; set; }
 
         public override NzbDroneValidationResult Validate()

--- a/src/NzbDrone.Core/Indexers/Definitions/TorrentSyndikat.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/TorrentSyndikat.cs
@@ -145,12 +145,15 @@ namespace NzbDrone.Core.Indexers.Definitions
             {
                 queryCollection.Add("tvdbId", string.Format("{0}", tvdbId));
             }
-            else if (!string.IsNullOrWhiteSpace(searchString))
+            else
             {
-                // Suffix the first occurence of `s01` surrounded by whitespace with *
-                // That way we also search for single episodes in a whole season search
-                var regex = new Regex(@"(^|\s)(s\d{2})(\s|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-                queryCollection.Add("searchstring", regex.Replace(searchString.Trim(), @"$1$2*$3"));
+                if (!string.IsNullOrWhiteSpace(searchString))
+                {
+                    // Suffix the first occurence of `s01` surrounded by whitespace with *
+                    // That way we also search for single episodes in a whole season search
+                    var regex = new Regex(@"(^|\s)(s\d{2})(\s|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+                    queryCollection.Add("searchstring", regex.Replace(searchString.Trim(), @"$1$2*$3"));
+                }
             }
 
             var cats = string.Join(",", Capabilities.Categories.MapTorznabCapsToTrackers(categories));


### PR DESCRIPTION
Let Prowlarr use TorrentSyndikat API with TVDbIds

If theres a tvdbid the searchterm is omitted

#### Database Migration
NO

#### Description
These changes allow Prowlarr to use TVDB-IDs when search with the Torrent-Syndikat Indexer

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)