### PR TITLE
Fixed: (assorted) Use GetArgumentFromQueryString and other minor fixes

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/HDSpace.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/HDSpace.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -93,12 +94,7 @@ namespace NzbDrone.Core.Indexers.Definitions
 
         protected override bool CheckIfLoginNeeded(HttpResponse httpResponse)
         {
-            if (!httpResponse.Content.Contains("logout.php"))
-            {
-                return true;
-            }
-
-            return false;
+            return !httpResponse.Content.Contains("logout.php");
         }
 
         private IndexerCapabilities SetCapabilities()
@@ -155,26 +151,30 @@ namespace NzbDrone.Core.Indexers.Definitions
 
         private IEnumerable<IndexerRequest> GetPagedRequests(string term, int[] categories, string imdb = null)
         {
-            var searchUrl = string.Format("{0}/index.php?page=torrents&", Settings.BaseUrl.TrimEnd('/'));
-
             var queryCollection = new NameValueCollection
             {
+                { "page", "torrents" },
                 { "active", "0" },
-                { "category", string.Join(";", Capabilities.Categories.MapTorznabCapsToTrackers(categories)) }
             };
 
-            if (imdb != null)
+            var catList = Capabilities.Categories.MapTorznabCapsToTrackers(categories);
+            if (catList.Any())
             {
-                queryCollection.Add("options", "2");
-                queryCollection.Add("search", imdb);
+                queryCollection.Set("category", string.Join(";", catList));
+            }
+
+            if (imdb.IsNotNullOrWhiteSpace())
+            {
+                queryCollection.Set("options", "2");
+                queryCollection.Set("search", imdb);
             }
             else
             {
-                queryCollection.Add("options", "0");
-                queryCollection.Add("search", term.Replace(".", " "));
+                queryCollection.Set("options", "0");
+                queryCollection.Set("search", term.Replace(".", " "));
             }
 
-            searchUrl += queryCollection.GetQueryString();
+            var searchUrl = $"{Settings.BaseUrl.TrimEnd('/')}/index.php?{queryCollection.GetQueryString()}";
 
             var request = new IndexerRequest(searchUrl, HttpAccept.Html);
 
@@ -267,15 +267,10 @@ namespace NzbDrone.Core.Indexers.Definitions
                 release.DownloadUrl = _settings.BaseUrl + downloadUrl;
 
                 // Use the torrent filename as release title
-                var torrentTitle = ParseUtil.GetArgumentFromQueryString(downloadUrl, "f")?
-                    .Replace("&amp;", "&")
-                    .Replace("&#039;", "'")
-                    .Replace(".torrent", "")
-                    .Trim();
-
+                var torrentTitle = ParseUtil.GetArgumentFromQueryString(downloadUrl, "f")?.Replace(".torrent", "").Trim();
                 if (torrentTitle.IsNotNullOrWhiteSpace())
                 {
-                    release.Title = torrentTitle;
+                    release.Title = WebUtility.HtmlDecode(torrentTitle);
                 }
 
                 var qGenres = row.QuerySelector("td:nth-child(2) span[style=\"color: #000000 \"]");
@@ -318,8 +313,9 @@ namespace NzbDrone.Core.Indexers.Definitions
                 }
 
                 release.UploadVolumeFactor = 1;
-                var qCat = row.QuerySelector("a[href^=\"index.php?page=torrents&category=\"]");
-                var cat = qCat.GetAttribute("href").Split('=')[2];
+
+                var categoryLink = row.QuerySelector("a[href^=\"index.php?page=torrents&category=\"]").GetAttribute("href");
+                var cat = ParseUtil.GetArgumentFromQueryString(categoryLink, "category");
                 release.Categories = _categories.MapTrackerCatToNewznab(cat);
 
                 torrentInfos.Add(release);

--- a/src/NzbDrone.Core/Indexers/Definitions/HDTorrents.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/HDTorrents.cs
@@ -222,7 +222,7 @@ namespace NzbDrone.Core.Indexers.Definitions
         private readonly UserPassTorrentBaseSettings _settings;
         private readonly IndexerCapabilitiesCategories _categories;
 
-        private readonly Regex _posterRegex = new Regex(@"src=\\'./([^']+)\\'", RegexOptions.IgnoreCase);
+        private readonly Regex _posterRegex = new (@"src=\\'./([^']+)\\'", RegexOptions.IgnoreCase);
         private readonly HashSet<string> _freeleechRanks = new (StringComparer.OrdinalIgnoreCase)
         {
             "VIP",
@@ -263,15 +263,14 @@ namespace NzbDrone.Core.Indexers.Definitions
                     : null;
 
                 var link = new Uri(_settings.BaseUrl + row.Children[4].FirstElementChild.GetAttribute("href"));
-                var description = row.Children[2].QuerySelector("span").TextContent;
+                var description = row.Children[2].QuerySelector("span")?.TextContent.Trim();
                 var size = ParseUtil.GetBytes(row.Children[7].TextContent);
 
-                var dateTag = row.Children[6].FirstElementChild;
-                var dateString = string.Join(" ", dateTag.Attributes.Select(attr => attr.Name));
-                var publishDate = DateTime.ParseExact(dateString, "dd MMM yyyy HH:mm:ss zz00", CultureInfo.InvariantCulture).ToLocalTime();
+                var dateAdded = string.Join(" ", row.Children[6].FirstElementChild.Attributes.Select(a => a.Name).Take(4));
+                var publishDate = DateTime.ParseExact(dateAdded, "dd MMM yyyy HH:mm:ss", CultureInfo.InvariantCulture);
 
-                var catStr = row.FirstElementChild.FirstElementChild.GetAttribute("href").Split('=')[1];
-                var cat = _categories.MapTrackerCatToNewznab(catStr);
+                var categoryLink = row.FirstElementChild.FirstElementChild.GetAttribute("href");
+                var cat = ParseUtil.GetArgumentFromQueryString(categoryLink, "category");
 
                 // Sometimes the uploader column is missing, so seeders, leechers, and grabs may be at a different index.
                 // There's room for improvement, but this works for now.
@@ -340,12 +339,13 @@ namespace NzbDrone.Core.Indexers.Definitions
                 var release = new TorrentInfo
                 {
                     Title = title,
+                    Description = description,
                     Guid = details.AbsoluteUri,
                     DownloadUrl = link.AbsoluteUri,
                     InfoUrl = details.AbsoluteUri,
                     PosterUrl = poster,
                     PublishDate = publishDate,
-                    Categories = cat,
+                    Categories = _categories.MapTrackerCatToNewznab(cat),
                     ImdbId = imdb ?? 0,
                     Size = size,
                     Grabs = grabs,


### PR DESCRIPTION
#### Database Migration
NO

#### Description
- use `ParseUtil.GetArgumentFromQueryString()` instead of `Split` (there a few more, but I can't test or find out what's the name of param)
- use `NameValueCollection.Set()`
- use `WebUtility.HtmlDecode()` for titles taken from download links
- ignore the hardcoded timezone in HDTS
- ST: use the date added before falling back to elapsed time, and change encoding to UTF-8 to match both header and meta `content-type` charset.