### PR TITLE
New: Smarter Newznab category mapping

### DIFF
--- a/src/NzbDrone.Core.Test/Files/Indexers/Newznab/newznab_caps.xml
+++ b/src/NzbDrone.Core.Test/Files/Indexers/Newznab/newznab_caps.xml
@@ -18,6 +18,7 @@
       <subcat id="5030" name="SD"/>
       <subcat id="5060" name="Sport"/>
       <subcat id="5010" name="WEB-DL"/>
+      <subcat id="5999" name="Other"/>
     </category>
     <category id="7000" name="Other">
       <subcat id="7010" name="Misc"/>

--- a/src/NzbDrone.Core.Test/IndexerTests/NewznabTests/NewznabCapabilitiesProviderFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/NewznabTests/NewznabCapabilitiesProviderFixture.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using System.Xml;
@@ -68,6 +69,19 @@ namespace NzbDrone.Core.Test.IndexerTests.NewznabTests
 
             caps.LimitsDefault.Value.Should().Be(25);
             caps.LimitsMax.Value.Should().Be(60);
+        }
+
+        [Test]
+        public void should_map_different_categories()
+        {
+            GivenCapsResponse(_caps);
+
+            var caps = Subject.GetCapabilities(_settings, _definition);
+
+            var bookCats = caps.Categories.MapTorznabCapsToTrackers(new int[] { NewznabStandardCategory.Books.Id });
+
+            bookCats.Count.Should().Be(2);
+            bookCats.Should().Contain("8000");
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/IndexerTests/NewznabTests/NewznabCapabilitiesProviderFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/NewznabTests/NewznabCapabilitiesProviderFixture.cs
@@ -85,6 +85,19 @@ namespace NzbDrone.Core.Test.IndexerTests.NewznabTests
         }
 
         [Test]
+        public void should_map_by_name_when_available()
+        {
+            GivenCapsResponse(_caps);
+
+            var caps = Subject.GetCapabilities(_settings, _definition);
+
+            var bookCats = caps.Categories.MapTrackerCatToNewznab("5999");
+
+            bookCats.Count.Should().Be(2);
+            bookCats.First().Id.Should().Be(5050);
+        }
+
+        [Test]
         public void should_use_default_pagesize_if_missing()
         {
             GivenCapsResponse(_caps.Replace("<limits", "<abclimits"));

--- a/src/NzbDrone.Core/Indexers/Definitions/Newznab/Newznab.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Newznab/Newznab.cs
@@ -42,7 +42,7 @@ namespace NzbDrone.Core.Indexers.Newznab
 
         public override IParseIndexerResponse GetParser()
         {
-            return new NewznabRssParser(Settings);
+            return new NewznabRssParser(Settings, Definition, _capabilitiesProvider);
         }
 
         public string[] GetBaseUrlFromSettings()

--- a/src/NzbDrone.Core/Indexers/Definitions/Newznab/NewznabRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Newznab/NewznabRequestGenerator.cs
@@ -68,6 +68,7 @@ namespace NzbDrone.Core.Indexers.Newznab
             }
 
             pageableRequests.Add(GetPagedRequests(searchCriteria,
+                capabilities,
                 parameters));
 
             return pageableRequests;
@@ -109,6 +110,7 @@ namespace NzbDrone.Core.Indexers.Newznab
             }
 
             pageableRequests.Add(GetPagedRequests(searchCriteria,
+                capabilities,
                 parameters));
 
             return pageableRequests;
@@ -175,6 +177,7 @@ namespace NzbDrone.Core.Indexers.Newznab
             }
 
             pageableRequests.Add(GetPagedRequests(searchCriteria,
+                capabilities,
                 parameters));
 
             return pageableRequests;
@@ -216,6 +219,7 @@ namespace NzbDrone.Core.Indexers.Newznab
             }
 
             pageableRequests.Add(GetPagedRequests(searchCriteria,
+                capabilities,
                 parameters));
 
             return pageableRequests;
@@ -233,15 +237,15 @@ namespace NzbDrone.Core.Indexers.Newznab
                 parameters.Add("q", NewsnabifyTitle(searchCriteria.SearchTerm));
             }
 
-            pageableRequests.Add(GetPagedRequests(searchCriteria, parameters));
+            pageableRequests.Add(GetPagedRequests(searchCriteria, capabilities, parameters));
 
             return pageableRequests;
         }
 
-        private IEnumerable<IndexerRequest> GetPagedRequests(SearchCriteriaBase searchCriteria, NameValueCollection parameters)
+        private IEnumerable<IndexerRequest> GetPagedRequests(SearchCriteriaBase searchCriteria, IndexerCapabilities capabilities, NameValueCollection parameters)
         {
             var baseUrl = string.Format("{0}{1}?t={2}&extended=1", Settings.BaseUrl.TrimEnd('/'), Settings.ApiPath.TrimEnd('/'), searchCriteria.SearchType);
-            var categories = searchCriteria.Categories;
+            var categories = capabilities.Categories.MapTorznabCapsToTrackers(searchCriteria.Categories);
 
             if (categories != null && categories.Any())
             {

--- a/src/NzbDrone.Core/Indexers/Definitions/Torznab/Torznab.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Torznab/Torznab.cs
@@ -41,7 +41,7 @@ namespace NzbDrone.Core.Indexers.Torznab
 
         public override IParseIndexerResponse GetParser()
         {
-            return new TorznabRssParser(Settings);
+            return new TorznabRssParser(Settings, Definition, _capabilitiesProvider);
         }
 
         public string[] GetBaseUrlFromSettings()


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Be smarter about mapping nab capabilities. Instead of simply using the id from the indexer and assuming it's going to match one of our standards, lets also compare by name. This allows us to better match those indexers which go by different Id standards without the need of maintaining ymls and such.

#### Todos
- [ ] Tests

* Fixes #1117