### PR TITLE
Fixed: (Redacted/Orpheus/Libble/SecretCinema) Add SupportsRawSearch

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/Libble.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Libble.cs
@@ -101,7 +101,8 @@ public class Libble : TorrentIndexerBase<LibbleSettings>
             MusicSearchParams = new List<MusicSearchParam>
             {
                 MusicSearchParam.Q, MusicSearchParam.Artist, MusicSearchParam.Album, MusicSearchParam.Label, MusicSearchParam.Year, MusicSearchParam.Genre
-            }
+            },
+            SupportsRawSearch = true
         };
 
         caps.Categories.AddCategoryMapping(1, NewznabStandardCategory.Audio, "Music");

--- a/src/NzbDrone.Core/Indexers/Definitions/Orpheus.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Orpheus.cs
@@ -61,7 +61,8 @@ namespace NzbDrone.Core.Indexers.Definitions
                 BookSearchParams = new List<BookSearchParam>
                 {
                     BookSearchParam.Q
-                }
+                },
+                SupportsRawSearch = true
             };
 
             caps.Categories.AddCategoryMapping(1, NewznabStandardCategory.Audio, "Music");

--- a/src/NzbDrone.Core/Indexers/Definitions/Redacted.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Redacted.cs
@@ -61,7 +61,8 @@ namespace NzbDrone.Core.Indexers.Definitions
                 BookSearchParams = new List<BookSearchParam>
                 {
                     BookSearchParam.Q
-                }
+                },
+                SupportsRawSearch = true
             };
 
             caps.Categories.AddCategoryMapping(1, NewznabStandardCategory.Audio, "Music");

--- a/src/NzbDrone.Core/Indexers/Definitions/SecretCinema.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/SecretCinema.cs
@@ -49,7 +49,8 @@ public class SecretCinema : GazelleBase<GazelleSettings>
             MusicSearchParams = new List<MusicSearchParam>
             {
                 MusicSearchParam.Q, MusicSearchParam.Artist, MusicSearchParam.Album, MusicSearchParam.Label, MusicSearchParam.Year
-            }
+            },
+            SupportsRawSearch = true
         };
 
         caps.Categories.AddCategoryMapping(1, NewznabStandardCategory.Movies, "Movies");


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fix for `Term: [Ramones Anthology Hey Ho Lets Go]` to be `Term: [Ramones Anthology: Hey Ho, Let’s Go!]`.

Now searches for `groupname=Anthology:+Hey+Ho,+Let’s+Go!` but some don't have commas in the name. Maybe cleanup on RequestGenerator!?