### PR TITLE
Fixed: (AvistaZ) Use different timezone offset than the rest

### DIFF
--- a/src/NzbDrone.Core.Test/IndexerTests/AvistazTests/AvistazFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/AvistazTests/AvistazFixture.cs
@@ -51,7 +51,7 @@ namespace NzbDrone.Core.Test.IndexerTests.AvistazTests
             torrentInfo.InfoUrl.Should().Be("https://avistaz.to/torrent/187240-japan-sinks-people-of-hope-2021-s01e05-720p-nf-web-dl-ddp20-x264-seikel");
             torrentInfo.CommentUrl.Should().BeNullOrEmpty();
             torrentInfo.Indexer.Should().Be(Subject.Definition.Name);
-            torrentInfo.PublishDate.Should().Be(DateTime.Parse("2021-11-15 04:26:21"));
+            torrentInfo.PublishDate.Should().Be(DateTime.Parse("2021-11-14 22:26:21"));
             torrentInfo.Size.Should().Be(935127615);
             torrentInfo.InfoHash.Should().Be("a879261d4e6e792402f92401141a21de70d51bf2");
             torrentInfo.MagnetUrl.Should().Be(null);

--- a/src/NzbDrone.Core/Indexers/Definitions/AvistaZ.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/AvistaZ.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using NLog;
-using NzbDrone.Common.Http;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Indexers.Definitions.Avistaz;
 using NzbDrone.Core.Messaging.Events;
@@ -10,18 +9,23 @@ namespace NzbDrone.Core.Indexers.Definitions
     public class AvistaZ : AvistazBase
     {
         public override string Name => "AvistaZ";
-        public override string[] IndexerUrls => new string[] { "https://avistaz.to/" };
+        public override string[] IndexerUrls => new[] { "https://avistaz.to/" };
         public override string Description => "Aka AsiaTorrents";
         public override IndexerPrivacy Privacy => IndexerPrivacy.Private;
 
-        public AvistaZ(IIndexerRepository indexerRepository, IIndexerHttpClient httpClient, IEventAggregator eventAggregator, IIndexerStatusService indexerStatusService, IConfigService configService, Logger logger)
+        public AvistaZ(IIndexerRepository indexerRepository,
+                       IIndexerHttpClient httpClient,
+                       IEventAggregator eventAggregator,
+                       IIndexerStatusService indexerStatusService,
+                       IConfigService configService,
+                       Logger logger)
             : base(indexerRepository, httpClient, eventAggregator, indexerStatusService, configService, logger)
         {
         }
 
         public override IIndexerRequestGenerator GetRequestGenerator()
         {
-            return new AvistazRequestGenerator()
+            return new AvistazRequestGenerator
             {
                 Settings = Settings,
                 HttpClient = _httpClient,
@@ -30,18 +34,23 @@ namespace NzbDrone.Core.Indexers.Definitions
             };
         }
 
+        public override IParseIndexerResponse GetParser()
+        {
+            return new AvistaZParser();
+        }
+
         protected override IndexerCapabilities SetCapabilities()
         {
             var caps = new IndexerCapabilities
             {
                 TvSearchParams = new List<TvSearchParam>
-                       {
-                           TvSearchParam.Q, TvSearchParam.Season, TvSearchParam.Ep, TvSearchParam.ImdbId, TvSearchParam.TvdbId, TvSearchParam.Genre
-                       },
+                {
+                    TvSearchParam.Q, TvSearchParam.Season, TvSearchParam.Ep, TvSearchParam.ImdbId, TvSearchParam.TvdbId, TvSearchParam.Genre
+                },
                 MovieSearchParams = new List<MovieSearchParam>
-                       {
-                           MovieSearchParam.Q, MovieSearchParam.ImdbId, MovieSearchParam.TmdbId, MovieSearchParam.Genre
-                       }
+                {
+                    MovieSearchParam.Q, MovieSearchParam.ImdbId, MovieSearchParam.TmdbId, MovieSearchParam.Genre
+                }
             };
 
             caps.Categories.AddCategoryMapping(1, NewznabStandardCategory.Movies);
@@ -56,5 +65,10 @@ namespace NzbDrone.Core.Indexers.Definitions
 
             return caps;
         }
+    }
+
+    public class AvistaZParser : AvistazParserBase
+    {
+        protected override string TimezoneOffset => "+01:00";
     }
 }

--- a/src/NzbDrone.Core/Indexers/Definitions/Avistaz/AvistazApi.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Avistaz/AvistazApi.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 

--- a/src/NzbDrone.Core/Indexers/Definitions/Avistaz/AvistazBase.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Avistaz/AvistazBase.cs
@@ -13,12 +13,11 @@ namespace NzbDrone.Core.Indexers.Definitions.Avistaz
     public abstract class AvistazBase : TorrentIndexerBase<AvistazSettings>
     {
         public override DownloadProtocol Protocol => DownloadProtocol.Torrent;
-        public override string[] IndexerUrls => new string[] { "" };
-        protected virtual string LoginUrl => Settings.BaseUrl + "api/v1/jackett/auth";
         public override bool SupportsRss => true;
         public override bool SupportsSearch => true;
         public override int PageSize => 50;
         public override IndexerCapabilities Capabilities => SetCapabilities();
+        protected virtual string LoginUrl => Settings.BaseUrl + "api/v1/jackett/auth";
         private IIndexerRepository _indexerRepository;
 
         public AvistazBase(IIndexerRepository indexerRepository,
@@ -34,7 +33,7 @@ namespace NzbDrone.Core.Indexers.Definitions.Avistaz
 
         public override IIndexerRequestGenerator GetRequestGenerator()
         {
-            return new AvistazRequestGenerator()
+            return new AvistazRequestGenerator
             {
                 Settings = Settings,
                 HttpClient = _httpClient,
@@ -45,14 +44,12 @@ namespace NzbDrone.Core.Indexers.Definitions.Avistaz
 
         public override IParseIndexerResponse GetParser()
         {
-            return new AvistazParser();
+            return new AvistazParserBase();
         }
 
         protected virtual IndexerCapabilities SetCapabilities()
         {
-            var caps = new IndexerCapabilities();
-
-            return caps;
+            return new IndexerCapabilities();
         }
 
         protected override async Task DoLogin()

--- a/src/NzbDrone.Core/Indexers/Definitions/Avistaz/AvistazParserBase.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Avistaz/AvistazParserBase.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Net;
 using NzbDrone.Common.Extensions;
@@ -10,13 +11,10 @@ using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.Indexers.Definitions.Avistaz
 {
-    public class AvistazParser : IParseIndexerResponse
+    public class AvistazParserBase : IParseIndexerResponse
     {
-        private readonly HashSet<string> _hdResolutions = new HashSet<string> { "1080p", "1080i", "720p" };
-
-        public AvistazParser()
-        {
-        }
+        protected virtual string TimezoneOffset => "-05:00"; // Avistaz does not specify a timezone & returns server time
+        private readonly HashSet<string> _hdResolutions = new () { "1080p", "1080i", "720p" };
 
         public Action<IDictionary<string, string>, DateTime?> CookiesUpdater { get; set; }
 
@@ -61,7 +59,7 @@ namespace NzbDrone.Core.Indexers.Definitions.Avistaz
                     InfoUrl = details,
                     Guid = details,
                     Categories = cats,
-                    PublishDate = DateTime.Parse(row.CreatedAt + "-05:00").ToUniversalTime(), // Avistaz does not specify a timezone & returns server time
+                    PublishDate = DateTime.Parse($"{row.CreatedAt} {TimezoneOffset}", CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal),
                     Size = row.FileSize,
                     Files = row.FileCount,
                     Grabs = row.Completed,

--- a/src/NzbDrone.Core/Indexers/Definitions/Avistaz/AvistazRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Avistaz/AvistazRequestGenerator.cs
@@ -12,17 +12,12 @@ namespace NzbDrone.Core.Indexers.Definitions.Avistaz
     public class AvistazRequestGenerator : IIndexerRequestGenerator
     {
         public AvistazSettings Settings { get; set; }
-
-        public IDictionary<string, string> AuthCookieCache { get; set; }
         public IIndexerHttpClient HttpClient { get; set; }
         public IndexerCapabilities Capabilities { get; set; }
         public Logger Logger { get; set; }
-
-        protected virtual string SearchUrl => Settings.BaseUrl + "api/v1/jackett/torrents";
-        protected virtual bool ImdbInTags => false;
-
         public Func<IDictionary<string, string>> GetCookies { get; set; }
         public Action<IDictionary<string, string>, DateTime?> CookiesUpdater { get; set; }
+        protected virtual string SearchUrl => Settings.BaseUrl + "api/v1/jackett/torrents";
 
         // hook to adjust the search category
         protected virtual List<KeyValuePair<string, string>> GetBasicSearchParameters(int[] categories, string genre)
@@ -45,7 +40,8 @@ namespace NzbDrone.Core.Indexers.Definitions.Avistaz
             }
 
             // resolution filter to improve the search
-            if (!categories.Contains(NewznabStandardCategory.Movies.Id) && !categories.Contains(NewznabStandardCategory.TV.Id) &&
+            if (!categories.Contains(NewznabStandardCategory.Movies.Id) &&
+                !categories.Contains(NewznabStandardCategory.TV.Id) &&
                 !categories.Contains(NewznabStandardCategory.Audio.Id))
             {
                 if (categories.Contains(NewznabStandardCategory.MoviesUHD.Id) || categories.Contains(NewznabStandardCategory.TVUHD.Id))

--- a/src/NzbDrone.Core/Indexers/Definitions/CinemaZ.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/CinemaZ.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using NLog;
-using NzbDrone.Common.Http;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Indexers.Definitions.Avistaz;
 using NzbDrone.Core.Messaging.Events;
@@ -10,18 +9,23 @@ namespace NzbDrone.Core.Indexers.Definitions
     public class CinemaZ : AvistazBase
     {
         public override string Name => "CinemaZ";
-        public override string[] IndexerUrls => new string[] { "https://cinemaz.to/" };
+        public override string[] IndexerUrls => new[] { "https://cinemaz.to/" };
         public override string Description => "CinemaZ (EuTorrents) is a Private Torrent Tracker for FOREIGN NON-ASIAN MOVIES.";
         public override IndexerPrivacy Privacy => IndexerPrivacy.Private;
 
-        public CinemaZ(IIndexerRepository indexerRepository, IIndexerHttpClient httpClient, IEventAggregator eventAggregator, IIndexerStatusService indexerStatusService, IConfigService configService, Logger logger)
+        public CinemaZ(IIndexerRepository indexerRepository,
+                       IIndexerHttpClient httpClient,
+                       IEventAggregator eventAggregator,
+                       IIndexerStatusService indexerStatusService,
+                       IConfigService configService,
+                       Logger logger)
             : base(indexerRepository, httpClient, eventAggregator, indexerStatusService, configService, logger)
         {
         }
 
         public override IIndexerRequestGenerator GetRequestGenerator()
         {
-            return new AvistazRequestGenerator()
+            return new AvistazRequestGenerator
             {
                 Settings = Settings,
                 HttpClient = _httpClient,

--- a/src/NzbDrone.Core/Indexers/Definitions/ExoticaZ.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/ExoticaZ.cs
@@ -10,18 +10,23 @@ namespace NzbDrone.Core.Indexers.Definitions
     public class ExoticaZ : AvistazBase
     {
         public override string Name => "ExoticaZ";
-        public override string[] IndexerUrls => new string[] { "https://exoticaz.to/" };
+        public override string[] IndexerUrls => new[] { "https://exoticaz.to/" };
         public override string Description => "ExoticaZ (YourExotic) is a Private Torrent Tracker for 3X";
         public override IndexerPrivacy Privacy => IndexerPrivacy.Private;
 
-        public ExoticaZ(IIndexerRepository indexerRepository, IIndexerHttpClient httpClient, IEventAggregator eventAggregator, IIndexerStatusService indexerStatusService, IConfigService configService, Logger logger)
+        public ExoticaZ(IIndexerRepository indexerRepository,
+                        IIndexerHttpClient httpClient,
+                        IEventAggregator eventAggregator,
+                        IIndexerStatusService indexerStatusService,
+                        IConfigService configService,
+                        Logger logger)
             : base(indexerRepository, httpClient, eventAggregator, indexerStatusService, configService, logger)
         {
         }
 
         public override IIndexerRequestGenerator GetRequestGenerator()
         {
-            return new AvistazRequestGenerator()
+            return new AvistazRequestGenerator
             {
                 Settings = Settings,
                 HttpClient = _httpClient,
@@ -52,7 +57,7 @@ namespace NzbDrone.Core.Indexers.Definitions
         }
     }
 
-    public class ExoticaZParser : AvistazParser
+    public class ExoticaZParser : AvistazParserBase
     {
         private readonly IndexerCapabilitiesCategories _categories;
 

--- a/src/NzbDrone.Core/Indexers/Definitions/PrivateHD.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/PrivateHD.cs
@@ -6,21 +6,26 @@ using NzbDrone.Core.Messaging.Events;
 
 namespace NzbDrone.Core.Indexers.Definitions
 {
-    public class PrivateHD : Avistaz.AvistazBase
+    public class PrivateHD : AvistazBase
     {
         public override string Name => "PrivateHD";
-        public override string[] IndexerUrls => new string[] { "https://privatehd.to/" };
+        public override string[] IndexerUrls => new[] { "https://privatehd.to/" };
         public override string Description => "PrivateHD is a Private Torrent Tracker for HD MOVIES / TV and the sister-site of AvistaZ, CinemaZ, ExoticaZ, and AnimeTorrents";
         public override IndexerPrivacy Privacy => IndexerPrivacy.Private;
 
-        public PrivateHD(IIndexerRepository indexerRepository, IIndexerHttpClient httpClient, IEventAggregator eventAggregator, IIndexerStatusService indexerStatusService, IConfigService configService, Logger logger)
+        public PrivateHD(IIndexerRepository indexerRepository,
+                         IIndexerHttpClient httpClient,
+                         IEventAggregator eventAggregator,
+                         IIndexerStatusService indexerStatusService,
+                         IConfigService configService,
+                         Logger logger)
             : base(indexerRepository, httpClient, eventAggregator, indexerStatusService, configService, logger)
         {
         }
 
         public override IIndexerRequestGenerator GetRequestGenerator()
         {
-            return new AvistazRequestGenerator()
+            return new AvistazRequestGenerator
             {
                 Settings = Settings,
                 HttpClient = _httpClient,
@@ -34,13 +39,13 @@ namespace NzbDrone.Core.Indexers.Definitions
             var caps = new IndexerCapabilities
             {
                 TvSearchParams = new List<TvSearchParam>
-                       {
-                           TvSearchParam.Q, TvSearchParam.Season, TvSearchParam.Ep, TvSearchParam.ImdbId, TvSearchParam.TvdbId, TvSearchParam.Genre
-                       },
+                {
+                    TvSearchParam.Q, TvSearchParam.Season, TvSearchParam.Ep, TvSearchParam.ImdbId, TvSearchParam.TvdbId, TvSearchParam.Genre
+                },
                 MovieSearchParams = new List<MovieSearchParam>
-                       {
-                           MovieSearchParam.Q, MovieSearchParam.ImdbId, MovieSearchParam.TmdbId, MovieSearchParam.Genre
-                       }
+                {
+                    MovieSearchParam.Q, MovieSearchParam.ImdbId, MovieSearchParam.TmdbId, MovieSearchParam.Genre
+                }
             };
 
             caps.Categories.AddCategoryMapping(1, NewznabStandardCategory.Movies);


### PR DESCRIPTION
#### Database Migration
NO

#### Description
AvistaZ was off by a large margin, so let's use the correct timezone offset for it. And in the future `TimezoneOffset` can be overwritten per tracker if needed.

Also some CS fixes, which I'll undo if they aren't necessary. 👍  