### PR TITLE
Fixed: (Indexers) Use the defined names for C# indexers

### DIFF
--- a/src/NzbDrone.Core/Indexers/IndexerBase.cs
+++ b/src/NzbDrone.Core/Indexers/IndexerBase.cs
@@ -68,7 +68,7 @@ namespace NzbDrone.Core.Indexers
 
                 yield return new IndexerDefinition
                 {
-                    Name = GetType().Name,
+                    Name = Name ?? GetType().Name,
                     Enable = config.Validate().IsValid && SupportsRss,
                     Implementation = GetType().Name,
                     Settings = config


### PR DESCRIPTION
#### Database Migration
NO
