### PR TITLE
Fixed: (SpeedCD) Add wildcard to season in tvsearch, add freeleech toggle, improve query selectors

### DIFF
--- a/src/NzbDrone.Core/Datastore/Migration/025_speedcd_userpasssettings_to_speedcdsettings.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/025_speedcd_userpasssettings_to_speedcdsettings.cs
@@ -1,0 +1,14 @@
+using FluentMigrator;
+using NzbDrone.Core.Datastore.Migration.Framework;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(025)]
+    public class speedcd_userpasssettings_to_speedcdsettings : NzbDroneMigrationBase
+    {
+        protected override void MainDbUpgrade()
+        {
+            Update.Table("Indexers").Set(new { ConfigContract = "SpeedCDSettings" }).Where(new { Implementation = "SpeedCD" });
+        }
+    }
+}


### PR DESCRIPTION
Database Migration
YES - 25

#### Description
- `tvsearch` was searching only by `imdbid` returning all seasons and episodes available, and changed to if you search season `S02` it will lookup for `imdbid S02*` or `tvshow S02*`, `*` being wildcard. 
- Same for episode, thus if you search an episode it will return only that episode.
- I should mention that I left the wildcard for episodes too, since the worst that could happen is to return E10X for E10 and so on.

Hope it makes sense.