### PR TITLE
Fixed: (TorrentDay) Add freeleech only setting

### DIFF
--- a/src/NzbDrone.Core/Datastore/Migration/026_torrentday_cookiesettings_to_torrentdaysettings.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/026_torrentday_cookiesettings_to_torrentdaysettings.cs
@@ -1,0 +1,14 @@
+using FluentMigrator;
+using NzbDrone.Core.Datastore.Migration.Framework;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(026)]
+    public class torrentday_cookiesettings_to_torrentdaysettings : NzbDroneMigrationBase
+    {
+        protected override void MainDbUpgrade()
+        {
+            Update.Table("Indexers").Set(new { ConfigContract = "TorrentDaySettings" }).Where(new { Implementation = "TorrentDay" });
+        }
+    }
+}


### PR DESCRIPTION
#### Database Migration
YES - 25

#### Description
Adds freeleech only setting.

I don't have an account to verify, but according to user's screenshot it only needs `;free` added for FL only search even if Jackett has `;free=on`. 

https://github.com/Prowlarr/Prowlarr/issues/1335#issuecomment-1386381234

#### Issues Fixed or Closed by this PR

* Fixes #1335 