### PR TITLE
Fixed: (LazyLibrarian) Error converting null to bool

### DIFF
--- a/src/NzbDrone.Core/Applications/LazyLibrarian/LazyLibrarianIndexer.cs
+++ b/src/NzbDrone.Core/Applications/LazyLibrarian/LazyLibrarianIndexer.cs
@@ -27,7 +27,7 @@ namespace NzbDrone.Core.Applications.LazyLibrarian
         public string Host { get; set; }
         public string Apikey { get; set; }
         public string Categories { get; set; }
-        public bool Enabled { get; set; }
+        public bool? Enabled { get; set; }
         public string Altername { get; set; }
         public LazyLibrarianProviderType Type { get; set; }
         public int Priority { get; set; }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fix for `[v10.0.0.8245] Newtonsoft.Json.JsonSerializationException: Error converting value {null} to type 'System.Boolean'. Path 'Data.Newznabs[0].ENABLED', line 1, position 91.`