### PR TITLE
New: freeleech token minimum torrent size

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/Pneumatic/Pneumatic.cs
+++ b/src/NzbDrone.Core/Download/Clients/Pneumatic/Pneumatic.cs
@@ -39,7 +39,7 @@ namespace NzbDrone.Core.Download.Clients.Pneumatic
 
             _logger.Debug("Downloading NZB from: {0} to: {1}", url, nzbFile);
 
-            var nzbData = await indexer.Download(url);
+            var nzbData = await indexer.Download(url, release);
 
             File.WriteAllBytes(nzbFile, nzbData);
 

--- a/src/NzbDrone.Core/Download/TorrentClientBase.cs
+++ b/src/NzbDrone.Core/Download/TorrentClientBase.cs
@@ -124,7 +124,7 @@ namespace NzbDrone.Core.Download
         {
             byte[] torrentFile = null;
 
-            torrentFile = await indexer.Download(new Uri(torrentUrl));
+            torrentFile = await indexer.Download(new Uri(torrentUrl), release);
 
             // handle magnet URLs
             if (torrentFile.Length >= 7

--- a/src/NzbDrone.Core/Download/UsenetClientBase.cs
+++ b/src/NzbDrone.Core/Download/UsenetClientBase.cs
@@ -43,7 +43,7 @@ namespace NzbDrone.Core.Download
 
             byte[] nzbData;
 
-            nzbData = await indexer.Download(url);
+            nzbData = await indexer.Download(url, release);
 
             _logger.Info("Adding report [{0}] to the queue.", release.Title);
             return AddFromNzbFile(release, filename, nzbData);

--- a/src/NzbDrone.Core/Indexers/Definitions/AnimeBytes.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/AnimeBytes.cs
@@ -521,9 +521,10 @@ namespace NzbDrone.Core.Indexers.Definitions
         public Action<IDictionary<string, string>, DateTime?> CookiesUpdater { get; set; }
     }
 
-    public class AnimeBytesSettingsValidator : AbstractValidator<AnimeBytesSettings>
+    public class AnimeBytesSettingsValidator : NoAuthSettingsValidator<AnimeBytesSettings>
     {
         public AnimeBytesSettingsValidator()
+        : base()
         {
             RuleFor(c => c.Passkey).NotEmpty()
                                    .Must(x => x.Length == 32 || x.Length == 48)

--- a/src/NzbDrone.Core/Indexers/Definitions/Avistaz/AvistazSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Avistaz/AvistazSettings.cs
@@ -5,9 +5,10 @@ using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.Definitions.Avistaz
 {
-    public class AvistazSettingsValidator : AbstractValidator<AvistazSettings>
+    public class AvistazSettingsValidator : NoAuthSettingsValidator<AvistazSettings>
     {
         public AvistazSettingsValidator()
+        : base()
         {
             RuleFor(c => c.Username).NotEmpty();
             RuleFor(c => c.Password).NotEmpty();

--- a/src/NzbDrone.Core/Indexers/Definitions/BakaBT.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/BakaBT.cs
@@ -49,7 +49,7 @@ namespace NzbDrone.Core.Indexers.Definitions
             return new BakaBTParser(Settings, Capabilities.Categories);
         }
 
-        public override async Task<byte[]> Download(Uri link)
+        public override async Task<byte[]> Download(Uri link, ReleaseInfo release = null)
         {
             var request = new HttpRequestBuilder(link.ToString())
                         .SetCookies(GetCookies() ?? new Dictionary<string, string>())
@@ -66,7 +66,7 @@ namespace NzbDrone.Core.Indexers.Definitions
                 throw new Exception("Unable to find download link.");
             }
 
-            return await base.Download(new Uri(Settings.BaseUrl + downloadLink));
+            return await base.Download(new Uri(Settings.BaseUrl + downloadLink), release);
         }
 
         protected override async Task DoLogin()

--- a/src/NzbDrone.Core/Indexers/Definitions/BeyondHD.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/BeyondHD.cs
@@ -246,9 +246,10 @@ namespace NzbDrone.Core.Indexers.Definitions
         public Action<IDictionary<string, string>, DateTime?> CookiesUpdater { get; set; }
     }
 
-    public class BeyondHDSettingsValidator : AbstractValidator<BeyondHDSettings>
+    public class BeyondHDSettingsValidator : NoAuthSettingsValidator<BeyondHDSettings>
     {
         public BeyondHDSettingsValidator()
+        : base()
         {
             RuleFor(c => c.ApiKey).NotEmpty();
             RuleFor(c => c.RssKey).NotEmpty();
@@ -257,7 +258,7 @@ namespace NzbDrone.Core.Indexers.Definitions
 
     public class BeyondHDSettings : NoAuthTorrentBaseSettings
     {
-        private static readonly BeyondHDSettingsValidator Validator = new BeyondHDSettingsValidator();
+        private static readonly BeyondHDSettingsValidator Validator = new ();
 
         public BeyondHDSettings()
         {

--- a/src/NzbDrone.Core/Indexers/Definitions/BroadcastheNet/BroadcastheNetSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/BroadcastheNet/BroadcastheNetSettings.cs
@@ -5,9 +5,10 @@ using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.BroadcastheNet
 {
-    public class BroadcastheNetSettingsValidator : AbstractValidator<BroadcastheNetSettings>
+    public class BroadcastheNetSettingsValidator : NoAuthSettingsValidator<BroadcastheNetSettings>
     {
         public BroadcastheNetSettingsValidator()
+        : base()
         {
             RuleFor(c => c.ApiKey).NotEmpty();
         }

--- a/src/NzbDrone.Core/Indexers/Definitions/Cardigann/Cardigann.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Cardigann/Cardigann.cs
@@ -12,6 +12,7 @@ using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Exceptions;
 using NzbDrone.Core.IndexerVersions;
 using NzbDrone.Core.Messaging.Events;
+using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 
@@ -165,7 +166,7 @@ namespace NzbDrone.Core.Indexers.Cardigann
             await generator.DoLogin();
         }
 
-        public override async Task<byte[]> Download(Uri link)
+        public override async Task<byte[]> Download(Uri link, ReleaseInfo release = null)
         {
             var generator = (CardigannRequestGenerator)GetRequestGenerator();
 

--- a/src/NzbDrone.Core/Indexers/Definitions/FileList/FileListSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/FileList/FileListSettings.cs
@@ -5,9 +5,10 @@ using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.FileList
 {
-    public class FileListSettingsValidator : AbstractValidator<FileListSettings>
+    public class FileListSettingsValidator : NoAuthSettingsValidator<FileListSettings>
     {
         public FileListSettingsValidator()
+        : base()
         {
             RuleFor(c => c.Username).NotEmpty();
             RuleFor(c => c.Passkey).NotEmpty();

--- a/src/NzbDrone.Core/Indexers/Definitions/Gazelle/Gazelle.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Gazelle/Gazelle.cs
@@ -5,6 +5,7 @@ using NLog;
 using NzbDrone.Common.Http;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Messaging.Events;
+using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.Indexers.Gazelle
 {
@@ -80,9 +81,9 @@ namespace NzbDrone.Core.Indexers.Gazelle
             _logger.Debug("Gazelle authentication succeeded.");
         }
 
-        public override async Task<byte[]> Download(Uri link)
+        public override async Task<byte[]> Download(Uri link, ReleaseInfo release = null)
         {
-            var response = await base.Download(link);
+            var response = await base.Download(link, release);
 
             if (response.Length >= 1
                 && response[0] != 'd' // simple test for torrent vs HTML content
@@ -97,7 +98,7 @@ namespace NzbDrone.Core.Indexers.Gazelle
                     // download again with usetoken=0
                     var requestLinkNew = link.ToString().Replace("usetoken=1", "usetoken=0");
 
-                    response = await base.Download(new Uri(requestLinkNew));
+                    response = await base.Download(new Uri(requestLinkNew), release);
                 }
             }
 

--- a/src/NzbDrone.Core/Indexers/Definitions/Gazelle/GazelleParser.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Gazelle/GazelleParser.cs
@@ -80,7 +80,7 @@ namespace NzbDrone.Core.Indexers.Gazelle
                             Grabs = torrent.Snatches,
                             Codec = torrent.Format,
                             Size = long.Parse(torrent.Size),
-                            DownloadUrl = GetDownloadUrl(id),
+                            DownloadUrl = GetDownloadUrl(id, long.Parse(torrent.Size)),
                             InfoUrl = infoUrl,
                             Seeders = int.Parse(torrent.Seeders),
                             Peers = int.Parse(torrent.Leechers) + int.Parse(torrent.Seeders),
@@ -115,7 +115,7 @@ namespace NzbDrone.Core.Indexers.Gazelle
                         Guid = infoUrl,
                         Title = groupName,
                         Size = long.Parse(result.Size),
-                        DownloadUrl = GetDownloadUrl(id),
+                        DownloadUrl = GetDownloadUrl(id, long.Parse(result.Size)),
                         InfoUrl = infoUrl,
                         Seeders = int.Parse(result.Seeders),
                         Peers = int.Parse(result.Leechers) + int.Parse(result.Seeders),
@@ -148,12 +148,12 @@ namespace NzbDrone.Core.Indexers.Gazelle
                     .ToArray();
         }
 
-        protected virtual string GetDownloadUrl(int torrentId)
+        protected virtual string GetDownloadUrl(int torrentId, long torrentSize)
         {
             var url = new HttpUri(_settings.BaseUrl)
                 .CombinePath("/torrents.php")
                 .AddQueryParam("action", "download")
-                .AddQueryParam("usetoken", _settings.UseFreeleechToken ? "1" : "0")
+                .AddQueryParam("usetoken", _settings.UseFreeleechToken && torrentSize >= _settings.FreeleechSize ? "1" : "0")
                 .AddQueryParam("id", torrentId);
 
             return url.FullUri;

--- a/src/NzbDrone.Core/Indexers/Definitions/Gazelle/GazelleSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Gazelle/GazelleSettings.cs
@@ -10,6 +10,7 @@ namespace NzbDrone.Core.Indexers.Gazelle
         public GazelleSettingsValidator()
         : base()
         {
+            RuleFor(c => c.FreeleechSize).GreaterThanOrEqualTo(0);
         }
     }
 
@@ -19,6 +20,8 @@ namespace NzbDrone.Core.Indexers.Gazelle
 
         public GazelleSettings()
         {
+            UseFreeleechToken = false;
+            FreeleechSize = 0;
         }
 
         public string AuthKey;
@@ -26,6 +29,9 @@ namespace NzbDrone.Core.Indexers.Gazelle
 
         [FieldDefinition(4, Type = FieldType.Checkbox, Label = "Use Freeleech Token", HelpText = "Use freeleech tokens when available")]
         public bool UseFreeleechToken { get; set; }
+
+        [FieldDefinition(5, Type = FieldType.Number, Label = "Freeleech Torrent Size", Unit = "bytes", Advanced = true, HelpText = "Only use freeleech tokens for torrents above a given size")]
+        public long FreeleechSize { get; set; }
 
         public override NzbDroneValidationResult Validate()
         {

--- a/src/NzbDrone.Core/Indexers/Definitions/Gazelle/GazelleSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Gazelle/GazelleSettings.cs
@@ -5,8 +5,18 @@ using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.Gazelle
 {
+    public class GazelleSettingsValidator : UserPassBaseSettingsValidator<GazelleSettings>
+    {
+        public GazelleSettingsValidator()
+        : base()
+        {
+        }
+    }
+
     public class GazelleSettings : UserPassTorrentBaseSettings
     {
+        private static readonly GazelleSettingsValidator Validator = new ();
+
         public GazelleSettings()
         {
         }
@@ -16,5 +26,10 @@ namespace NzbDrone.Core.Indexers.Gazelle
 
         [FieldDefinition(4, Type = FieldType.Checkbox, Label = "Use Freeleech Token", HelpText = "Use freeleech tokens when available")]
         public bool UseFreeleechToken { get; set; }
+
+        public override NzbDroneValidationResult Validate()
+        {
+            return new NzbDroneValidationResult(Validator.Validate(this));
+        }
     }
 }

--- a/src/NzbDrone.Core/Indexers/Definitions/GazelleGames.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/GazelleGames.cs
@@ -431,9 +431,10 @@ namespace NzbDrone.Core.Indexers.Definitions
         public Action<IDictionary<string, string>, DateTime?> CookiesUpdater { get; set; }
     }
 
-    public class GazelleGamesSettingsValidator : AbstractValidator<GazelleGamesSettings>
+    public class GazelleGamesSettingsValidator : NoAuthSettingsValidator<GazelleGamesSettings>
     {
         public GazelleGamesSettingsValidator()
+        : base()
         {
             RuleFor(c => c.Apikey).NotEmpty();
         }

--- a/src/NzbDrone.Core/Indexers/Definitions/GreatPosterWall.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/GreatPosterWall.cs
@@ -129,7 +129,7 @@ public class GreatPosterWallParser : GazelleParser
                     InfoUrl = infoUrl,
                     Guid = infoUrl,
                     PosterUrl = GetPosterUrl(result.Cover),
-                    DownloadUrl = GetDownloadUrl(torrent.TorrentId, torrent.CanUseToken),
+                    DownloadUrl = GetDownloadUrl(torrent.TorrentId, torrent.CanUseToken, torrent.Size),
                     PublishDate = new DateTimeOffset(time, TimeSpan.FromHours(8)).LocalDateTime, // Time is Chinese Time, add 8 hours difference from UTC and then convert back to local time
                     Categories = new List<IndexerCategory> { NewznabStandardCategory.Movies },
                     Size = torrent.Size,
@@ -176,12 +176,12 @@ public class GreatPosterWallParser : GazelleParser
         return torrentInfos;
     }
 
-    protected string GetDownloadUrl(int torrentId, bool canUseToken)
+    protected string GetDownloadUrl(int torrentId, bool canUseToken, long torrentSize)
     {
         var url = new HttpUri(_settings.BaseUrl)
             .CombinePath("/torrents.php")
             .AddQueryParam("action", "download")
-            .AddQueryParam("usetoken", _settings.UseFreeleechToken && canUseToken ? "1" : "0")
+            .AddQueryParam("usetoken", _settings.UseFreeleechToken && canUseToken && torrentSize >= _settings.FreeleechSize ? "1" : "0")
             .AddQueryParam("id", torrentId);
 
         return url.FullUri;

--- a/src/NzbDrone.Core/Indexers/Definitions/HDBits/HDBitsSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/HDBits/HDBitsSettings.cs
@@ -6,9 +6,10 @@ using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.HDBits
 {
-    public class HDBitsSettingsValidator : AbstractValidator<HDBitsSettings>
+    public class HDBitsSettingsValidator : NoAuthSettingsValidator<HDBitsSettings>
     {
         public HDBitsSettingsValidator()
+        : base()
         {
             RuleFor(c => c.ApiKey).NotEmpty();
         }

--- a/src/NzbDrone.Core/Indexers/Definitions/Headphones/Headphones.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Headphones/Headphones.cs
@@ -8,6 +8,7 @@ using NzbDrone.Common.Http;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Download;
 using NzbDrone.Core.Messaging.Events;
+using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.Indexers.Headphones
 {
@@ -51,7 +52,7 @@ namespace NzbDrone.Core.Indexers.Headphones
             }
         }
 
-        public override async Task<byte[]> Download(Uri link)
+        public override async Task<byte[]> Download(Uri link, ReleaseInfo release = null)
         {
             var requestBuilder = new HttpRequestBuilder(link.AbsoluteUri);
 

--- a/src/NzbDrone.Core/Indexers/Definitions/MyAnonamouse.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/MyAnonamouse.cs
@@ -427,9 +427,10 @@ namespace NzbDrone.Core.Indexers.Definitions
         public Action<IDictionary<string, string>, DateTime?> CookiesUpdater { get; set; }
     }
 
-    public class MyAnonamouseSettingsValidator : AbstractValidator<MyAnonamouseSettings>
+    public class MyAnonamouseSettingsValidator : NoAuthSettingsValidator<MyAnonamouseSettings>
     {
         public MyAnonamouseSettingsValidator()
+        : base()
         {
             RuleFor(c => c.MamId).NotEmpty();
         }
@@ -437,7 +438,7 @@ namespace NzbDrone.Core.Indexers.Definitions
 
     public class MyAnonamouseSettings : NoAuthTorrentBaseSettings
     {
-        private static readonly MyAnonamouseSettingsValidator Validator = new MyAnonamouseSettingsValidator();
+        private static readonly MyAnonamouseSettingsValidator Validator = new ();
 
         public MyAnonamouseSettings()
         {

--- a/src/NzbDrone.Core/Indexers/Definitions/MyAnonamouse.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/MyAnonamouse.cs
@@ -50,9 +50,9 @@ namespace NzbDrone.Core.Indexers.Definitions
             return new MyAnonamouseParser(Settings, Capabilities.Categories);
         }
 
-        public override async Task<byte[]> Download(Uri link)
+        public override async Task<byte[]> Download(Uri link, ReleaseInfo release = null)
         {
-            if (Settings.Freeleech)
+            if (Settings.Freeleech && (release == null || release.Size >= Settings.FreeleechSize))
             {
                 _logger.Debug($"Attempting to use freeleech token for {link.AbsoluteUri}");
 
@@ -88,7 +88,7 @@ namespace NzbDrone.Core.Indexers.Definitions
                 }
             }
 
-            return await base.Download(link).ConfigureAwait(false);
+            return await base.Download(link, release).ConfigureAwait(false);
         }
 
         protected override IDictionary<string, string> GetCookies()
@@ -433,6 +433,7 @@ namespace NzbDrone.Core.Indexers.Definitions
         : base()
         {
             RuleFor(c => c.MamId).NotEmpty();
+            RuleFor(c => c.FreeleechSize).GreaterThanOrEqualTo(0);
         }
     }
 
@@ -443,6 +444,7 @@ namespace NzbDrone.Core.Indexers.Definitions
         public MyAnonamouseSettings()
         {
             MamId = "";
+            FreeleechSize = 0;
         }
 
         [FieldDefinition(2, Label = "Mam Id", HelpText = "Mam Session Id (Created Under Preferences -> Security)")]
@@ -453,6 +455,9 @@ namespace NzbDrone.Core.Indexers.Definitions
 
         [FieldDefinition(4, Type = FieldType.Checkbox, Label = "Freeleech", HelpText = "Use freeleech token for download")]
         public bool Freeleech { get; set; }
+
+        [FieldDefinition(5, Type = FieldType.Number, Label = "Freeleech Torrent Size", Unit = "bytes", Advanced = true, HelpText = "Only use freeleech tokens for torrents above a given size")]
+        public long FreeleechSize { get; set; }
 
         public override NzbDroneValidationResult Validate()
         {

--- a/src/NzbDrone.Core/Indexers/Definitions/Orpheus.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Orpheus.cs
@@ -381,9 +381,10 @@ namespace NzbDrone.Core.Indexers.Definitions
         }
     }
 
-    public class OrpheusSettingsValidator : AbstractValidator<OrpheusSettings>
+    public class OrpheusSettingsValidator : NoAuthSettingsValidator<OrpheusSettings>
     {
         public OrpheusSettingsValidator()
+        : base()
         {
             RuleFor(c => c.Apikey).NotEmpty();
         }
@@ -391,7 +392,7 @@ namespace NzbDrone.Core.Indexers.Definitions
 
     public class OrpheusSettings : NoAuthTorrentBaseSettings
     {
-        private static readonly OrpheusSettingsValidator Validator = new OrpheusSettingsValidator();
+        private static readonly OrpheusSettingsValidator Validator = new ();
 
         public OrpheusSettings()
         {

--- a/src/NzbDrone.Core/Indexers/Definitions/Orpheus.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Orpheus.cs
@@ -72,7 +72,7 @@ namespace NzbDrone.Core.Indexers.Definitions
             return caps;
         }
 
-        public override async Task<byte[]> Download(Uri link)
+        public override async Task<byte[]> Download(Uri link, ReleaseInfo release = null)
         {
             var request = new HttpRequestBuilder(link.AbsoluteUri)
                 .SetHeader("Authorization", $"token {Settings.Apikey}")
@@ -281,7 +281,7 @@ namespace NzbDrone.Core.Indexers.Definitions
                             Container = torrent.Encoding,
                             Codec = torrent.Format,
                             Size = long.Parse(torrent.Size),
-                            DownloadUrl = GetDownloadUrl(id, torrent.CanUseToken),
+                            DownloadUrl = GetDownloadUrl(id, torrent.CanUseToken, long.Parse(torrent.Size)),
                             InfoUrl = infoUrl,
                             Seeders = int.Parse(torrent.Seeders),
                             Peers = int.Parse(torrent.Leechers) + int.Parse(torrent.Seeders),
@@ -319,7 +319,7 @@ namespace NzbDrone.Core.Indexers.Definitions
                         Guid = infoUrl,
                         Title = WebUtility.HtmlDecode(result.GroupName),
                         Size = long.Parse(result.Size),
-                        DownloadUrl = GetDownloadUrl(id, result.CanUseToken),
+                        DownloadUrl = GetDownloadUrl(id, result.CanUseToken, long.Parse(result.Size)),
                         InfoUrl = infoUrl,
                         Seeders = int.Parse(result.Seeders),
                         Peers = int.Parse(result.Leechers) + int.Parse(result.Seeders),
@@ -352,7 +352,7 @@ namespace NzbDrone.Core.Indexers.Definitions
                     .ToArray();
         }
 
-        private string GetDownloadUrl(int torrentId, bool canUseToken)
+        private string GetDownloadUrl(int torrentId, bool canUseToken, long torrentSize)
         {
             // AuthKey is required but not checked, just pass in a dummy variable
             // to avoid having to track authkey, which is randomly cycled
@@ -362,7 +362,7 @@ namespace NzbDrone.Core.Indexers.Definitions
                 .AddQueryParam("id", torrentId);
 
             // Orpheus fails to download if usetoken=0 so we need to only add if we will use one
-            if (_settings.UseFreeleechToken)
+            if (_settings.UseFreeleechToken && canUseToken && torrentSize >= _settings.FreeleechSize)
             {
                 url = url.AddQueryParam("usetoken", "1");
             }
@@ -387,6 +387,7 @@ namespace NzbDrone.Core.Indexers.Definitions
         : base()
         {
             RuleFor(c => c.Apikey).NotEmpty();
+            RuleFor(c => c.FreeleechSize).GreaterThanOrEqualTo(0);
         }
     }
 
@@ -398,6 +399,7 @@ namespace NzbDrone.Core.Indexers.Definitions
         {
             Apikey = "";
             UseFreeleechToken = false;
+            FreeleechSize = 0;
         }
 
         [FieldDefinition(2, Label = "API Key", HelpText = "API Key from the Site (Found in Settings => Access Settings)", Privacy = PrivacyLevel.ApiKey)]
@@ -405,6 +407,9 @@ namespace NzbDrone.Core.Indexers.Definitions
 
         [FieldDefinition(3, Label = "Use Freeleech Tokens", HelpText = "Use freeleech tokens when available", Type = FieldType.Checkbox)]
         public bool UseFreeleechToken { get; set; }
+
+        [FieldDefinition(4, Type = FieldType.Number, Label = "Freeleech Torrent Size", Unit = "bytes", Advanced = true, HelpText = "Only use freeleech tokens for torrents above a given size")]
+        public long FreeleechSize { get; set; }
 
         public override NzbDroneValidationResult Validate()
         {

--- a/src/NzbDrone.Core/Indexers/Definitions/PassThePopcorn/PassThePopcornSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/PassThePopcorn/PassThePopcornSettings.cs
@@ -5,9 +5,10 @@ using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.PassThePopcorn
 {
-    public class PassThePopcornSettingsValidator : AbstractValidator<PassThePopcornSettings>
+    public class PassThePopcornSettingsValidator : NoAuthSettingsValidator<PassThePopcornSettings>
     {
         public PassThePopcornSettingsValidator()
+        : base()
         {
             RuleFor(c => c.APIUser).NotEmpty();
             RuleFor(c => c.APIKey).NotEmpty();
@@ -16,7 +17,7 @@ namespace NzbDrone.Core.Indexers.PassThePopcorn
 
     public class PassThePopcornSettings : NoAuthTorrentBaseSettings
     {
-        private static readonly PassThePopcornSettingsValidator Validator = new PassThePopcornSettingsValidator();
+        private static readonly PassThePopcornSettingsValidator Validator = new ();
 
         public PassThePopcornSettings()
         {

--- a/src/NzbDrone.Core/Indexers/Definitions/PreToMe.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/PreToMe.cs
@@ -380,9 +380,10 @@ namespace NzbDrone.Core.Indexers.Definitions
         public Action<IDictionary<string, string>, DateTime?> CookiesUpdater { get; set; }
     }
 
-    public class PreToMeSettingsValidator : AbstractValidator<PreToMeSettings>
+    public class PreToMeSettingsValidator : NoAuthSettingsValidator<PreToMeSettings>
     {
         public PreToMeSettingsValidator()
+        : base()
         {
             RuleFor(c => c.Pin).NotEmpty();
             RuleFor(c => c.Username).NotEmpty();
@@ -392,7 +393,7 @@ namespace NzbDrone.Core.Indexers.Definitions
 
     public class PreToMeSettings : NoAuthTorrentBaseSettings
     {
-        private static readonly PreToMeSettingsValidator Validator = new PreToMeSettingsValidator();
+        private static readonly PreToMeSettingsValidator Validator = new ();
 
         public PreToMeSettings()
         {

--- a/src/NzbDrone.Core/Indexers/Definitions/Redacted.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Redacted.cs
@@ -326,9 +326,10 @@ namespace NzbDrone.Core.Indexers.Definitions
         }
     }
 
-    public class RedactedSettingsValidator : AbstractValidator<RedactedSettings>
+    public class RedactedSettingsValidator : NoAuthSettingsValidator<RedactedSettings>
     {
         public RedactedSettingsValidator()
+        : base()
         {
             RuleFor(c => c.Apikey).NotEmpty();
         }

--- a/src/NzbDrone.Core/Indexers/Definitions/SceneHD.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/SceneHD.cs
@@ -233,9 +233,10 @@ namespace NzbDrone.Core.Indexers.Definitions
         public Action<IDictionary<string, string>, DateTime?> CookiesUpdater { get; set; }
     }
 
-    public class SceneHDSettingsValidator : AbstractValidator<SceneHDSettings>
+    public class SceneHDSettingsValidator : NoAuthSettingsValidator<SceneHDSettings>
     {
         public SceneHDSettingsValidator()
+        : base()
         {
             RuleFor(c => c.Passkey).NotEmpty().Length(32);
         }
@@ -243,7 +244,7 @@ namespace NzbDrone.Core.Indexers.Definitions
 
     public class SceneHDSettings : NoAuthTorrentBaseSettings
     {
-        private static readonly SceneHDSettingsValidator Validator = new SceneHDSettingsValidator();
+        private static readonly SceneHDSettingsValidator Validator = new ();
 
         public SceneHDSettings()
         {

--- a/src/NzbDrone.Core/Indexers/Definitions/SpeedApp/SpeedAppBase.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/SpeedApp/SpeedAppBase.cs
@@ -325,9 +325,10 @@ namespace NzbDrone.Core.Indexers.Definitions
         }
     }
 
-    public class SpeedAppSettingsValidator : AbstractValidator<SpeedAppSettings>
+    public class SpeedAppSettingsValidator : NoAuthSettingsValidator<SpeedAppSettings>
     {
         public SpeedAppSettingsValidator()
+        : base()
         {
             RuleFor(c => c.Email).NotEmpty();
             RuleFor(c => c.Password).NotEmpty();

--- a/src/NzbDrone.Core/Indexers/Definitions/SpeedApp/SpeedAppBase.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/SpeedApp/SpeedAppBase.cs
@@ -103,7 +103,7 @@ namespace NzbDrone.Core.Indexers.Definitions
             request.HttpRequest.Headers.Set("Authorization", $"Bearer {Settings.ApiKey}");
         }
 
-        public override async Task<byte[]> Download(Uri link)
+        public override async Task<byte[]> Download(Uri link, ReleaseInfo release = null)
         {
             Cookies = GetCookies();
 

--- a/src/NzbDrone.Core/Indexers/Definitions/TorrentSyndikat.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/TorrentSyndikat.cs
@@ -323,9 +323,10 @@ namespace NzbDrone.Core.Indexers.Definitions
         public Action<IDictionary<string, string>, DateTime?> CookiesUpdater { get; set; }
     }
 
-    public class TorrentSyndikatSettingsValidator : AbstractValidator<TorrentSyndikatSettings>
+    public class TorrentSyndikatSettingsValidator : NoAuthSettingsValidator<TorrentSyndikatSettings>
     {
         public TorrentSyndikatSettingsValidator()
+        : base()
         {
             RuleFor(c => c.ApiKey).NotEmpty();
         }
@@ -333,7 +334,7 @@ namespace NzbDrone.Core.Indexers.Definitions
 
     public class TorrentSyndikatSettings : NoAuthTorrentBaseSettings
     {
-        private static readonly TorrentSyndikatSettingsValidator Validator = new TorrentSyndikatSettingsValidator();
+        private static readonly TorrentSyndikatSettingsValidator Validator = new ();
 
         public TorrentSyndikatSettings()
         {

--- a/src/NzbDrone.Core/Indexers/Definitions/UNIT3D/Unit3dSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/UNIT3D/Unit3dSettings.cs
@@ -5,9 +5,10 @@ using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.Definitions.UNIT3D
 {
-    public class Unit3dSettingsValidator : AbstractValidator<Unit3dSettings>
+    public class Unit3dSettingsValidator : NoAuthSettingsValidator<Unit3dSettings>
     {
         public Unit3dSettingsValidator()
+        : base()
         {
             RuleFor(c => c.ApiKey).NotEmpty();
         }
@@ -15,7 +16,7 @@ namespace NzbDrone.Core.Indexers.Definitions.UNIT3D
 
     public class Unit3dSettings : NoAuthTorrentBaseSettings
     {
-        private static readonly Unit3dSettingsValidator Validator = new Unit3dSettingsValidator();
+        private static readonly Unit3dSettingsValidator Validator = new ();
 
         public Unit3dSettings()
         {

--- a/src/NzbDrone.Core/Indexers/Definitions/Xthor/XthorSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Xthor/XthorSettings.cs
@@ -4,9 +4,17 @@ using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.Definitions.Xthor
 {
+    public class XthorSettingsValidator : NoAuthSettingsValidator<XthorSettings>
+    {
+        public XthorSettingsValidator()
+        : base()
+        {
+        }
+    }
+
     public class XthorSettings : NoAuthTorrentBaseSettings
     {
-        private static readonly XthorSettingsValidator Validator = new XthorSettingsValidator();
+        private static readonly XthorSettingsValidator Validator = new ();
 
         public XthorSettings()
         {

--- a/src/NzbDrone.Core/Indexers/Definitions/Xthor/XthorSettingsValidator.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Xthor/XthorSettingsValidator.cs
@@ -1,8 +1,0 @@
-﻿using FluentValidation;
-
-namespace NzbDrone.Core.Indexers.Definitions.Xthor
-{
-    public class XthorSettingsValidator : AbstractValidator<XthorSettings>
-    {
-    }
-}

--- a/src/NzbDrone.Core/Indexers/IIndexer.cs
+++ b/src/NzbDrone.Core/Indexers/IIndexer.cs
@@ -2,6 +2,7 @@ using System;
 using System.Text;
 using System.Threading.Tasks;
 using NzbDrone.Core.IndexerSearch.Definitions;
+using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.ThingiProvider;
 
 namespace NzbDrone.Core.Indexers
@@ -27,7 +28,7 @@ namespace NzbDrone.Core.Indexers
         Task<IndexerPageableQueryResult> Fetch(BookSearchCriteria searchCriteria);
         Task<IndexerPageableQueryResult> Fetch(BasicSearchCriteria searchCriteria);
 
-        Task<byte[]> Download(Uri link);
+        Task<byte[]> Download(Uri link, ReleaseInfo release = null);
         bool IsObsolete();
 
         IndexerCapabilities GetCapabilities();

--- a/src/NzbDrone.Core/Indexers/IndexerBase.cs
+++ b/src/NzbDrone.Core/Indexers/IndexerBase.cs
@@ -100,7 +100,7 @@ namespace NzbDrone.Core.Indexers
         public abstract Task<IndexerPageableQueryResult> Fetch(TvSearchCriteria searchCriteria);
         public abstract Task<IndexerPageableQueryResult> Fetch(BookSearchCriteria searchCriteria);
         public abstract Task<IndexerPageableQueryResult> Fetch(BasicSearchCriteria searchCriteria);
-        public abstract Task<byte[]> Download(Uri link);
+        public abstract Task<byte[]> Download(Uri link, ReleaseInfo release);
 
         public abstract IndexerCapabilities GetCapabilities();
 

--- a/src/NzbDrone.Core/Indexers/Settings/NoAuthTorrentBaseSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Settings/NoAuthTorrentBaseSettings.cs
@@ -4,7 +4,8 @@ using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.Settings
 {
-    public class NoAuthSettingsValidator : AbstractValidator<NoAuthTorrentBaseSettings>
+    public class NoAuthSettingsValidator<T> : AbstractValidator<T>
+    where T : NoAuthTorrentBaseSettings
     {
         public NoAuthSettingsValidator()
         {
@@ -15,7 +16,7 @@ namespace NzbDrone.Core.Indexers.Settings
 
     public class NoAuthTorrentBaseSettings : ITorrentIndexerSettings
     {
-        private static readonly NoAuthSettingsValidator Validator = new NoAuthSettingsValidator();
+        private static readonly NoAuthSettingsValidator<NoAuthTorrentBaseSettings> Validator = new ();
 
         [FieldDefinition(1, Label = "Base Url", Type = FieldType.Select, SelectOptionsProviderAction = "getUrls", HelpText = "Select which baseurl Prowlarr will use for requests to the site")]
         public string BaseUrl { get; set; }

--- a/src/NzbDrone.Core/Indexers/Settings/UserPassTorrentBaseSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Settings/UserPassTorrentBaseSettings.cs
@@ -4,20 +4,21 @@ using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.Settings
 {
+    public class UserPassBaseSettingsValidator<T> : AbstractValidator<T>
+    where T : UserPassTorrentBaseSettings
+    {
+        public UserPassBaseSettingsValidator()
+        {
+            RuleFor(c => c.Username).NotEmpty();
+            RuleFor(c => c.Password).NotEmpty();
+            RuleFor(x => x.BaseSettings).SetValidator(new IndexerCommonSettingsValidator());
+            RuleFor(x => x.TorrentBaseSettings).SetValidator(new IndexerTorrentSettingsValidator());
+        }
+    }
+
     public class UserPassTorrentBaseSettings : ITorrentIndexerSettings
     {
-        public class UserPassBaseSettingsValidator : AbstractValidator<UserPassTorrentBaseSettings>
-        {
-            public UserPassBaseSettingsValidator()
-            {
-                RuleFor(c => c.Username).NotEmpty();
-                RuleFor(c => c.Password).NotEmpty();
-                RuleFor(x => x.BaseSettings).SetValidator(new IndexerCommonSettingsValidator());
-                RuleFor(x => x.TorrentBaseSettings).SetValidator(new IndexerTorrentSettingsValidator());
-            }
-        }
-
-        private static readonly UserPassBaseSettingsValidator Validator = new UserPassBaseSettingsValidator();
+        private static readonly UserPassBaseSettingsValidator<UserPassTorrentBaseSettings> Validator = new ();
 
         public UserPassTorrentBaseSettings()
         {
@@ -40,7 +41,7 @@ namespace NzbDrone.Core.Indexers.Settings
         [FieldDefinition(11)]
         public IndexerTorrentBaseSettings TorrentBaseSettings { get; set; } = new IndexerTorrentBaseSettings();
 
-        public NzbDroneValidationResult Validate()
+        public virtual NzbDroneValidationResult Validate()
         {
             return new NzbDroneValidationResult(Validator.Validate(this));
         }

--- a/src/NzbDrone.Core/Indexers/TorrentIndexerBase.cs
+++ b/src/NzbDrone.Core/Indexers/TorrentIndexerBase.cs
@@ -8,6 +8,7 @@ using NzbDrone.Common.Http;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Exceptions;
 using NzbDrone.Core.Messaging.Events;
+using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.Indexers
 {
@@ -19,7 +20,7 @@ namespace NzbDrone.Core.Indexers
         {
         }
 
-        public override async Task<byte[]> Download(Uri link)
+        public override async Task<byte[]> Download(Uri link, ReleaseInfo release = null)
         {
             Cookies = GetCookies();
 

--- a/src/NzbDrone.Core/Indexers/UsenetIndexerBase.cs
+++ b/src/NzbDrone.Core/Indexers/UsenetIndexerBase.cs
@@ -7,6 +7,7 @@ using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Download;
 using NzbDrone.Core.Exceptions;
 using NzbDrone.Core.Messaging.Events;
+using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.Indexers
 {
@@ -21,7 +22,7 @@ namespace NzbDrone.Core.Indexers
             _nzbValidationService = nzbValidationService;
         }
 
-        public override async Task<byte[]> Download(Uri link)
+        public override async Task<byte[]> Download(Uri link, ReleaseInfo release = null)
         {
             Cookies = GetCookies();
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description

I only want to use my tokens for torrents above a given size. This
extends IIndexer.Download() to include optional ReleaseInfo, which can
be used to compare ReleaseInfo.Size against the configured
FreeleechSize.

In cases like Gazelle where GetDownloadUrl() handles the `usetoken`
parameter, I added a `torrentSize` parameter as well.

#### Screenshot (if UI related)

![image](https://user-images.githubusercontent.com/259751/210431068-1f7cc965-9100-4629-9339-72d776c30a4a.png)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

I haven't created an issue, I figured I would just PR this.

Changes to Gazelle's settings ended up based on my other PR #1279 