### PR TITLE
Removed suspicious URL in the default definitions

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/Torznab/Torznab.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Torznab/Torznab.cs
@@ -89,7 +89,6 @@ namespace NzbDrone.Core.Indexers.Torznab
             get
             {
                 yield return GetDefinition("AnimeTosho", GetSettings("https://feed.animetosho.org"));
-                yield return GetDefinition("HD4Free.xyz", GetSettings("http://hd4free.xyz"));
                 yield return GetDefinition("Generic Torznab", GetSettings(""));
             }
         }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Removed suspicious URL from the code. Looks like the site that was originally there doesn't exist anymore and it's hosting malware (HD4Free.xyz).

#### Screenshot (if UI related)
none

#### Todos
- none

#### Issues Fixed or Closed by this PR
