### PR TITLE
Fixed: (Cardigann) Allow use of template variables in fields selector

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/Cardigann/CardigannBase.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Cardigann/CardigannBase.cs
@@ -132,20 +132,22 @@ namespace NzbDrone.Core.Indexers.Cardigann
 
             if (selector.Selector != null)
             {
-                if (dom.Matches(selector.Selector))
+                var selectorSelector = ApplyGoTemplateText(selector.Selector, variables);
+
+                if (dom.Matches(selectorSelector))
                 {
                     selection = dom;
                 }
                 else
                 {
-                    selection = QuerySelector(dom, selector.Selector);
+                    selection = QuerySelector(dom, selectorSelector);
                 }
 
                 if (selection == null)
                 {
                     if (required)
                     {
-                        throw new Exception(string.Format("Selector \"{0}\" didn't match {1}", selector.Selector, dom.ToHtmlPretty()));
+                        throw new Exception(string.Format("Selector \"{0}\" didn't match {1}", selectorSelector, dom.ToHtmlPretty()));
                     }
 
                     return null;


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fix to allow usage of template variables in selectors for cases like [this](https://github.com/Prowlarr/Indexers/blob/59be412d014e834eea6acd4b1f88cb042fe50e56/definitions/v7/thesceneplace.yml#L151).

Fixes Prowlarr/Indexers#287