### PR TITLE
Log Skipped Application-Indexer Syncs at trace for support

### DIFF
--- a/src/NzbDrone.Core/Applications/LazyLibrarian/LazyLibrarian.cs
+++ b/src/NzbDrone.Core/Applications/LazyLibrarian/LazyLibrarian.cs
@@ -74,6 +74,8 @@ namespace NzbDrone.Core.Applications.LazyLibrarian
                 var remoteIndexer = _lazyLibrarianV1Proxy.AddIndexer(lazyLibrarianIndexer, Settings);
                 _appIndexerMapService.Insert(new AppIndexerMap { AppId = Definition.Id, IndexerId = indexer.Id, RemoteIndexerName = $"{remoteIndexer.Type},{remoteIndexer.Name}" });
             }
+
+            _logger.Trace("Skipping add for indexer {0} [{1}] due to no app Sync Categories supported by the indexer", indexer.Name, indexer.Id);
         }
 
         public override void RemoveIndexer(int indexerId)

--- a/src/NzbDrone.Core/Applications/Lidarr/Lidarr.cs
+++ b/src/NzbDrone.Core/Applications/Lidarr/Lidarr.cs
@@ -91,6 +91,8 @@ namespace NzbDrone.Core.Applications.Lidarr
                 var remoteIndexer = _lidarrV1Proxy.AddIndexer(lidarrIndexer, Settings);
                 _appIndexerMapService.Insert(new AppIndexerMap { AppId = Definition.Id, IndexerId = indexer.Id, RemoteIndexerId = remoteIndexer.Id });
             }
+
+            _logger.Trace("Skipping add for indexer {0} [{1}] due to no app Sync Categories supported by the indexer", indexer.Name, indexer.Id);
         }
 
         public override void RemoveIndexer(int indexerId)

--- a/src/NzbDrone.Core/Applications/Mylar/Mylar.cs
+++ b/src/NzbDrone.Core/Applications/Mylar/Mylar.cs
@@ -75,6 +75,8 @@ namespace NzbDrone.Core.Applications.Mylar
                 var remoteIndexer = _mylarV3Proxy.AddIndexer(mylarIndexer, Settings);
                 _appIndexerMapService.Insert(new AppIndexerMap { AppId = Definition.Id, IndexerId = indexer.Id, RemoteIndexerName = $"{remoteIndexer.Type},{remoteIndexer.Name}" });
             }
+
+            _logger.Trace("Skipping add for indexer {0} [{1}] due to no app Sync Categories supported by the indexer", indexer.Name, indexer.Id);
         }
 
         public override void RemoveIndexer(int indexerId)

--- a/src/NzbDrone.Core/Applications/Radarr/Radarr.cs
+++ b/src/NzbDrone.Core/Applications/Radarr/Radarr.cs
@@ -91,6 +91,8 @@ namespace NzbDrone.Core.Applications.Radarr
                 var remoteIndexer = _radarrV3Proxy.AddIndexer(radarrIndexer, Settings);
                 _appIndexerMapService.Insert(new AppIndexerMap { AppId = Definition.Id, IndexerId = indexer.Id, RemoteIndexerId = remoteIndexer.Id });
             }
+
+            _logger.Trace("Skipping add for indexer {0} [{1}] due to no app Sync Categories supported by the indexer", indexer.Name, indexer.Id);
         }
 
         public override void RemoveIndexer(int indexerId)

--- a/src/NzbDrone.Core/Applications/Readarr/Readarr.cs
+++ b/src/NzbDrone.Core/Applications/Readarr/Readarr.cs
@@ -91,6 +91,8 @@ namespace NzbDrone.Core.Applications.Readarr
                 var remoteIndexer = _readarrV1Proxy.AddIndexer(readarrIndexer, Settings);
                 _appIndexerMapService.Insert(new AppIndexerMap { AppId = Definition.Id, IndexerId = indexer.Id, RemoteIndexerId = remoteIndexer.Id });
             }
+
+            _logger.Trace("Skipping add for indexer {0} [{1}] due to no app Sync Categories supported by the indexer", indexer.Name, indexer.Id);
         }
 
         public override void RemoveIndexer(int indexerId)

--- a/src/NzbDrone.Core/Applications/Sonarr/Sonarr.cs
+++ b/src/NzbDrone.Core/Applications/Sonarr/Sonarr.cs
@@ -91,6 +91,8 @@ namespace NzbDrone.Core.Applications.Sonarr
                 var remoteIndexer = _sonarrV3Proxy.AddIndexer(sonarrIndexer, Settings);
                 _appIndexerMapService.Insert(new AppIndexerMap { AppId = Definition.Id, IndexerId = indexer.Id, RemoteIndexerId = remoteIndexer.Id });
             }
+
+            _logger.Trace("Skipping add for indexer {0} [{1}] due to no app Sync Categories supported by the indexer", indexer.Name, indexer.Id);
         }
 
         public override void RemoveIndexer(int indexerId)

--- a/src/NzbDrone.Core/Applications/Whisparr/Whisparr.cs
+++ b/src/NzbDrone.Core/Applications/Whisparr/Whisparr.cs
@@ -91,6 +91,8 @@ namespace NzbDrone.Core.Applications.Whisparr
                 var remoteIndexer = _whisparrV3Proxy.AddIndexer(radarrIndexer, Settings);
                 _appIndexerMapService.Insert(new AppIndexerMap { AppId = Definition.Id, IndexerId = indexer.Id, RemoteIndexerId = remoteIndexer.Id });
             }
+
+            _logger.Trace("Skipping add for indexer {0} [{1}] due to no app Sync Categories supported by the indexer", indexer.Name, indexer.Id);
         }
 
         public override void RemoveIndexer(int indexerId)


### PR DESCRIPTION
#### Database Migration
NO

#### Description

- there is no log indication nor obvious ui indication for why an indexer would not be synced to an app if the categories do not align.

- adds a trace line when add indexers are skipped to each app as a result of category mismatch

#### Screenshot (if UI related)

#### Todos
- Tests
- Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes Chasing around settings to figure out why X did not sync or attempt to sync to Y