### PR TITLE
Fixed: (IPTorrents) use offset to set page field

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/IPTorrents.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/IPTorrents.cs
@@ -165,7 +165,7 @@ namespace NzbDrone.Core.Indexers.Definitions
         {
         }
 
-        private IEnumerable<IndexerRequest> GetPagedRequests(string term, int[] categories, string imdbId = null)
+        private IEnumerable<IndexerRequest> GetPagedRequests(string term, int[] categories, int limit, int offset, string imdbId = null)
         {
             var searchUrl = Settings.BaseUrl + "t";
 
@@ -194,6 +194,8 @@ namespace NzbDrone.Core.Indexers.Definitions
                 qc.Add(cat, string.Empty);
             }
 
+            qc.Add("p", ((offset / limit) + 1).ToString());
+
             searchUrl = searchUrl + "?" + qc.GetQueryString();
 
             var request = new IndexerRequest(searchUrl, HttpAccept.Html);
@@ -210,7 +212,7 @@ namespace NzbDrone.Core.Indexers.Definitions
         {
             var pageableRequests = new IndexerPageableRequestChain();
 
-            pageableRequests.Add(GetPagedRequests(string.Format("{0}", searchCriteria.SearchTerm), searchCriteria.Categories, searchCriteria.FullImdbId));
+            pageableRequests.Add(GetPagedRequests(string.Format("{0}", searchCriteria.SearchTerm), searchCriteria.Categories, searchCriteria.Limit ?? 100, searchCriteria.Offset ?? 0, searchCriteria.FullImdbId));
 
             return pageableRequests;
         }
@@ -219,7 +221,7 @@ namespace NzbDrone.Core.Indexers.Definitions
         {
             var pageableRequests = new IndexerPageableRequestChain();
 
-            pageableRequests.Add(GetPagedRequests(string.Format("{0}", searchCriteria.SanitizedSearchTerm), searchCriteria.Categories));
+            pageableRequests.Add(GetPagedRequests(string.Format("{0}", searchCriteria.SanitizedSearchTerm), searchCriteria.Categories, searchCriteria.Limit ?? 100, searchCriteria.Offset ?? 0));
 
             return pageableRequests;
         }
@@ -228,7 +230,7 @@ namespace NzbDrone.Core.Indexers.Definitions
         {
             var pageableRequests = new IndexerPageableRequestChain();
 
-            pageableRequests.Add(GetPagedRequests(string.Format("{0}", searchCriteria.SanitizedTvSearchString), searchCriteria.Categories, searchCriteria.FullImdbId));
+            pageableRequests.Add(GetPagedRequests(string.Format("{0}", searchCriteria.SanitizedTvSearchString), searchCriteria.Categories, searchCriteria.Limit ?? 100, searchCriteria.Offset ?? 0, searchCriteria.FullImdbId));
 
             return pageableRequests;
         }
@@ -237,7 +239,7 @@ namespace NzbDrone.Core.Indexers.Definitions
         {
             var pageableRequests = new IndexerPageableRequestChain();
 
-            pageableRequests.Add(GetPagedRequests(string.Format("{0}", searchCriteria.SanitizedSearchTerm), searchCriteria.Categories));
+            pageableRequests.Add(GetPagedRequests(string.Format("{0}", searchCriteria.SanitizedSearchTerm), searchCriteria.Categories, searchCriteria.Limit ?? 100, searchCriteria.Offset ?? 0));
 
             return pageableRequests;
         }
@@ -246,7 +248,7 @@ namespace NzbDrone.Core.Indexers.Definitions
         {
             var pageableRequests = new IndexerPageableRequestChain();
 
-            pageableRequests.Add(GetPagedRequests(string.Format("{0}", searchCriteria.SanitizedSearchTerm), searchCriteria.Categories));
+            pageableRequests.Add(GetPagedRequests(string.Format("{0}", searchCriteria.SanitizedSearchTerm), searchCriteria.Categories, searchCriteria.Limit ?? 100, searchCriteria.Offset ?? 0));
 
             return pageableRequests;
         }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
The IPTorrents indexer doesn't currently handle offset searching and will hit the same page over and over again looking for more releases as a result:

<details>
  <summary>log</summary>

```
2022-12-28 11:07:38.4|Debug|Prowlarr.Http.Authentication.ApiKeyAuthenticationHandler|AuthenticationScheme: API was successfully authenticated.
2022-12-28 11:07:38.4|Info|ReleaseSearchService|Searching indexer(s): [IPTorrents] for Term: [] for Season / Episode:[], Offset: 0, Limit: 100, Categories: [5000, 5030, 5040, 5020, 5010, 5070]
2022-12-28 11:07:38.4|Debug|IPTorrents|Downloading Feed https://iptorrents.com/t?73=&26=&55=&78=&23=&24=&25=&66=&82=&65=&83=&79=&22=&5=&99=&4=&60=
2022-12-28 11:07:38.7|Debug|ReleaseSearchService|Total of 100 reports were found for Term: [] for Season / Episode:[], Offset: 0, Limit: 100, Categories: [5000, 5030, 5040, 5020, 5010, 5070] from 1 indexer(s)
2022-12-28 11:07:40.4|Debug|Prowlarr.Http.Authentication.ApiKeyAuthenticationHandler|AuthenticationScheme: API was successfully authenticated.
2022-12-28 11:07:40.4|Info|ReleaseSearchService|Searching indexer(s): [IPTorrents] for Term: [] for Season / Episode:[], Offset: 100, Limit: 100, Categories: [5000, 5030, 5040, 5020, 5010, 5070]
2022-12-28 11:07:40.4|Debug|IPTorrents|Downloading Feed https://iptorrents.com/t?73=&26=&55=&78=&23=&24=&25=&66=&82=&65=&83=&79=&22=&5=&99=&4=&60=
2022-12-28 11:07:40.7|Debug|ReleaseSearchService|Total of 100 reports were found for Term: [] for Season / Episode:[], Offset: 100, Limit: 100, Categories: [5000, 5030, 5040, 5020, 5010, 5070] from 1 indexer(s)
2022-12-28 11:07:42.4|Debug|Prowlarr.Http.Authentication.ApiKeyAuthenticationHandler|AuthenticationScheme: API was successfully authenticated.
2022-12-28 11:07:42.4|Info|ReleaseSearchService|Searching indexer(s): [IPTorrents] for Term: [] for Season / Episode:[], Offset: 200, Limit: 100, Categories: [5000, 5030, 5040, 5020, 5010, 5070]
2022-12-28 11:07:42.4|Debug|IPTorrents|Downloading Feed https://iptorrents.com/t?73=&26=&55=&78=&23=&24=&25=&66=&82=&65=&83=&79=&22=&5=&99=&4=&60=
2022-12-28 11:07:42.5|Debug|ReleaseSearchService|Total of 100 reports were found for Term: [] for Season / Episode:[], Offset: 200, Limit: 100, Categories: [5000, 5030, 5040, 5020, 5010, 5070] from 1 indexer(s)
2022-12-28 11:07:44.4|Debug|Prowlarr.Http.Authentication.ApiKeyAuthenticationHandler|AuthenticationScheme: API was successfully authenticated.
2022-12-28 11:07:44.4|Info|ReleaseSearchService|Searching indexer(s): [IPTorrents] for Term: [] for Season / Episode:[], Offset: 300, Limit: 100, Categories: [5000, 5030, 5040, 5020, 5010, 5070]
2022-12-28 11:07:44.4|Debug|IPTorrents|Downloading Feed https://iptorrents.com/t?73=&26=&55=&78=&23=&24=&25=&66=&82=&65=&83=&79=&22=&5=&99=&4=&60=
2022-12-28 11:07:44.7|Debug|ReleaseSearchService|Total of 100 reports were found for Term: [] for Season / Episode:[], Offset: 300, Limit: 100, Categories: [5000, 5030, 5040, 5020, 5010, 5070] from 1 indexer(s)
2022-12-28 11:07:46.4|Debug|Prowlarr.Http.Authentication.ApiKeyAuthenticationHandler|AuthenticationScheme: API was successfully authenticated.
2022-12-28 11:07:46.4|Info|ReleaseSearchService|Searching indexer(s): [IPTorrents] for Term: [] for Season / Episode:[], Offset: 400, Limit: 100, Categories: [5000, 5030, 5040, 5020, 5010, 5070]
2022-12-28 11:07:46.4|Debug|IPTorrents|Downloading Feed https://iptorrents.com/t?73=&26=&55=&78=&23=&24=&25=&66=&82=&65=&83=&79=&22=&5=&99=&4=&60=
2022-12-28 11:07:46.7|Debug|ReleaseSearchService|Total of 100 reports were found for Term: [] for Season / Episode:[], Offset: 400, Limit: 100, Categories: [5000, 5030, 5040, 5020, 5010, 5070] from 1 indexer(s)
2022-12-28 11:07:48.4|Debug|Prowlarr.Http.Authentication.ApiKeyAuthenticationHandler|AuthenticationScheme: API was successfully authenticated.
2022-12-28 11:07:48.4|Info|ReleaseSearchService|Searching indexer(s): [IPTorrents] for Term: [] for Season / Episode:[], Offset: 500, Limit: 100, Categories: [5000, 5030, 5040, 5020, 5010, 5070]
2022-12-28 11:07:48.4|Debug|IPTorrents|Downloading Feed https://iptorrents.com/t?73=&26=&55=&78=&23=&24=&25=&66=&82=&65=&83=&79=&22=&5=&99=&4=&60=
2022-12-28 11:07:48.7|Debug|ReleaseSearchService|Total of 100 reports were found for Term: [] for Season / Episode:[], Offset: 500, Limit: 100, Categories: [5000, 5030, 5040, 5020, 5010, 5070] from 1 indexer(s)
2022-12-28 11:07:50.4|Debug|Prowlarr.Http.Authentication.ApiKeyAuthenticationHandler|AuthenticationScheme: API was successfully authenticated.
2022-12-28 11:07:50.4|Info|ReleaseSearchService|Searching indexer(s): [IPTorrents] for Term: [] for Season / Episode:[], Offset: 600, Limit: 100, Categories: [5000, 5030, 5040, 5020, 5010, 5070]
2022-12-28 11:07:50.4|Debug|IPTorrents|Downloading Feed https://iptorrents.com/t?73=&26=&55=&78=&23=&24=&25=&66=&82=&65=&83=&79=&22=&5=&99=&4=&60=
2022-12-28 11:07:50.7|Debug|ReleaseSearchService|Total of 100 reports were found for Term: [] for Season / Episode:[], Offset: 600, Limit: 100, Categories: [5000, 5030, 5040, 5020, 5010, 5070] from 1 indexer(s)
2022-12-28 11:07:52.4|Debug|Prowlarr.Http.Authentication.ApiKeyAuthenticationHandler|AuthenticationScheme: API was successfully authenticated.
2022-12-28 11:07:52.4|Info|ReleaseSearchService|Searching indexer(s): [IPTorrents] for Term: [] for Season / Episode:[], Offset: 700, Limit: 100, Categories: [5000, 5030, 5040, 5020, 5010, 5070]
2022-12-28 11:07:52.4|Debug|IPTorrents|Downloading Feed https://iptorrents.com/t?73=&26=&55=&78=&23=&24=&25=&66=&82=&65=&83=&79=&22=&5=&99=&4=&60=
2022-12-28 11:07:52.7|Debug|ReleaseSearchService|Total of 100 reports were found for Term: [] for Season / Episode:[], Offset: 700, Limit: 100, Categories: [5000, 5030, 5040, 5020, 5010, 5070] from 1 indexer(s)
2022-12-28 11:07:54.4|Debug|Prowlarr.Http.Authentication.ApiKeyAuthenticationHandler|AuthenticationScheme: API was successfully authenticated.
2022-12-28 11:07:54.4|Info|ReleaseSearchService|Searching indexer(s): [IPTorrents] for Term: [] for Season / Episode:[], Offset: 800, Limit: 100, Categories: [5000, 5030, 5040, 5020, 5010, 5070]
2022-12-28 11:07:54.4|Debug|IPTorrents|Downloading Feed https://iptorrents.com/t?73=&26=&55=&78=&23=&24=&25=&66=&82=&65=&83=&79=&22=&5=&99=&4=&60=
2022-12-28 11:07:54.7|Debug|ReleaseSearchService|Total of 100 reports were found for Term: [] for Season / Episode:[], Offset: 800, Limit: 100, Categories: [5000, 5030, 5040, 5020, 5010, 5070] from 1 indexer(s)
2022-12-28 11:07:56.4|Debug|Prowlarr.Http.Authentication.ApiKeyAuthenticationHandler|AuthenticationScheme: API was successfully authenticated.
2022-12-28 11:07:56.4|Info|ReleaseSearchService|Searching indexer(s): [IPTorrents] for Term: [] for Season / Episode:[], Offset: 900, Limit: 100, Categories: [5000, 5030, 5040, 5020, 5010, 5070]
2022-12-28 11:07:56.4|Debug|IPTorrents|Downloading Feed https://iptorrents.com/t?73=&26=&55=&78=&23=&24=&25=&66=&82=&65=&83=&79=&22=&5=&99=&4=&60=
2022-12-28 11:07:56.7|Debug|ReleaseSearchService|Total of 100 reports were found for Term: [] for Season / Episode:[], Offset: 900, Limit: 100, Categories: [5000, 5030, 5040, 5020, 5010, 5070] from 1 indexer(s)
2022-12-28 11:07:58.4|Debug|Prowlarr.Http.Authentication.ApiKeyAuthenticationHandler|AuthenticationScheme: API was successfully authenticated.
2022-12-28 11:07:58.4|Info|ReleaseSearchService|Searching indexer(s): [IPTorrents] for Term: [] for Season / Episode:[], Offset: 1000, Limit: 100, Categories: [5000, 5030, 5040, 5020, 5010, 5070]
2022-12-28 11:07:58.4|Debug|IPTorrents|Downloading Feed https://iptorrents.com/t?73=&26=&55=&78=&23=&24=&25=&66=&82=&65=&83=&79=&22=&5=&99=&4=&60=
2022-12-28 11:07:58.7|Debug|ReleaseSearchService|Total of 100 reports were found for Term: [] for Season / Episode:[], Offset: 1000, Limit: 100, Categories: [5000, 5030, 5040, 5020, 5010, 5070] from 1 indexer(s)
```
</details>

This change reuses code from the [NzbIndex indexer](https://github.com/Prowlarr/Prowlarr/blob/74a1d95ab74e6b4ede077e02995033a7dcc611e4/src/NzbDrone.Core/Indexers/Definitions/NzbIndex.cs#L1039) to set the p (page) field based on the offset value provided:

<details>
  <summary>log</summary>

```
Debug|Prowlarr.Http.Authentication.ApiKeyAuthenticationHandler|AuthenticationScheme: API was successfully authenticated.
Info|ReleaseSearchService|Searching indexer(s): [IPTorrents] for Term: [] | ID(s): IMDbId:[(removed)] for Season / Episode:[], Offset: 0, Limit: 100, Categories: [5000, 5030, 5040, 5020, 5010]
Debug|IPTorrents|Downloading Feed https://iptorrents.com/t?q=%2B(tt(removed))&73=&26=&55=&78=&23=&24=&25=&66=&82=&65=&83=&79=&22=&5=&99=&4=&60=&p=1
Debug|ReleaseSearchService|Total of 100 reports were found for Term: [] | ID(s): IMDbId:[(removed)] for Season / Episode:[], Offset: 0, Limit: 100, Categories: [5000, 5030, 5040, 5020, 5010] from 1 indexer(s)
Debug|Prowlarr.Http.Authentication.ApiKeyAuthenticationHandler|AuthenticationScheme: API was successfully authenticated.
Info|ReleaseSearchService|Searching indexer(s): [IPTorrents] for Term: [] | ID(s): IMDbId:[(removed)] for Season / Episode:[], Offset: 100, Limit: 100, Categories: [5000, 5030, 5040, 5020, 5010]
Debug|IPTorrents|Downloading Feed https://iptorrents.com/t?q=%2B(tt(removed))&73=&26=&55=&78=&23=&24=&25=&66=&82=&65=&83=&79=&22=&5=&99=&4=&60=&p=2
Debug|ReleaseSearchService|Total of 100 reports were found for Term: [] | ID(s): IMDbId:[(removed)] for Season / Episode:[], Offset: 100, Limit: 100, Categories: [5000, 5030, 5040, 5020, 5010] from 1 indexer(s)
Debug|Prowlarr.Http.Authentication.ApiKeyAuthenticationHandler|AuthenticationScheme: API was successfully authenticated.
Info|ReleaseSearchService|Searching indexer(s): [IPTorrents] for Term: [] | ID(s): IMDbId:[(removed)] for Season / Episode:[], Offset: 200, Limit: 100, Categories: [5000, 5030, 5040, 5020, 5010]
Debug|IPTorrents|Downloading Feed https://iptorrents.com/t?q=%2B(tt(removed))&73=&26=&55=&78=&23=&24=&25=&66=&82=&65=&83=&79=&22=&5=&99=&4=&60=&p=3
Debug|ReleaseSearchService|Total of 100 reports were found for Term: [] | ID(s): IMDbId:[(removed)] for Season / Episode:[], Offset: 200, Limit: 100, Categories: [5000, 5030, 5040, 5020, 5010] from 1 indexer(s)
Debug|Prowlarr.Http.Authentication.ApiKeyAuthenticationHandler|AuthenticationScheme: API was successfully authenticated.
Info|ReleaseSearchService|Searching indexer(s): [IPTorrents] for Term: [] | ID(s): IMDbId:[(removed)] for Season / Episode:[], Offset: 300, Limit: 100, Categories: [5000, 5030, 5040, 5020, 5010]
Debug|IPTorrents|Downloading Feed https://iptorrents.com/t?q=%2B(tt(removed))&73=&26=&55=&78=&23=&24=&25=&66=&82=&65=&83=&79=&22=&5=&99=&4=&60=&p=4
Debug|Prowlarr.Http.Authentication.ApiKeyAuthenticationHandler|AuthenticationScheme: API was successfully authenticated.
Debug|ReleaseSearchService|Total of 100 reports were found for Term: [] | ID(s): IMDbId:[(removed)] for Season / Episode:[], Offset: 300, Limit: 100, Categories: [5000, 5030, 5040, 5020, 5010] from 1 indexer(s)
Debug|Prowlarr.Http.Authentication.ApiKeyAuthenticationHandler|AuthenticationScheme: API was successfully authenticated.
Info|ReleaseSearchService|Searching indexer(s): [IPTorrents] for Term: [] | ID(s): IMDbId:[(removed)] for Season / Episode:[], Offset: 400, Limit: 100, Categories: [5000, 5030, 5040, 5020, 5010]
Debug|IPTorrents|Downloading Feed https://iptorrents.com/t?q=%2B(tt(removed))&73=&26=&55=&78=&23=&24=&25=&66=&82=&65=&83=&79=&22=&5=&99=&4=&60=&p=5
Debug|ReleaseSearchService|Total of 55 reports were found for Term: [] | ID(s): IMDbId:[(removed)] for Season / Episode:[], Offset: 400, Limit: 100, Categories: [5000, 5030, 5040, 5020, 5010] from 1 indexer(s)
```
</details>

