### PR TITLE
New: Return 429 for Query and Grab Limits

### DIFF
--- a/src/Prowlarr.Api.V1/Indexers/NewznabController.cs
+++ b/src/Prowlarr.Api.V1/Indexers/NewznabController.cs
@@ -131,7 +131,7 @@ namespace NzbDrone.Api.V1.Indexers
             //TODO Optimize this so it's not called here and in NzbSearchService (for manual search)
             if (_indexerLimitService.AtQueryLimit(indexerDef))
             {
-                return Content(CreateErrorXML(500, $"Request limit reached ({((IIndexerSettings)indexer.Definition.Settings).BaseSettings.QueryLimit})"), "application/rss+xml");
+                return Content(CreateErrorXML(429, $"Request limit reached ({((IIndexerSettings)indexer.Definition.Settings).BaseSettings.QueryLimit})"), "application/rss+xml");
             }
 
             switch (requestType)
@@ -171,7 +171,7 @@ namespace NzbDrone.Api.V1.Indexers
 
             if (_indexerLimitService.AtDownloadLimit(indexerDef))
             {
-                throw new BadRequestException("Grab limit reached");
+                return Content(CreateErrorXML(429, $"Grab limit reached ({((IIndexerSettings)indexer.Definition.Settings).BaseSettings.DownloadLimit})"), "application/rss+xml");
             }
 
             if (link.IsNullOrWhiteSpace() || file.IsNullOrWhiteSpace())


### PR DESCRIPTION
#### Database Migration
NO

#### Description

respond with 429 rate limit reached if the grab or query limit is met. This should improve backoff handling for downstream usage.

https://github.com/cross-seed/cross-seed/issues/327

#### Screenshot (if UI related)

#### Todos
- Tests
- Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
-  [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX