### PR TITLE
Fixed: (AnimeBytes) add delimiter to episode release

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/AnimeBytes.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/AnimeBytes.cs
@@ -321,9 +321,10 @@ namespace NzbDrone.Core.Indexers.Definitions
 
                         if (episode != null)
                         {
-                            releaseInfo = episode is > 0 and < 10
+                            var episodeString = episode is > 0 and < 10
                                 ? "0" + episode
                                 : episode.ToString();
+                            releaseInfo = $" - {episodeString}";
                         }
                         else
                         {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This is a non breaking PR and only fixes compatibility with shows such as `Mob Psycho 100`

Example Current: `[SubsPlease] Mob Psycho 100 III 01 [Web][MKV][h264][1080p][AAC 2.0][Softsubs (SubsPlease)]`
Example New: `[SubsPlease] Mob Psycho 100 III - 01 [Web][MKV][h264][1080p][AAC 2.0][Softsubs (SubsPlease)]`

This fixes issues with Shows having numbers in there name but no delimiter of episodes so that Sonarr would parse the first number in the name which is the Shows name and not the episode and thus never grab valid releases

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

Issue was brought up to me on Discord