### PR TITLE
Fixed: (SearchIndex) Add New Indexer button

### DIFF
--- a/frontend/src/Search/SearchIndex.js
+++ b/frontend/src/Search/SearchIndex.js
@@ -11,6 +11,8 @@ import PageToolbarSection from 'Components/Page/Toolbar/PageToolbarSection';
 import PageToolbarSeparator from 'Components/Page/Toolbar/PageToolbarSeparator';
 import TableOptionsModalWrapper from 'Components/Table/TableOptions/TableOptionsModalWrapper';
 import { align, icons, sortDirections } from 'Helpers/Props';
+import AddIndexerModal from 'Indexer/Add/AddIndexerModal';
+import EditIndexerModalConnector from 'Indexer/Edit/EditIndexerModalConnector';
 import NoIndexer from 'Indexer/NoIndexer';
 import * as keyCodes from 'Utilities/Constants/keyCodes';
 import getErrorMessage from 'Utilities/Object/getErrorMessage';
@@ -51,7 +53,9 @@ class SearchIndex extends Component {
       lastToggled: null,
       allSelected: false,
       allUnselected: false,
-      selectedState: {}
+      selectedState: {},
+      isAddIndexerModalOpen: false,
+      isEditIndexerModalOpen: false
     };
   }
 
@@ -178,6 +182,22 @@ class SearchIndex extends Component {
   //
   // Listeners
 
+  onAddIndexerPress = () => {
+    this.setState({ isAddIndexerModalOpen: true });
+  };
+
+  onAddIndexerModalClose = () => {
+    this.setState({ isAddIndexerModalOpen: false });
+  };
+
+  onAddIndexerSelectIndexer = () => {
+    this.setState({ isEditIndexerModalOpen: true });
+  };
+
+  onEditIndexerModalClose = () => {
+    this.setState({ isEditIndexerModalOpen: false });
+  };
+
   onJumpBarItemPress = (jumpToCharacter) => {
     this.setState({ jumpToCharacter });
   };
@@ -250,7 +270,9 @@ class SearchIndex extends Component {
       jumpToCharacter,
       selectedState,
       allSelected,
-      allUnselected
+      allUnselected,
+      isAddIndexerModalOpen,
+      isEditIndexerModalOpen
     } = this.state;
 
     const selectedIndexerIds = this.getSelectedIds();
@@ -347,6 +369,17 @@ class SearchIndex extends Component {
               !error && !isFetching && hasIndexers && !items.length &&
                 <NoSearchResults totalItems={totalItems} />
             }
+
+            <AddIndexerModal
+              isOpen={isAddIndexerModalOpen}
+              onModalClose={this.onAddIndexerModalClose}
+              onSelectIndexer={this.onAddIndexerSelectIndexer}
+            />
+
+            <EditIndexerModalConnector
+              isOpen={isEditIndexerModalOpen}
+              onModalClose={this.onEditIndexerModalClose}
+            />
           </PageContentBody>
 
           {


### PR DESCRIPTION
Add missing listeners and components to make add indexer button work on search page when no indexers are present

#### Database Migration
NO

#### Description
Fixes "Add New Indexer" button not working on search page that shows up when no indexers are present