### PR TITLE
Fixed: Indexer inherited setting validation

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/AnimeBytes.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/AnimeBytes.cs
@@ -521,9 +521,10 @@ namespace NzbDrone.Core.Indexers.Definitions
         public Action<IDictionary<string, string>, DateTime?> CookiesUpdater { get; set; }
     }
 
-    public class AnimeBytesSettingsValidator : AbstractValidator<AnimeBytesSettings>
+    public class AnimeBytesSettingsValidator : NoAuthSettingsValidator<AnimeBytesSettings>
     {
         public AnimeBytesSettingsValidator()
+        : base()
         {
             RuleFor(c => c.Passkey).NotEmpty()
                                    .Must(x => x.Length == 32 || x.Length == 48)

--- a/src/NzbDrone.Core/Indexers/Definitions/Avistaz/AvistazSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Avistaz/AvistazSettings.cs
@@ -5,9 +5,10 @@ using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.Definitions.Avistaz
 {
-    public class AvistazSettingsValidator : AbstractValidator<AvistazSettings>
+    public class AvistazSettingsValidator : NoAuthSettingsValidator<AvistazSettings>
     {
         public AvistazSettingsValidator()
+        : base()
         {
             RuleFor(c => c.Username).NotEmpty();
             RuleFor(c => c.Password).NotEmpty();

--- a/src/NzbDrone.Core/Indexers/Definitions/BeyondHD.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/BeyondHD.cs
@@ -246,9 +246,10 @@ namespace NzbDrone.Core.Indexers.Definitions
         public Action<IDictionary<string, string>, DateTime?> CookiesUpdater { get; set; }
     }
 
-    public class BeyondHDSettingsValidator : AbstractValidator<BeyondHDSettings>
+    public class BeyondHDSettingsValidator : NoAuthSettingsValidator<BeyondHDSettings>
     {
         public BeyondHDSettingsValidator()
+        : base()
         {
             RuleFor(c => c.ApiKey).NotEmpty();
             RuleFor(c => c.RssKey).NotEmpty();
@@ -257,7 +258,7 @@ namespace NzbDrone.Core.Indexers.Definitions
 
     public class BeyondHDSettings : NoAuthTorrentBaseSettings
     {
-        private static readonly BeyondHDSettingsValidator Validator = new BeyondHDSettingsValidator();
+        private static readonly BeyondHDSettingsValidator Validator = new ();
 
         public BeyondHDSettings()
         {

--- a/src/NzbDrone.Core/Indexers/Definitions/BroadcastheNet/BroadcastheNetSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/BroadcastheNet/BroadcastheNetSettings.cs
@@ -5,9 +5,10 @@ using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.BroadcastheNet
 {
-    public class BroadcastheNetSettingsValidator : AbstractValidator<BroadcastheNetSettings>
+    public class BroadcastheNetSettingsValidator : NoAuthSettingsValidator<BroadcastheNetSettings>
     {
         public BroadcastheNetSettingsValidator()
+        : base()
         {
             RuleFor(c => c.ApiKey).NotEmpty();
         }

--- a/src/NzbDrone.Core/Indexers/Definitions/FileList/FileListSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/FileList/FileListSettings.cs
@@ -5,9 +5,10 @@ using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.FileList
 {
-    public class FileListSettingsValidator : AbstractValidator<FileListSettings>
+    public class FileListSettingsValidator : NoAuthSettingsValidator<FileListSettings>
     {
         public FileListSettingsValidator()
+        : base()
         {
             RuleFor(c => c.Username).NotEmpty();
             RuleFor(c => c.Passkey).NotEmpty();

--- a/src/NzbDrone.Core/Indexers/Definitions/Gazelle/GazelleSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Gazelle/GazelleSettings.cs
@@ -5,8 +5,18 @@ using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.Gazelle
 {
+    public class GazelleSettingsValidator : UserPassBaseSettingsValidator<GazelleSettings>
+    {
+        public GazelleSettingsValidator()
+        : base()
+        {
+        }
+    }
+
     public class GazelleSettings : UserPassTorrentBaseSettings
     {
+        private static readonly GazelleSettingsValidator Validator = new ();
+
         public GazelleSettings()
         {
         }
@@ -16,5 +26,10 @@ namespace NzbDrone.Core.Indexers.Gazelle
 
         [FieldDefinition(4, Type = FieldType.Checkbox, Label = "Use Freeleech Token", HelpText = "Use freeleech tokens when available")]
         public bool UseFreeleechToken { get; set; }
+
+        public override NzbDroneValidationResult Validate()
+        {
+            return new NzbDroneValidationResult(Validator.Validate(this));
+        }
     }
 }

--- a/src/NzbDrone.Core/Indexers/Definitions/GazelleGames.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/GazelleGames.cs
@@ -431,9 +431,10 @@ namespace NzbDrone.Core.Indexers.Definitions
         public Action<IDictionary<string, string>, DateTime?> CookiesUpdater { get; set; }
     }
 
-    public class GazelleGamesSettingsValidator : AbstractValidator<GazelleGamesSettings>
+    public class GazelleGamesSettingsValidator : NoAuthSettingsValidator<GazelleGamesSettings>
     {
         public GazelleGamesSettingsValidator()
+        : base()
         {
             RuleFor(c => c.Apikey).NotEmpty();
         }

--- a/src/NzbDrone.Core/Indexers/Definitions/HDBits/HDBitsSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/HDBits/HDBitsSettings.cs
@@ -6,9 +6,10 @@ using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.HDBits
 {
-    public class HDBitsSettingsValidator : AbstractValidator<HDBitsSettings>
+    public class HDBitsSettingsValidator : NoAuthSettingsValidator<HDBitsSettings>
     {
         public HDBitsSettingsValidator()
+        : base()
         {
             RuleFor(c => c.ApiKey).NotEmpty();
         }

--- a/src/NzbDrone.Core/Indexers/Definitions/MyAnonamouse.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/MyAnonamouse.cs
@@ -427,9 +427,10 @@ namespace NzbDrone.Core.Indexers.Definitions
         public Action<IDictionary<string, string>, DateTime?> CookiesUpdater { get; set; }
     }
 
-    public class MyAnonamouseSettingsValidator : AbstractValidator<MyAnonamouseSettings>
+    public class MyAnonamouseSettingsValidator : NoAuthSettingsValidator<MyAnonamouseSettings>
     {
         public MyAnonamouseSettingsValidator()
+        : base()
         {
             RuleFor(c => c.MamId).NotEmpty();
         }
@@ -437,7 +438,7 @@ namespace NzbDrone.Core.Indexers.Definitions
 
     public class MyAnonamouseSettings : NoAuthTorrentBaseSettings
     {
-        private static readonly MyAnonamouseSettingsValidator Validator = new MyAnonamouseSettingsValidator();
+        private static readonly MyAnonamouseSettingsValidator Validator = new ();
 
         public MyAnonamouseSettings()
         {

--- a/src/NzbDrone.Core/Indexers/Definitions/Orpheus.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Orpheus.cs
@@ -381,9 +381,10 @@ namespace NzbDrone.Core.Indexers.Definitions
         }
     }
 
-    public class OrpheusSettingsValidator : AbstractValidator<OrpheusSettings>
+    public class OrpheusSettingsValidator : NoAuthSettingsValidator<OrpheusSettings>
     {
         public OrpheusSettingsValidator()
+        : base()
         {
             RuleFor(c => c.Apikey).NotEmpty();
         }
@@ -391,7 +392,7 @@ namespace NzbDrone.Core.Indexers.Definitions
 
     public class OrpheusSettings : NoAuthTorrentBaseSettings
     {
-        private static readonly OrpheusSettingsValidator Validator = new OrpheusSettingsValidator();
+        private static readonly OrpheusSettingsValidator Validator = new ();
 
         public OrpheusSettings()
         {

--- a/src/NzbDrone.Core/Indexers/Definitions/PassThePopcorn/PassThePopcornSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/PassThePopcorn/PassThePopcornSettings.cs
@@ -5,9 +5,10 @@ using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.PassThePopcorn
 {
-    public class PassThePopcornSettingsValidator : AbstractValidator<PassThePopcornSettings>
+    public class PassThePopcornSettingsValidator : NoAuthSettingsValidator<PassThePopcornSettings>
     {
         public PassThePopcornSettingsValidator()
+        : base()
         {
             RuleFor(c => c.APIUser).NotEmpty();
             RuleFor(c => c.APIKey).NotEmpty();
@@ -16,7 +17,7 @@ namespace NzbDrone.Core.Indexers.PassThePopcorn
 
     public class PassThePopcornSettings : NoAuthTorrentBaseSettings
     {
-        private static readonly PassThePopcornSettingsValidator Validator = new PassThePopcornSettingsValidator();
+        private static readonly PassThePopcornSettingsValidator Validator = new ();
 
         public PassThePopcornSettings()
         {

--- a/src/NzbDrone.Core/Indexers/Definitions/PreToMe.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/PreToMe.cs
@@ -380,9 +380,10 @@ namespace NzbDrone.Core.Indexers.Definitions
         public Action<IDictionary<string, string>, DateTime?> CookiesUpdater { get; set; }
     }
 
-    public class PreToMeSettingsValidator : AbstractValidator<PreToMeSettings>
+    public class PreToMeSettingsValidator : NoAuthSettingsValidator<PreToMeSettings>
     {
         public PreToMeSettingsValidator()
+        : base()
         {
             RuleFor(c => c.Pin).NotEmpty();
             RuleFor(c => c.Username).NotEmpty();
@@ -392,7 +393,7 @@ namespace NzbDrone.Core.Indexers.Definitions
 
     public class PreToMeSettings : NoAuthTorrentBaseSettings
     {
-        private static readonly PreToMeSettingsValidator Validator = new PreToMeSettingsValidator();
+        private static readonly PreToMeSettingsValidator Validator = new ();
 
         public PreToMeSettings()
         {

--- a/src/NzbDrone.Core/Indexers/Definitions/Redacted.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Redacted.cs
@@ -326,9 +326,10 @@ namespace NzbDrone.Core.Indexers.Definitions
         }
     }
 
-    public class RedactedSettingsValidator : AbstractValidator<RedactedSettings>
+    public class RedactedSettingsValidator : NoAuthSettingsValidator<RedactedSettings>
     {
         public RedactedSettingsValidator()
+        : base()
         {
             RuleFor(c => c.Apikey).NotEmpty();
         }

--- a/src/NzbDrone.Core/Indexers/Definitions/SceneHD.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/SceneHD.cs
@@ -233,9 +233,10 @@ namespace NzbDrone.Core.Indexers.Definitions
         public Action<IDictionary<string, string>, DateTime?> CookiesUpdater { get; set; }
     }
 
-    public class SceneHDSettingsValidator : AbstractValidator<SceneHDSettings>
+    public class SceneHDSettingsValidator : NoAuthSettingsValidator<SceneHDSettings>
     {
         public SceneHDSettingsValidator()
+        : base()
         {
             RuleFor(c => c.Passkey).NotEmpty().Length(32);
         }
@@ -243,7 +244,7 @@ namespace NzbDrone.Core.Indexers.Definitions
 
     public class SceneHDSettings : NoAuthTorrentBaseSettings
     {
-        private static readonly SceneHDSettingsValidator Validator = new SceneHDSettingsValidator();
+        private static readonly SceneHDSettingsValidator Validator = new ();
 
         public SceneHDSettings()
         {

--- a/src/NzbDrone.Core/Indexers/Definitions/SpeedApp/SpeedAppBase.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/SpeedApp/SpeedAppBase.cs
@@ -325,9 +325,10 @@ namespace NzbDrone.Core.Indexers.Definitions
         }
     }
 
-    public class SpeedAppSettingsValidator : AbstractValidator<SpeedAppSettings>
+    public class SpeedAppSettingsValidator : NoAuthSettingsValidator<SpeedAppSettings>
     {
         public SpeedAppSettingsValidator()
+        : base()
         {
             RuleFor(c => c.Email).NotEmpty();
             RuleFor(c => c.Password).NotEmpty();

--- a/src/NzbDrone.Core/Indexers/Definitions/TorrentSyndikat.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/TorrentSyndikat.cs
@@ -323,9 +323,10 @@ namespace NzbDrone.Core.Indexers.Definitions
         public Action<IDictionary<string, string>, DateTime?> CookiesUpdater { get; set; }
     }
 
-    public class TorrentSyndikatSettingsValidator : AbstractValidator<TorrentSyndikatSettings>
+    public class TorrentSyndikatSettingsValidator : NoAuthSettingsValidator<TorrentSyndikatSettings>
     {
         public TorrentSyndikatSettingsValidator()
+        : base()
         {
             RuleFor(c => c.ApiKey).NotEmpty();
         }
@@ -333,7 +334,7 @@ namespace NzbDrone.Core.Indexers.Definitions
 
     public class TorrentSyndikatSettings : NoAuthTorrentBaseSettings
     {
-        private static readonly TorrentSyndikatSettingsValidator Validator = new TorrentSyndikatSettingsValidator();
+        private static readonly TorrentSyndikatSettingsValidator Validator = new ();
 
         public TorrentSyndikatSettings()
         {

--- a/src/NzbDrone.Core/Indexers/Definitions/UNIT3D/Unit3dSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/UNIT3D/Unit3dSettings.cs
@@ -5,9 +5,10 @@ using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.Definitions.UNIT3D
 {
-    public class Unit3dSettingsValidator : AbstractValidator<Unit3dSettings>
+    public class Unit3dSettingsValidator : NoAuthSettingsValidator<Unit3dSettings>
     {
         public Unit3dSettingsValidator()
+        : base()
         {
             RuleFor(c => c.ApiKey).NotEmpty();
         }
@@ -15,7 +16,7 @@ namespace NzbDrone.Core.Indexers.Definitions.UNIT3D
 
     public class Unit3dSettings : NoAuthTorrentBaseSettings
     {
-        private static readonly Unit3dSettingsValidator Validator = new Unit3dSettingsValidator();
+        private static readonly Unit3dSettingsValidator Validator = new ();
 
         public Unit3dSettings()
         {

--- a/src/NzbDrone.Core/Indexers/Definitions/Xthor/XthorSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Xthor/XthorSettings.cs
@@ -4,9 +4,17 @@ using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.Definitions.Xthor
 {
+    public class XthorSettingsValidator : NoAuthSettingsValidator<XthorSettings>
+    {
+        public XthorSettingsValidator()
+        : base()
+        {
+        }
+    }
+
     public class XthorSettings : NoAuthTorrentBaseSettings
     {
-        private static readonly XthorSettingsValidator Validator = new XthorSettingsValidator();
+        private static readonly XthorSettingsValidator Validator = new ();
 
         public XthorSettings()
         {

--- a/src/NzbDrone.Core/Indexers/Definitions/Xthor/XthorSettingsValidator.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Xthor/XthorSettingsValidator.cs
@@ -1,8 +1,0 @@
-﻿using FluentValidation;
-
-namespace NzbDrone.Core.Indexers.Definitions.Xthor
-{
-    public class XthorSettingsValidator : AbstractValidator<XthorSettings>
-    {
-    }
-}

--- a/src/NzbDrone.Core/Indexers/Settings/NoAuthTorrentBaseSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Settings/NoAuthTorrentBaseSettings.cs
@@ -4,7 +4,8 @@ using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.Settings
 {
-    public class NoAuthSettingsValidator : AbstractValidator<NoAuthTorrentBaseSettings>
+    public class NoAuthSettingsValidator<T> : AbstractValidator<T>
+    where T : NoAuthTorrentBaseSettings
     {
         public NoAuthSettingsValidator()
         {
@@ -15,7 +16,7 @@ namespace NzbDrone.Core.Indexers.Settings
 
     public class NoAuthTorrentBaseSettings : ITorrentIndexerSettings
     {
-        private static readonly NoAuthSettingsValidator Validator = new NoAuthSettingsValidator();
+        private static readonly NoAuthSettingsValidator<NoAuthTorrentBaseSettings> Validator = new ();
 
         [FieldDefinition(1, Label = "Base Url", Type = FieldType.Select, SelectOptionsProviderAction = "getUrls", HelpText = "Select which baseurl Prowlarr will use for requests to the site")]
         public string BaseUrl { get; set; }

--- a/src/NzbDrone.Core/Indexers/Settings/UserPassTorrentBaseSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Settings/UserPassTorrentBaseSettings.cs
@@ -4,20 +4,21 @@ using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.Settings
 {
+    public class UserPassBaseSettingsValidator<T> : AbstractValidator<T>
+    where T : UserPassTorrentBaseSettings
+    {
+        public UserPassBaseSettingsValidator()
+        {
+            RuleFor(c => c.Username).NotEmpty();
+            RuleFor(c => c.Password).NotEmpty();
+            RuleFor(x => x.BaseSettings).SetValidator(new IndexerCommonSettingsValidator());
+            RuleFor(x => x.TorrentBaseSettings).SetValidator(new IndexerTorrentSettingsValidator());
+        }
+    }
+
     public class UserPassTorrentBaseSettings : ITorrentIndexerSettings
     {
-        public class UserPassBaseSettingsValidator : AbstractValidator<UserPassTorrentBaseSettings>
-        {
-            public UserPassBaseSettingsValidator()
-            {
-                RuleFor(c => c.Username).NotEmpty();
-                RuleFor(c => c.Password).NotEmpty();
-                RuleFor(x => x.BaseSettings).SetValidator(new IndexerCommonSettingsValidator());
-                RuleFor(x => x.TorrentBaseSettings).SetValidator(new IndexerTorrentSettingsValidator());
-            }
-        }
-
-        private static readonly UserPassBaseSettingsValidator Validator = new UserPassBaseSettingsValidator();
+        private static readonly UserPassBaseSettingsValidator<UserPassTorrentBaseSettings> Validator = new ();
 
         public UserPassTorrentBaseSettings()
         {
@@ -40,7 +41,7 @@ namespace NzbDrone.Core.Indexers.Settings
         [FieldDefinition(11)]
         public IndexerTorrentBaseSettings TorrentBaseSettings { get; set; } = new IndexerTorrentBaseSettings();
 
-        public NzbDroneValidationResult Validate()
+        public virtual NzbDroneValidationResult Validate()
         {
             return new NzbDroneValidationResult(Validator.Validate(this));
         }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Many indexers were not properly validating inherited properties, this adjusts UserPassBaseSettingsValidator and NoAuthSettingsValidator to be generic, and subclasses of the settings that need their own validators added now inherity properly from that.

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

I don't see any open issues, I found this while working on another PR