### PR TITLE
New: Add apps minimum seeders per indexer

### DIFF
--- a/src/NzbDrone.Core/Applications/Lidarr/Lidarr.cs
+++ b/src/NzbDrone.Core/Applications/Lidarr/Lidarr.cs
@@ -196,7 +196,7 @@ namespace NzbDrone.Core.Applications.Lidarr
 
             if (indexer.Protocol == DownloadProtocol.Torrent)
             {
-                lidarrIndexer.Fields.FirstOrDefault(x => x.Name == "minimumSeeders").Value = indexer.AppProfile.Value.MinimumSeeders;
+                lidarrIndexer.Fields.FirstOrDefault(x => x.Name == "minimumSeeders").Value = ((ITorrentIndexerSettings)indexer.Settings).TorrentBaseSettings.AppMinimumSeeders ?? indexer.AppProfile.Value.MinimumSeeders;
                 lidarrIndexer.Fields.FirstOrDefault(x => x.Name == "seedCriteria.seedRatio").Value = ((ITorrentIndexerSettings)indexer.Settings).TorrentBaseSettings.SeedRatio;
                 lidarrIndexer.Fields.FirstOrDefault(x => x.Name == "seedCriteria.seedTime").Value = ((ITorrentIndexerSettings)indexer.Settings).TorrentBaseSettings.SeedTime;
 

--- a/src/NzbDrone.Core/Applications/Radarr/Radarr.cs
+++ b/src/NzbDrone.Core/Applications/Radarr/Radarr.cs
@@ -196,7 +196,7 @@ namespace NzbDrone.Core.Applications.Radarr
 
             if (indexer.Protocol == DownloadProtocol.Torrent)
             {
-                radarrIndexer.Fields.FirstOrDefault(x => x.Name == "minimumSeeders").Value = indexer.AppProfile.Value.MinimumSeeders;
+                radarrIndexer.Fields.FirstOrDefault(x => x.Name == "minimumSeeders").Value = ((ITorrentIndexerSettings)indexer.Settings).TorrentBaseSettings.AppMinimumSeeders ?? indexer.AppProfile.Value.MinimumSeeders;
                 radarrIndexer.Fields.FirstOrDefault(x => x.Name == "seedCriteria.seedRatio").Value = ((ITorrentIndexerSettings)indexer.Settings).TorrentBaseSettings.SeedRatio;
                 radarrIndexer.Fields.FirstOrDefault(x => x.Name == "seedCriteria.seedTime").Value = ((ITorrentIndexerSettings)indexer.Settings).TorrentBaseSettings.SeedTime;
             }

--- a/src/NzbDrone.Core/Applications/Readarr/Readarr.cs
+++ b/src/NzbDrone.Core/Applications/Readarr/Readarr.cs
@@ -192,7 +192,7 @@ namespace NzbDrone.Core.Applications.Readarr
 
             if (indexer.Protocol == DownloadProtocol.Torrent)
             {
-                readarrIndexer.Fields.FirstOrDefault(x => x.Name == "minimumSeeders").Value = indexer.AppProfile.Value.MinimumSeeders;
+                readarrIndexer.Fields.FirstOrDefault(x => x.Name == "minimumSeeders").Value = ((ITorrentIndexerSettings)indexer.Settings).TorrentBaseSettings.AppMinimumSeeders ?? indexer.AppProfile.Value.MinimumSeeders;
                 readarrIndexer.Fields.FirstOrDefault(x => x.Name == "seedCriteria.seedRatio").Value = ((ITorrentIndexerSettings)indexer.Settings).TorrentBaseSettings.SeedRatio;
                 readarrIndexer.Fields.FirstOrDefault(x => x.Name == "seedCriteria.seedTime").Value = ((ITorrentIndexerSettings)indexer.Settings).TorrentBaseSettings.SeedTime;
 

--- a/src/NzbDrone.Core/Applications/Sonarr/Sonarr.cs
+++ b/src/NzbDrone.Core/Applications/Sonarr/Sonarr.cs
@@ -198,7 +198,7 @@ namespace NzbDrone.Core.Applications.Sonarr
 
             if (indexer.Protocol == DownloadProtocol.Torrent)
             {
-                sonarrIndexer.Fields.FirstOrDefault(x => x.Name == "minimumSeeders").Value = indexer.AppProfile.Value.MinimumSeeders;
+                sonarrIndexer.Fields.FirstOrDefault(x => x.Name == "minimumSeeders").Value = ((ITorrentIndexerSettings)indexer.Settings).TorrentBaseSettings.AppMinimumSeeders ?? indexer.AppProfile.Value.MinimumSeeders;
                 sonarrIndexer.Fields.FirstOrDefault(x => x.Name == "seedCriteria.seedRatio").Value = ((ITorrentIndexerSettings)indexer.Settings).TorrentBaseSettings.SeedRatio;
                 sonarrIndexer.Fields.FirstOrDefault(x => x.Name == "seedCriteria.seedTime").Value = ((ITorrentIndexerSettings)indexer.Settings).TorrentBaseSettings.SeedTime;
                 sonarrIndexer.Fields.FirstOrDefault(x => x.Name == "seedCriteria.seasonPackSeedTime").Value = ((ITorrentIndexerSettings)indexer.Settings).TorrentBaseSettings.PackSeedTime ?? ((ITorrentIndexerSettings)indexer.Settings).TorrentBaseSettings.SeedTime;

--- a/src/NzbDrone.Core/Applications/Whisparr/Whisparr.cs
+++ b/src/NzbDrone.Core/Applications/Whisparr/Whisparr.cs
@@ -192,7 +192,7 @@ namespace NzbDrone.Core.Applications.Whisparr
 
             if (indexer.Protocol == DownloadProtocol.Torrent)
             {
-                whisparrIndexer.Fields.FirstOrDefault(x => x.Name == "minimumSeeders").Value = indexer.AppProfile.Value.MinimumSeeders;
+                whisparrIndexer.Fields.FirstOrDefault(x => x.Name == "minimumSeeders").Value = ((ITorrentIndexerSettings)indexer.Settings).TorrentBaseSettings.AppMinimumSeeders ?? indexer.AppProfile.Value.MinimumSeeders;
                 whisparrIndexer.Fields.FirstOrDefault(x => x.Name == "seedCriteria.seedRatio").Value = ((ITorrentIndexerSettings)indexer.Settings).TorrentBaseSettings.SeedRatio;
                 whisparrIndexer.Fields.FirstOrDefault(x => x.Name == "seedCriteria.seedTime").Value = ((ITorrentIndexerSettings)indexer.Settings).TorrentBaseSettings.SeedTime;
             }

--- a/src/NzbDrone.Core/Indexers/IndexerTorrentBaseSettings.cs
+++ b/src/NzbDrone.Core/Indexers/IndexerTorrentBaseSettings.cs
@@ -8,6 +8,10 @@ namespace NzbDrone.Core.Indexers
     {
         public IndexerTorrentSettingsValidator(double seedRatioMinimum = 0.0, int seedTimeMinimum = 0, int seasonPackSeedTimeMinimum = 0)
         {
+            RuleFor(c => c.AppMinimumSeeders).GreaterThan(0)
+                .When(c => c.AppMinimumSeeders.HasValue)
+                .WithMessage("Should be greater than zero");
+
             RuleFor(c => c.SeedRatio).GreaterThan(0.0)
                 .When(c => c.SeedRatio.HasValue)
                 .AsWarning().WithMessage("Should be greater than zero");
@@ -38,13 +42,16 @@ namespace NzbDrone.Core.Indexers
     {
         private static readonly IndexerTorrentSettingsValidator Validator = new IndexerTorrentSettingsValidator();
 
-        [FieldDefinition(1, Type = FieldType.Textbox, Label = "Seed Ratio", HelpText = "The ratio a torrent should reach before stopping, empty is app's default", Advanced = true)]
+        [FieldDefinition(1, Type = FieldType.Number, Label = "Apps Minimum Seeders", HelpText = "Minimum seeders required by the Applications for the indexer to grab, empty is Sync profile's default", Advanced = true)]
+        public int? AppMinimumSeeders { get; set; }
+
+        [FieldDefinition(2, Type = FieldType.Textbox, Label = "Seed Ratio", HelpText = "The ratio a torrent should reach before stopping, empty is app's default", Advanced = true)]
         public double? SeedRatio { get; set; }
 
-        [FieldDefinition(2, Type = FieldType.Number, Label = "Seed Time", HelpText = "The time a torrent should be seeded before stopping, empty is app's default", Unit = "minutes", Advanced = true)]
+        [FieldDefinition(3, Type = FieldType.Number, Label = "Seed Time", HelpText = "The time a torrent should be seeded before stopping, empty is app's default", Unit = "minutes", Advanced = true)]
         public int? SeedTime { get; set; }
 
-        [FieldDefinition(3, Type = FieldType.Number, Label = "Pack Seed Time", HelpText = "The time a pack (season or discography) torrent should be seeded before stopping, empty is app's default", Unit = "minutes", Advanced = true)]
+        [FieldDefinition(4, Type = FieldType.Number, Label = "Pack Seed Time", HelpText = "The time a pack (season or discography) torrent should be seeded before stopping, empty is app's default", Unit = "minutes", Advanced = true)]
         public int? PackSeedTime { get; set; }
     }
 }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Sometimes the app's minimum seeders value isn't one size fits all for every indexer, so I think this would be a good addition to be able to set it per indexer if you'll like, with fallback to Sync profile's value.