### PR TITLE
Serve plain text files (e.g. logs) as UTF-8.

### DIFF
--- a/src/Prowlarr.Http/Frontend/Mappers/StaticResourceMapperBase.cs
+++ b/src/Prowlarr.Http/Frontend/Mappers/StaticResourceMapperBase.cs
@@ -1,7 +1,9 @@
 using System;
 using System.IO;
+using System.Text;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.StaticFiles;
+using Microsoft.Net.Http.Headers;
 using NLog;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.EnvironmentInfo;
@@ -39,7 +41,10 @@ namespace Prowlarr.Http.Frontend.Mappers
                     contentType = "application/octet-stream";
                 }
 
-                return new FileStreamResult(GetContentStream(filePath), contentType);
+                return new FileStreamResult(GetContentStream(filePath), new MediaTypeHeaderValue(contentType)
+                {
+                    Encoding = contentType == "text/plain" ? Encoding.UTF8 : null
+                });
             }
 
             _logger.Warn("File {0} not found", filePath);


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Serve plain text files as UTF-8, so as to ensure they are properly decoded by browsers.

#### Screenshot (if UI related)
![Screenshot 2023-01-30 at 00 46 06](https://user-images.githubusercontent.com/1703924/215362862-ac43e152-53d7-4e09-8657-172c7fd3efbd.png)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #1371