### PR TITLE
Rarbg Rate Limiting

### DIFF
--- a/src/NzbDrone.Common/Http/TooManyRequestsException.cs
+++ b/src/NzbDrone.Common/Http/TooManyRequestsException.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace NzbDrone.Common.Http
 {
@@ -24,6 +24,12 @@ namespace NzbDrone.Common.Http
                     RetryAfter = date.ToUniversalTime() - DateTime.UtcNow;
                 }
             }
+        }
+
+        public TooManyRequestsException(HttpRequest request, HttpResponse response, TimeSpan retryWait)
+            : base(request, response)
+        {
+            RetryAfter = retryWait;
         }
     }
 }

--- a/src/NzbDrone.Core/Indexers/Definitions/Rarbg/RarbgParser.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Rarbg/RarbgParser.cs
@@ -23,19 +23,31 @@ namespace NzbDrone.Core.Indexers.Rarbg
         public IList<ReleaseInfo> ParseResponse(IndexerResponse indexerResponse)
         {
             var results = new List<ReleaseInfo>();
+            var retryTime = TimeSpan.FromMinutes(1);
+            var responseCode = (int)indexerResponse.HttpResponse.StatusCode;
 
-            switch (indexerResponse.HttpResponse.StatusCode)
+            switch (responseCode)
             {
-                default:
-                    if (indexerResponse.HttpResponse.StatusCode != HttpStatusCode.OK)
-                    {
-                        throw new IndexerException(indexerResponse, "Indexer API call returned an unexpected StatusCode [{0}]", indexerResponse.HttpResponse.StatusCode);
-                    }
-
+                case (int)HttpStatusCode.TooManyRequests:
+                    retryTime = TimeSpan.FromMinutes(2);
+                    throw new TooManyRequestsException(indexerResponse.HttpRequest, indexerResponse.HttpResponse, retryTime);
+                case 520:
+                    retryTime = TimeSpan.FromMinutes(3);
+                    throw new TooManyRequestsException(indexerResponse.HttpRequest, indexerResponse.HttpResponse, retryTime);
+                case (int)HttpStatusCode.OK:
+                    retryTime = TimeSpan.FromMinutes(5);
                     break;
+                default:
+                    throw new IndexerException(indexerResponse, "Indexer API call returned an unexpected StatusCode [{0}]", responseCode);
             }
 
             var jsonResponse = new HttpResponse<RarbgResponse>(indexerResponse.HttpResponse);
+
+            // Handle 200 Rate Limiting
+            if (jsonResponse.Resource.rate_limit == 1)
+            {
+                throw new TooManyRequestsException(indexerResponse.HttpRequest, indexerResponse.HttpResponse, retryTime);
+            }
 
             if (jsonResponse.Resource.error_code.HasValue)
             {


### PR DESCRIPTION
#### Database Migration
NO

#### Description

- (Core) Add variable retryWait to TooManyRequestsException
- (Rarbg) don't try paging if rate_limit is populated
- (Rarbg) increase sleep from 2s to 4s
- (Rarbg) Treat 429 as TooManyRequests - backoff for 2 minutes
- (Rarbg) Treat 520 as TooManyRequests - backoff for 3 minutes
- (Rarbg) Treat 200 with rate_limt of 1 as TooManyRequests  - backoff for 5 minutes

@rarbg is this accurate as you expect?

#### Screenshot (if UI related)

#### Todos
- Tests
- Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #1169