### PR TITLE
Fixed: (Indexer) Added "TvSearchParam.ImdbId" to SpeedApp

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/RetroFlix.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/RetroFlix.cs
@@ -9,12 +9,9 @@ namespace NzbDrone.Core.Indexers.Definitions
     public class RetroFlix : SpeedAppBase
     {
         public override string Name => "RetroFlix";
-
         public override string[] IndexerUrls => new string[] { "https://retroflix.club/" };
         public override string[] LegacyUrls => new string[] { "https://retroflix.net/" };
-
         public override string Description => "Private Torrent Tracker for Classic Movies / TV / General Releases";
-
         public override IndexerPrivacy Privacy => IndexerPrivacy.Private;
         public override TimeSpan RateLimit => TimeSpan.FromSeconds(2.1);
 
@@ -29,15 +26,11 @@ namespace NzbDrone.Core.Indexers.Definitions
             {
                 TvSearchParams = new List<TvSearchParam>
                 {
-                    TvSearchParam.Q,
-                    TvSearchParam.Season,
-                    TvSearchParam.Ep,
-                    TvSearchParam.ImdbId
+                    TvSearchParam.Q, TvSearchParam.ImdbId, TvSearchParam.Season, TvSearchParam.Ep,
                 },
                 MovieSearchParams = new List<MovieSearchParam>
                 {
-                    MovieSearchParam.Q,
-                    MovieSearchParam.ImdbId
+                    MovieSearchParam.Q, MovieSearchParam.ImdbId,
                 },
                 MusicSearchParams = new List<MusicSearchParam>
                 {

--- a/src/NzbDrone.Core/Indexers/Definitions/SpeedApp.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/SpeedApp.cs
@@ -8,14 +8,10 @@ namespace NzbDrone.Core.Indexers.Definitions
     public class SpeedApp : SpeedAppBase
     {
         public override string Name => "SpeedApp.io";
-
         public override string[] IndexerUrls => new string[] { "https://speedapp.io/" };
         public override string[] LegacyUrls => new string[] { "https://speedapp.io" };
-
         public override string Description => "SpeedApp is a ROMANIAN Private Torrent Tracker for MOVIES / TV / GENERAL";
-
         public override string Language => "ro-RO";
-
         public override IndexerPrivacy Privacy => IndexerPrivacy.Private;
 
         public SpeedApp(IIndexerHttpClient httpClient, IEventAggregator eventAggregator, IIndexerStatusService indexerStatusService, IConfigService configService, Logger logger, IIndexerRepository indexerRepository)
@@ -29,14 +25,11 @@ namespace NzbDrone.Core.Indexers.Definitions
             {
                 TvSearchParams = new List<TvSearchParam>
                 {
-                    TvSearchParam.Q,
-                    TvSearchParam.Season,
-                    TvSearchParam.Ep,
+                    TvSearchParam.Q, TvSearchParam.ImdbId, TvSearchParam.Season, TvSearchParam.Ep,
                 },
                 MovieSearchParams = new List<MovieSearchParam>
                 {
-                    MovieSearchParam.Q,
-                    MovieSearchParam.ImdbId,
+                    MovieSearchParam.Q, MovieSearchParam.ImdbId,
                 },
                 MusicSearchParams = new List<MusicSearchParam>
                 {

--- a/src/NzbDrone.Core/Indexers/Definitions/SpeedApp/SpeedAppBase.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/SpeedApp/SpeedAppBase.cs
@@ -29,11 +29,8 @@ namespace NzbDrone.Core.Indexers.Definitions
     public abstract class SpeedAppBase : TorrentIndexerBase<SpeedAppSettings>
     {
         private string LoginUrl => Settings.BaseUrl + "api/login";
-
         public override Encoding Encoding => Encoding.UTF8;
-
         public override DownloadProtocol Protocol => DownloadProtocol.Torrent;
-
         public override IndexerCapabilities Capabilities => SetCapabilities();
 
         private IIndexerRepository _indexerRepository;
@@ -304,7 +301,7 @@ namespace NzbDrone.Core.Indexers.Definitions
                 Description = torrent.ShortDescription,
                 Size = torrent.Size,
                 ImdbId = ParseUtil.GetImdbID(torrent.ImdbId).GetValueOrDefault(),
-                DownloadUrl = $"{_settings.BaseUrl}/api/torrent/{torrent.Id}/download",
+                DownloadUrl = $"{_settings.BaseUrl}api/torrent/{torrent.Id}/download",
                 PosterUrl = torrent.Poster,
                 InfoUrl = torrent.Url,
                 Grabs = torrent.TimesCompleted,


### PR DESCRIPTION
#### Database Migration
NO

#### Description
- Added `TvSearchParam.ImdbId` to prevent unnecessary results. 
- Fixed the double slash the download link as well.