### PR TITLE
Fixed: (Cardigann) Apply RateLimit by using RequestDelay from definitions

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/Cardigann/Cardigann.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Cardigann/Cardigann.cs
@@ -30,8 +30,23 @@ namespace NzbDrone.Core.Indexers.Cardigann
         public override IndexerPrivacy Privacy => IndexerPrivacy.Private;
 
         // Page size is different per indexer, setting to 1 ensures we don't break out of paging logic
-        // thinking its a partial page and insteaad all search_path requests are run for each indexer
+        // thinking its a partial page and instead all search_path requests are run for each indexer
         public override int PageSize => 1;
+
+        public override TimeSpan RateLimit
+        {
+            get
+            {
+                var definition = _definitionService.GetCachedDefinition(Settings.DefinitionFile);
+
+                if (definition.RequestDelay.HasValue && definition.RequestDelay.Value > base.RateLimit.TotalSeconds)
+                {
+                    return TimeSpan.FromSeconds(definition.RequestDelay.Value);
+                }
+
+                return base.RateLimit;
+            }
+        }
 
         public override IIndexerRequestGenerator GetRequestGenerator()
         {

--- a/src/NzbDrone.Core/Indexers/Definitions/Cardigann/CardigannDefinition.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Cardigann/CardigannDefinition.cs
@@ -41,6 +41,7 @@ namespace NzbDrone.Core.Indexers.Cardigann
         public string Type { get; set; }
         public string Language { get; set; }
         public string Encoding { get; set; }
+        public double? RequestDelay { get; set; }
         public List<string> Links { get; set; }
         public List<string> Legacylinks { get; set; }
         public bool Followredirect { get; set; } = false;


### PR DESCRIPTION
Just as a safe measure, use `RequestDelay` value only if it's greater than the inherited RateLimit (2s currently).

#### Database Migration
NO

#### Issues Fixed or Closed by this PR

* Fixes #1287