### PR TITLE
Fixed: (GreatPosterWall) move imdb id search to searchstr query param

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/Gazelle/GazelleRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Gazelle/GazelleRequestGenerator.cs
@@ -32,14 +32,9 @@ namespace NzbDrone.Core.Indexers.Gazelle
 
         protected IEnumerable<IndexerRequest> GetRequest(string searchParameters)
         {
-            var filter = "";
-            if (searchParameters == null)
-            {
-            }
-
             var request =
                 new IndexerRequest(
-                    $"{APIUrl}?{searchParameters}{filter}",
+                    $"{APIUrl}?{searchParameters}",
                     HttpAccept.Json);
 
             yield return request;

--- a/src/NzbDrone.Core/Indexers/Definitions/Gazelle/GazelleRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Gazelle/GazelleRequestGenerator.cs
@@ -30,7 +30,7 @@ namespace NzbDrone.Core.Indexers.Gazelle
             return pageableRequests;
         }
 
-        private IEnumerable<IndexerRequest> GetRequest(string searchParameters)
+        protected IEnumerable<IndexerRequest> GetRequest(string searchParameters)
         {
             var filter = "";
             if (searchParameters == null)
@@ -45,7 +45,7 @@ namespace NzbDrone.Core.Indexers.Gazelle
             yield return request;
         }
 
-        private string GetBasicSearchParameters(string searchTerm, int[] categories)
+        protected string GetBasicSearchParameters(string searchTerm, int[] categories)
         {
             var searchString = GetSearchTerm(searchTerm);
 

--- a/src/NzbDrone.Core/Indexers/Definitions/GreatPosterWall.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/GreatPosterWall.cs
@@ -8,6 +8,7 @@ using NzbDrone.Common.Http;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Indexers.Exceptions;
 using NzbDrone.Core.Indexers.Gazelle;
+using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Messaging.Events;
 using NzbDrone.Core.Parser;
 using NzbDrone.Core.Parser.Model;
@@ -61,6 +62,20 @@ public class GreatPosterWall : Gazelle.Gazelle
 public class GreatPosterWallRequestGenerator : GazelleRequestGenerator
 {
     protected override bool ImdbInTags => false;
+
+    public new IndexerPageableRequestChain GetSearchRequests(MovieSearchCriteria searchCriteria)
+    {
+        var parameters = GetBasicSearchParameters(searchCriteria.SearchTerm, searchCriteria.Categories);
+
+        if (searchCriteria.ImdbId != null)
+        {
+            parameters += string.Format("&searchstr={0}", searchCriteria.FullImdbId);
+        }
+
+        var pageableRequests = new IndexerPageableRequestChain();
+        pageableRequests.Add(GetRequest(parameters));
+        return pageableRequests;
+    }
 }
 
 public class GreatPosterWallParser : GazelleParser


### PR DESCRIPTION
#### Database Migration
NO

#### Description
The default Gazelle implementation uses the `cataloguenumber` query parameter for imdb id searches which GPW doesn't support so if you use Prowlarr in combination with Radarr as example it would return useless results as GPW ignores that query parameter, i've made the gazelle methods protected so that i could override the request generator method for GPW in specific (also removed unused code still in gazelles default request generator)

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

Fixes issues brought up to me on Discord