### PR TITLE
Fixed: (Avistaz) Workaround for fetching "retry-after" header 

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/Avistaz/AvistazRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Avistaz/AvistazRequestGenerator.cs
@@ -73,7 +73,8 @@ namespace NzbDrone.Core.Indexers.Definitions.Avistaz
         {
             var searchUrl = SearchUrl + "?" + searchParameters.GetQueryString();
 
-            var request = new IndexerRequest(searchUrl, HttpAccept.Json);
+            // TODO: Change to HttpAccept.Json after they fix the issue with missing headers
+            var request = new IndexerRequest(searchUrl, HttpAccept.Html);
             request.HttpRequest.Headers.Add("Authorization", $"Bearer {Settings.Token}");
 
             yield return request;


### PR DESCRIPTION
not present when using "Accept: application/json"

#### Database Migration
NO