### PR TITLE
Fixed: (Newznab) Remove extra ampersand from URL

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/Newznab/NewznabRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Newznab/NewznabRequestGenerator.cs
@@ -35,17 +35,17 @@ namespace NzbDrone.Core.Indexers.Newznab
 
             if (searchCriteria.TmdbId.HasValue && capabilities.MovieSearchTmdbAvailable)
             {
-                parameters.Add("tmdbid", searchCriteria.TmdbId.Value.ToString());
+                parameters.Set("tmdbid", searchCriteria.TmdbId.Value.ToString());
             }
 
             if (searchCriteria.ImdbId.IsNotNullOrWhiteSpace() && capabilities.MovieSearchImdbAvailable)
             {
-                parameters.Add("imdbid", searchCriteria.ImdbId);
+                parameters.Set("imdbid", searchCriteria.ImdbId);
             }
 
             if (searchCriteria.TraktId.HasValue && capabilities.MovieSearchTraktAvailable)
             {
-                parameters.Add("traktid", searchCriteria.TraktId.ToString());
+                parameters.Set("traktid", searchCriteria.TraktId.ToString());
             }
 
             //Workaround issue with Sphinx search returning garbage results on some indexers. If we don't use id parameters, fallback to t=search
@@ -55,14 +55,14 @@ namespace NzbDrone.Core.Indexers.Newznab
 
                 if (searchCriteria.SearchTerm.IsNotNullOrWhiteSpace() && capabilities.SearchAvailable)
                 {
-                    parameters.Add("q", NewsnabifyTitle(searchCriteria.SearchTerm));
+                    parameters.Set("q", NewsnabifyTitle(searchCriteria.SearchTerm));
                 }
             }
             else
             {
                 if (searchCriteria.SearchTerm.IsNotNullOrWhiteSpace() && capabilities.MovieSearchAvailable)
                 {
-                    parameters.Add("q", NewsnabifyTitle(searchCriteria.SearchTerm));
+                    parameters.Set("q", NewsnabifyTitle(searchCriteria.SearchTerm));
                 }
             }
 
@@ -82,12 +82,12 @@ namespace NzbDrone.Core.Indexers.Newznab
 
             if (searchCriteria.Artist.IsNotNullOrWhiteSpace() && capabilities.MusicSearchArtistAvailable)
             {
-                parameters.Add("artist", searchCriteria.Artist);
+                parameters.Set("artist", searchCriteria.Artist);
             }
 
             if (searchCriteria.Album.IsNotNullOrWhiteSpace() && capabilities.MusicSearchAlbumAvailable)
             {
-                parameters.Add("album", searchCriteria.Album);
+                parameters.Set("album", searchCriteria.Album);
             }
 
             //Workaround issue with Sphinx search returning garbage results on some indexers. If we don't use id parameters, fallback to t=search
@@ -97,14 +97,14 @@ namespace NzbDrone.Core.Indexers.Newznab
 
                 if (searchCriteria.SearchTerm.IsNotNullOrWhiteSpace() && capabilities.SearchAvailable)
                 {
-                    parameters.Add("q", NewsnabifyTitle(searchCriteria.SearchTerm));
+                    parameters.Set("q", NewsnabifyTitle(searchCriteria.SearchTerm));
                 }
             }
             else
             {
                 if (searchCriteria.SearchTerm.IsNotNullOrWhiteSpace() && capabilities.MusicSearchAvailable)
                 {
-                    parameters.Add("q", NewsnabifyTitle(searchCriteria.SearchTerm));
+                    parameters.Set("q", NewsnabifyTitle(searchCriteria.SearchTerm));
                 }
             }
 
@@ -124,37 +124,37 @@ namespace NzbDrone.Core.Indexers.Newznab
 
             if (searchCriteria.TvdbId.HasValue && capabilities.TvSearchTvdbAvailable)
             {
-                parameters.Add("tvdbid", searchCriteria.TvdbId.Value.ToString());
+                parameters.Set("tvdbid", searchCriteria.TvdbId.Value.ToString());
             }
 
             if (searchCriteria.TmdbId.HasValue && capabilities.TvSearchTvdbAvailable)
             {
-                parameters.Add("tmdbid", searchCriteria.TvdbId.Value.ToString());
+                parameters.Set("tmdbid", searchCriteria.TvdbId.Value.ToString());
             }
 
             if (searchCriteria.ImdbId.IsNotNullOrWhiteSpace() && capabilities.TvSearchImdbAvailable)
             {
-                parameters.Add("imdbid", searchCriteria.ImdbId);
+                parameters.Set("imdbid", searchCriteria.ImdbId);
             }
 
             if (searchCriteria.TvMazeId.HasValue && capabilities.TvSearchTvMazeAvailable)
             {
-                parameters.Add("tvmazeid", searchCriteria.TvMazeId.ToString());
+                parameters.Set("tvmazeid", searchCriteria.TvMazeId.ToString());
             }
 
             if (searchCriteria.RId.HasValue && capabilities.TvSearchTvRageAvailable)
             {
-                parameters.Add("rid", searchCriteria.RId.ToString());
+                parameters.Set("rid", searchCriteria.RId.ToString());
             }
 
             if (searchCriteria.Season.HasValue && capabilities.TvSearchSeasonAvailable)
             {
-                parameters.Add("season", NewznabifySeasonNumber(searchCriteria.Season.Value));
+                parameters.Set("season", NewznabifySeasonNumber(searchCriteria.Season.Value));
             }
 
             if (searchCriteria.Episode.IsNotNullOrWhiteSpace() && capabilities.TvSearchEpAvailable)
             {
-                parameters.Add("ep", searchCriteria.Episode);
+                parameters.Set("ep", searchCriteria.Episode);
             }
 
             //Workaround issue with Sphinx search returning garbage results on some indexers. If we don't use id parameters, fallback to t=search
@@ -164,14 +164,14 @@ namespace NzbDrone.Core.Indexers.Newznab
 
                 if (searchCriteria.SearchTerm.IsNotNullOrWhiteSpace() && capabilities.SearchAvailable)
                 {
-                    parameters.Add("q", NewsnabifyTitle(searchCriteria.SearchTerm));
+                    parameters.Set("q", NewsnabifyTitle(searchCriteria.SearchTerm));
                 }
             }
             else
             {
                 if (searchCriteria.SearchTerm.IsNotNullOrWhiteSpace() && capabilities.TvSearchAvailable)
                 {
-                    parameters.Add("q", NewsnabifyTitle(searchCriteria.SearchTerm));
+                    parameters.Set("q", NewsnabifyTitle(searchCriteria.SearchTerm));
                 }
             }
 
@@ -191,12 +191,12 @@ namespace NzbDrone.Core.Indexers.Newznab
 
             if (searchCriteria.Author.IsNotNullOrWhiteSpace() && capabilities.BookSearchAuthorAvailable)
             {
-                parameters.Add("author", searchCriteria.Author);
+                parameters.Set("author", searchCriteria.Author);
             }
 
             if (searchCriteria.Title.IsNotNullOrWhiteSpace() && capabilities.BookSearchTitleAvailable)
             {
-                parameters.Add("title", searchCriteria.Title);
+                parameters.Set("title", searchCriteria.Title);
             }
 
             //Workaround issue with Sphinx search returning garbage results on some indexers. If we don't use id parameters, fallback to t=search
@@ -206,14 +206,14 @@ namespace NzbDrone.Core.Indexers.Newznab
 
                 if (searchCriteria.SearchTerm.IsNotNullOrWhiteSpace() && capabilities.SearchAvailable)
                 {
-                    parameters.Add("q", NewsnabifyTitle(searchCriteria.SearchTerm));
+                    parameters.Set("q", NewsnabifyTitle(searchCriteria.SearchTerm));
                 }
             }
             else
             {
                 if (searchCriteria.SearchTerm.IsNotNullOrWhiteSpace() && capabilities.BookSearchAvailable)
                 {
-                    parameters.Add("q", NewsnabifyTitle(searchCriteria.SearchTerm));
+                    parameters.Set("q", NewsnabifyTitle(searchCriteria.SearchTerm));
                 }
             }
 
@@ -233,7 +233,7 @@ namespace NzbDrone.Core.Indexers.Newznab
 
             if (searchCriteria.SearchTerm.IsNotNullOrWhiteSpace() && capabilities.SearchAvailable)
             {
-                parameters.Add("q", NewsnabifyTitle(searchCriteria.SearchTerm));
+                parameters.Set("q", NewsnabifyTitle(searchCriteria.SearchTerm));
             }
 
             pageableRequests.Add(GetPagedRequests(searchCriteria, capabilities, parameters));
@@ -264,12 +264,12 @@ namespace NzbDrone.Core.Indexers.Newznab
 
             if (searchCriteria.Limit.HasValue)
             {
-                parameters.Add("limit", searchCriteria.Limit.ToString());
+                parameters.Set("limit", searchCriteria.Limit.ToString());
             }
 
             if (searchCriteria.Offset.HasValue)
             {
-                parameters.Add("offset", searchCriteria.Offset.ToString());
+                parameters.Set("offset", searchCriteria.Offset.ToString());
             }
 
             if (parameters.Count > 0)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
- Remove the extra ampersand from the search URL generation 
- Use [NameValueCollection.Set()](https://learn.microsoft.com/en-us/dotnet/api/system.collections.specialized.namevaluecollection.set?view=net-6.0#remarks), since `Add()` has the possibility for example to change `limit=100` to `limit=100,100` if used multiple times.
