### PR TITLE
Fixed: (AvistaZ/CinemaZ) Remove Music category mapping

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/AvistaZ.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/AvistaZ.cs
@@ -61,7 +61,6 @@ namespace NzbDrone.Core.Indexers.Definitions
             caps.Categories.AddCategoryMapping(2, NewznabStandardCategory.TVUHD);
             caps.Categories.AddCategoryMapping(2, NewznabStandardCategory.TVHD);
             caps.Categories.AddCategoryMapping(2, NewznabStandardCategory.TVSD);
-            caps.Categories.AddCategoryMapping(3, NewznabStandardCategory.Audio);
 
             return caps;
         }

--- a/src/NzbDrone.Core/Indexers/Definitions/CinemaZ.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/CinemaZ.cs
@@ -56,7 +56,6 @@ namespace NzbDrone.Core.Indexers.Definitions
             caps.Categories.AddCategoryMapping(2, NewznabStandardCategory.TVUHD);
             caps.Categories.AddCategoryMapping(2, NewznabStandardCategory.TVHD);
             caps.Categories.AddCategoryMapping(2, NewznabStandardCategory.TVSD);
-            caps.Categories.AddCategoryMapping(3, NewznabStandardCategory.Audio);
 
             return caps;
         }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
They'll remove the category on 31 January 2023.