### PR TITLE
Fixed: (Rarbg) Add slash to IndexerUrl, increase RateLimit to 5s

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/Rarbg/Rarbg.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Rarbg/Rarbg.cs
@@ -17,19 +17,15 @@ namespace NzbDrone.Core.Indexers.Rarbg
 {
     public class Rarbg : TorrentIndexerBase<RarbgSettings>
     {
-        private readonly IRarbgTokenProvider _tokenProvider;
-
         public override string Name => "Rarbg";
-        public override string[] IndexerUrls => new string[] { "https://torrentapi.org" };
+        public override string[] IndexerUrls => new[] { "https://torrentapi.org/" };
+        public override string[] LegacyUrls => new[] { "https://torrentapi.org" };
         public override string Description => "RARBG is a Public torrent site for MOVIES / TV / GENERAL";
-
         public override DownloadProtocol Protocol => DownloadProtocol.Torrent;
-
         public override IndexerPrivacy Privacy => IndexerPrivacy.Public;
-
         public override IndexerCapabilities Capabilities => SetCapabilities();
-
-        public override TimeSpan RateLimit => TimeSpan.FromSeconds(4);
+        public override TimeSpan RateLimit => TimeSpan.FromSeconds(5);
+        private readonly IRarbgTokenProvider _tokenProvider;
 
         public Rarbg(IRarbgTokenProvider tokenProvider, IIndexerHttpClient httpClient, IEventAggregator eventAggregator, IIndexerStatusService indexerStatusService, IConfigService configService, Logger logger)
             : base(httpClient, eventAggregator, indexerStatusService, configService, logger)
@@ -44,7 +40,7 @@ namespace NzbDrone.Core.Indexers.Rarbg
 
         public override IParseIndexerResponse GetParser()
         {
-            return new RarbgParser(Capabilities);
+            return new RarbgParser(Capabilities, _logger);
         }
 
         private IndexerCapabilities SetCapabilities()
@@ -52,17 +48,17 @@ namespace NzbDrone.Core.Indexers.Rarbg
             var caps = new IndexerCapabilities
             {
                 TvSearchParams = new List<TvSearchParam>
-                       {
-                           TvSearchParam.Q, TvSearchParam.Season, TvSearchParam.Ep, TvSearchParam.ImdbId, TvSearchParam.TvdbId
-                       },
+                {
+                    TvSearchParam.Q, TvSearchParam.Season, TvSearchParam.Ep, TvSearchParam.ImdbId, TvSearchParam.TvdbId
+                },
                 MovieSearchParams = new List<MovieSearchParam>
-                       {
-                           MovieSearchParam.Q, MovieSearchParam.ImdbId, MovieSearchParam.TmdbId
-                       },
+                {
+                    MovieSearchParam.Q, MovieSearchParam.ImdbId, MovieSearchParam.TmdbId
+                },
                 MusicSearchParams = new List<MusicSearchParam>
-                       {
-                           MusicSearchParam.Q
-                       }
+                {
+                    MusicSearchParam.Q
+                }
             };
 
             caps.Categories.AddCategoryMapping(4, NewznabStandardCategory.XXX, "XXX (18+)");
@@ -106,7 +102,7 @@ namespace NzbDrone.Core.Indexers.Rarbg
 
             if (jsonResponse.Resource.error_code.HasValue)
             {
-                if (jsonResponse.Resource.error_code == 4 || jsonResponse.Resource.error_code == 2)
+                if (jsonResponse.Resource.error_code is 4 or 2)
                 {
                     _logger.Debug("Invalid or expired token, refreshing token from Rarbg");
                     _tokenProvider.ExpireToken(Settings);
@@ -118,7 +114,7 @@ namespace NzbDrone.Core.Indexers.Rarbg
                     request.HttpRequest.Url = request.Url.SetQuery(qs.GetQueryString());
                     response = await FetchIndexerResponse(request);
                 }
-                else if (jsonResponse.Resource.error_code == 5)
+                else if (jsonResponse.Resource.error_code is 5)
                 {
                     _logger.Debug("Rarbg temp rate limit hit, retrying request");
                     response = await FetchIndexerResponse(request);
@@ -155,9 +151,9 @@ namespace NzbDrone.Core.Indexers.Rarbg
                 Settings.Validate().Filter("BaseUrl").ThrowOnError();
 
                 var request = new HttpRequestBuilder(Settings.BaseUrl.Trim('/'))
-                           .Resource($"/pubapi_v2.php?get_token=get_token&app_id={BuildInfo.AppName}")
-                           .Accept(HttpAccept.Json)
-                           .Build();
+                    .Resource($"/pubapi_v2.php?get_token=get_token&app_id={BuildInfo.AppName}")
+                    .Accept(HttpAccept.Json)
+                    .Build();
 
                 _httpClient.Get(request);
 
@@ -166,7 +162,8 @@ namespace NzbDrone.Core.Indexers.Rarbg
                     captchaToken = ""
                 };
             }
-            else if (action == "getCaptchaCookie")
+
+            if (action == "getCaptchaCookie")
             {
                 if (query["responseUrl"].IsNullOrWhiteSpace())
                 {
@@ -200,7 +197,8 @@ namespace NzbDrone.Core.Indexers.Rarbg
                     captchaToken = cfClearanceCookie
                 };
             }
-            else if (action == "getUrls")
+
+            if (action == "getUrls")
             {
                 var links = IndexerUrls;
 

--- a/src/NzbDrone.Core/Indexers/Definitions/Rarbg/RarbgParser.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Rarbg/RarbgParser.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Text.RegularExpressions;
+using NLog;
 using NzbDrone.Common.EnvironmentInfo;
 using NzbDrone.Common.Http;
 using NzbDrone.Core.Indexers.Exceptions;
@@ -14,10 +15,12 @@ namespace NzbDrone.Core.Indexers.Rarbg
         private static readonly Regex RegexGuid = new Regex(@"^magnet:\?xt=urn:btih:([a-f0-9]+)", RegexOptions.Compiled);
 
         private readonly IndexerCapabilities _capabilities;
+        private readonly Logger _logger;
 
-        public RarbgParser(IndexerCapabilities capabilities)
+        public RarbgParser(IndexerCapabilities capabilities, Logger logger)
         {
             _capabilities = capabilities;
+            _logger = logger;
         }
 
         public IList<ReleaseInfo> ParseResponse(IndexerResponse indexerResponse)
@@ -41,12 +44,19 @@ namespace NzbDrone.Core.Indexers.Rarbg
 
             if (jsonResponse.Resource.error_code.HasValue)
             {
-                if (jsonResponse.Resource.error_code == 20 || jsonResponse.Resource.error_code == 8
-                    || jsonResponse.Resource.error_code == 9 || jsonResponse.Resource.error_code == 10
-                    || jsonResponse.Resource.error_code == 5 || jsonResponse.Resource.error_code == 13
-                    || jsonResponse.Resource.error_code == 14)
+                if (jsonResponse.Resource.error_code is 20 or 8 or 9 or 10 or 5 or 13 or 14)
                 {
-                    // No results, rate limit, or imdbid/tvdb not found
+                    var reason = $"{jsonResponse.Resource.error} ({jsonResponse.Resource.error_code})";
+
+                    if (jsonResponse.Resource.rate_limit is 1)
+                    {
+                        _logger.Debug("No results due to rate limiting. Reason: {0}", reason);
+                    }
+                    else
+                    {
+                        _logger.Debug("No results or imdbid/tvdb not found. Reason: {0}", reason);
+                    }
+
                     return results;
                 }
 

--- a/src/NzbDrone.Core/Indexers/Definitions/Rarbg/RarbgRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Rarbg/RarbgRequestGenerator.cs
@@ -22,11 +22,10 @@ namespace NzbDrone.Core.Indexers.Rarbg
 
         private IEnumerable<IndexerRequest> GetRequest(string term, int[] categories, string imdbId = null, int? tmdbId = null, int? tvdbId = null)
         {
-            var requestBuilder = new HttpRequestBuilder(Settings.BaseUrl)
+            var requestBuilder = new HttpRequestBuilder(Settings.BaseUrl.Trim('/'))
                 .Resource("/pubapi_v2.php")
+                .AddQueryParam("mode", "search")
                 .Accept(HttpAccept.Json);
-
-            requestBuilder.AddQueryParam("mode", "search");
 
             if (imdbId.IsNotNullOrWhiteSpace())
             {

--- a/src/NzbDrone.Core/Indexers/Definitions/Rarbg/RarbgTokenProvider.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Rarbg/RarbgTokenProvider.cs
@@ -37,7 +37,7 @@ namespace NzbDrone.Core.Indexers.Rarbg
                 () =>
                 {
                     var requestBuilder = new HttpRequestBuilder(settings.BaseUrl.Trim('/'))
-                        .WithRateLimit(3.0)
+                        .WithRateLimit(5.0)
                         .Resource($"/pubapi_v2.php?get_token=get_token&app_id={BuildInfo.AppName}")
                         .Accept(HttpAccept.Json);
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
I don't think it's in fact 1req/2s like they say in `apidocs_v2.txt`, I think they also use something like `token bucket algorithm` with a span of a few minutes.

- ~~Let's increase the RateLimit to 5s and to retry when `rate_limit=1` is in the error response.~~
- log why the parser didn't find any results.

/cc @bakerboy448