### PR TITLE
Fixed: Add support for sanitized Artist/Album/Label/Genre/Track

### DIFF
--- a/src/NzbDrone.Core/IndexerSearch/Definitions/BookSearchCriteria.cs
+++ b/src/NzbDrone.Core/IndexerSearch/Definitions/BookSearchCriteria.cs
@@ -10,17 +10,6 @@ namespace NzbDrone.Core.IndexerSearch.Definitions
         public int? Year { get; set; }
         public string Genre { get; set; }
 
-        public override bool RssSearch
-        {
-            get
-            {
-                if (SearchTerm.IsNullOrWhiteSpace() && Author.IsNullOrWhiteSpace() && Title.IsNullOrWhiteSpace())
-                {
-                    return true;
-                }
-
-                return false;
-            }
-        }
+        public override bool RssSearch => SearchTerm.IsNullOrWhiteSpace() && Author.IsNullOrWhiteSpace() && Title.IsNullOrWhiteSpace();
     }
 }

--- a/src/NzbDrone.Core/IndexerSearch/Definitions/MovieSearchCriteria.cs
+++ b/src/NzbDrone.Core/IndexerSearch/Definitions/MovieSearchCriteria.cs
@@ -13,18 +13,7 @@ namespace NzbDrone.Core.IndexerSearch.Definitions
         public int? Year { get; set; }
         public string Genre { get; set; }
 
-        public override bool RssSearch
-        {
-            get
-            {
-                if (SearchTerm.IsNullOrWhiteSpace() && ImdbId.IsNullOrWhiteSpace() && !TmdbId.HasValue && !TraktId.HasValue)
-                {
-                    return true;
-                }
-
-                return false;
-            }
-        }
+        public override bool RssSearch => SearchTerm.IsNullOrWhiteSpace() && ImdbId.IsNullOrWhiteSpace() && !TmdbId.HasValue && !TraktId.HasValue;
 
         public string FullImdbId => ParseUtil.GetFullImdbId(ImdbId);
 

--- a/src/NzbDrone.Core/IndexerSearch/Definitions/MusicSearchCriteria.cs
+++ b/src/NzbDrone.Core/IndexerSearch/Definitions/MusicSearchCriteria.cs
@@ -1,9 +1,13 @@
+using System.Text.RegularExpressions;
 using NzbDrone.Common.Extensions;
 
 namespace NzbDrone.Core.IndexerSearch.Definitions
 {
     public class MusicSearchCriteria : SearchCriteriaBase
     {
+        private static readonly Regex VariousArtists = new (@"\bVarious Artists\b", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex BeginningThe = new (@"^the\s", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
         public string Album { get; set; }
         public string Artist { get; set; }
         public string Label { get; set; }
@@ -11,17 +15,24 @@ namespace NzbDrone.Core.IndexerSearch.Definitions
         public string Track { get; set; }
         public int? Year { get; set; }
 
-        public override bool RssSearch
-        {
-            get
-            {
-                if (SearchTerm.IsNullOrWhiteSpace() && Album.IsNullOrWhiteSpace() && Artist.IsNullOrWhiteSpace() && Label.IsNullOrWhiteSpace())
-                {
-                    return true;
-                }
+        public string SanitizedAlbum => GetSanitizedTerm(Album);
+        public string SanitizedArtist => GetSanitizedTerm(Artist);
+        public string SanitizedLabel => GetSanitizedTerm(Label);
+        public string SanitizedGenre => GetSanitizedTerm(Genre);
+        public string SanitizedTrack => GetSanitizedTerm(Track);
 
-                return false;
-            }
+        public override bool RssSearch => SearchTerm.IsNullOrWhiteSpace() && Album.IsNullOrWhiteSpace() && Artist.IsNullOrWhiteSpace() && Label.IsNullOrWhiteSpace();
+
+        protected override string GetSanitizedTerm(string term)
+        {
+            term ??= "";
+
+            // Most VA albums are listed as VA, not Various Artists
+            term = VariousArtists.Replace(term, "VA");
+
+            term = BeginningThe.Replace(term, string.Empty);
+
+            return base.GetSanitizedTerm(term);
         }
     }
 }

--- a/src/NzbDrone.Core/IndexerSearch/Definitions/SearchCriteriaBase.cs
+++ b/src/NzbDrone.Core/IndexerSearch/Definitions/SearchCriteriaBase.cs
@@ -7,9 +7,8 @@ namespace NzbDrone.Core.IndexerSearch.Definitions
 {
     public abstract class SearchCriteriaBase
     {
-        private static readonly Regex SpecialCharacter = new Regex(@"[`'.]", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-        private static readonly Regex NonWord = new Regex(@"[\W]", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-        private static readonly Regex BeginningThe = new Regex(@"^the\s", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex CleanDashesRegex = new (@"\p{Pd}", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex CleanSingleQuotesRegex = new (@"[\u0060\u00B4\u2018\u2019]", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         public virtual bool InteractiveSearch { get; set; }
         public List<int> IndexerIds { get; set; }
@@ -21,58 +20,24 @@ namespace NzbDrone.Core.IndexerSearch.Definitions
         public string Source { get; set; }
         public string Host { get; set; }
 
-        public virtual string SearchQuery
+        public override string ToString() => $"{SearchQuery}, Offset: {Offset ?? 0}, Limit: {Limit ?? 0}, Categories: [{string.Join(", ", Categories)}]";
+
+        public virtual string SearchQuery => $"Term: [{SearchTerm}]";
+
+        public virtual bool RssSearch => SearchTerm.IsNullOrWhiteSpace();
+
+        public string SanitizedSearchTerm => GetSanitizedTerm(SearchTerm);
+
+        protected virtual string GetSanitizedTerm(string term)
         {
-            get
-            {
-                return $"Term: [{SearchTerm}]";
-            }
-        }
+            term ??= "";
 
-        public override string ToString()
-        {
-            return $"{SearchQuery}, Offset: {Offset ?? 0}, Limit: {Limit ?? 0}, Categories: [{string.Join(", ", Categories)}]";
-        }
+            term = CleanDashesRegex.Replace(term, "-");
+            term = CleanSingleQuotesRegex.Replace(term, "'");
 
-        public virtual bool RssSearch
-        {
-            get
-            {
-                if (SearchTerm.IsNullOrWhiteSpace())
-                {
-                    return true;
-                }
+            var safeTitle = term.Where(c => char.IsLetterOrDigit(c) || char.IsWhiteSpace(c) || c is '-' or '.' or '_' or '(' or ')' or '@' or '/' or '\'' or '[' or ']' or '+' or '%');
 
-                return false;
-            }
-        }
-
-        public string SanitizedSearchTerm
-        {
-            get
-            {
-                var term = SearchTerm;
-                if (SearchTerm == null)
-                {
-                    term = "";
-                }
-
-                var safeTitle = term.Where(c => (char.IsLetterOrDigit(c)
-                                                 || char.IsWhiteSpace(c)
-                                                 || c == '-'
-                                                 || c == '.'
-                                                 || c == '_'
-                                                 || c == '('
-                                                 || c == ')'
-                                                 || c == '@'
-                                                 || c == '/'
-                                                 || c == '\''
-                                                 || c == '['
-                                                 || c == ']'
-                                                 || c == '+'
-                                                 || c == '%'));
-                return string.Concat(safeTitle);
-            }
+            return string.Concat(safeTitle);
         }
     }
 }

--- a/src/NzbDrone.Core/IndexerSearch/Definitions/TvSearchCriteria.cs
+++ b/src/NzbDrone.Core/IndexerSearch/Definitions/TvSearchCriteria.cs
@@ -21,23 +21,12 @@ namespace NzbDrone.Core.IndexerSearch.Definitions
         public int? Year { get; set; }
         public string Genre { get; set; }
 
-        public string SanitizedTvSearchString => (SanitizedSearchTerm + " " + EpisodeSearchString).Trim();
+        public string SanitizedTvSearchString => $"{SanitizedSearchTerm} {EpisodeSearchString}".Trim();
         public string EpisodeSearchString => GetEpisodeSearchString();
 
         public string FullImdbId => ParseUtil.GetFullImdbId(ImdbId);
 
-        public override bool RssSearch
-        {
-            get
-            {
-                if (SearchTerm.IsNullOrWhiteSpace() && ImdbId.IsNullOrWhiteSpace() && !TvdbId.HasValue && !RId.HasValue && !TraktId.HasValue && !TvMazeId.HasValue)
-                {
-                    return true;
-                }
-
-                return false;
-            }
-        }
+        public override bool RssSearch => SearchTerm.IsNullOrWhiteSpace() && ImdbId.IsNullOrWhiteSpace() && !TvdbId.HasValue && !RId.HasValue && !TraktId.HasValue && !TvMazeId.HasValue;
 
         public override string SearchQuery
         {

--- a/src/NzbDrone.Core/Indexers/Definitions/Gazelle/GazelleRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Gazelle/GazelleRequestGenerator.cs
@@ -46,7 +46,7 @@ public class GazelleRequestGenerator : IIndexerRequestGenerator
     {
         var pageableRequests = new IndexerPageableRequestChain();
 
-        var parameters = GetBasicSearchParameters(searchCriteria.SearchTerm, searchCriteria.Categories);
+        var parameters = GetBasicSearchParameters(searchCriteria.SanitizedSearchTerm, searchCriteria.Categories);
 
         if (searchCriteria.ImdbId != null)
         {
@@ -62,19 +62,34 @@ public class GazelleRequestGenerator : IIndexerRequestGenerator
     {
         var pageableRequests = new IndexerPageableRequestChain();
 
-        var parameters = GetBasicSearchParameters(searchCriteria.SearchTerm, searchCriteria.Categories);
+        var parameters = GetBasicSearchParameters(searchCriteria.SanitizedSearchTerm, searchCriteria.Categories);
 
-        if (searchCriteria.Artist.IsNotNullOrWhiteSpace())
+        if (Capabilities.SupportsRawSearch)
+        {
+            if (searchCriteria.SanitizedArtist.IsNotNullOrWhiteSpace() && searchCriteria.SanitizedArtist != "VA")
+            {
+                parameters.Set("artistname", searchCriteria.SanitizedArtist);
+            }
+        }
+        else if (searchCriteria.Artist.IsNotNullOrWhiteSpace() && searchCriteria.Artist != "VA")
         {
             parameters.Set("artistname", searchCriteria.Artist);
         }
 
-        if (searchCriteria.Album.IsNotNullOrWhiteSpace())
+        if (Capabilities.SupportsRawSearch && searchCriteria.SanitizedAlbum.IsNotNullOrWhiteSpace())
+        {
+            parameters.Set("groupname", searchCriteria.SanitizedAlbum);
+        }
+        else if (searchCriteria.Album.IsNotNullOrWhiteSpace())
         {
             parameters.Set("groupname", searchCriteria.Album);
         }
 
-        if (searchCriteria.Label.IsNotNullOrWhiteSpace())
+        if (Capabilities.SupportsRawSearch && searchCriteria.SanitizedLabel.IsNotNullOrWhiteSpace())
+        {
+            parameters.Set("recordlabel", searchCriteria.SanitizedLabel);
+        }
+        else if (searchCriteria.Label.IsNotNullOrWhiteSpace())
         {
             parameters.Set("recordlabel", searchCriteria.Label);
         }
@@ -104,7 +119,7 @@ public class GazelleRequestGenerator : IIndexerRequestGenerator
     {
         var pageableRequests = new IndexerPageableRequestChain();
 
-        var parameters = GetBasicSearchParameters(searchCriteria.SearchTerm, searchCriteria.Categories);
+        var parameters = GetBasicSearchParameters(searchCriteria.SanitizedSearchTerm, searchCriteria.Categories);
         pageableRequests.Add(GetRequest(parameters));
 
         return pageableRequests;
@@ -114,7 +129,7 @@ public class GazelleRequestGenerator : IIndexerRequestGenerator
     {
         var pageableRequests = new IndexerPageableRequestChain();
 
-        var parameters = GetBasicSearchParameters(searchCriteria.SearchTerm, searchCriteria.Categories);
+        var parameters = GetBasicSearchParameters(searchCriteria.SanitizedSearchTerm, searchCriteria.Categories);
         pageableRequests.Add(GetRequest(parameters));
 
         return pageableRequests;

--- a/src/NzbDrone.Core/Indexers/Definitions/Orpheus.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Orpheus.cs
@@ -136,22 +136,22 @@ namespace NzbDrone.Core.Indexers.Definitions
             var pageableRequests = new IndexerPageableRequestChain();
             var parameters = new NameValueCollection();
 
-            if (searchCriteria.Artist.IsNotNullOrWhiteSpace())
+            if (searchCriteria.SanitizedArtist.IsNotNullOrWhiteSpace() && searchCriteria.SanitizedArtist != "VA")
             {
-                parameters.Add("artistname", searchCriteria.Artist);
+                parameters.Set("artistname", searchCriteria.SanitizedArtist);
             }
 
-            if (searchCriteria.Album.IsNotNullOrWhiteSpace())
+            if (searchCriteria.SanitizedAlbum.IsNotNullOrWhiteSpace())
             {
-                parameters.Add("groupname", searchCriteria.Album);
+                parameters.Set("groupname", searchCriteria.SanitizedAlbum);
             }
 
             if (searchCriteria.Year.HasValue)
             {
-                parameters.Add("year", searchCriteria.Year.ToString());
+                parameters.Set("year", searchCriteria.Year.ToString());
             }
 
-            pageableRequests.Add(GetRequest(searchCriteria, parameters));
+            pageableRequests.Add(GetPagedRequests(searchCriteria, parameters));
 
             return pageableRequests;
         }
@@ -161,7 +161,7 @@ namespace NzbDrone.Core.Indexers.Definitions
             var pageableRequests = new IndexerPageableRequestChain();
             var parameters = new NameValueCollection();
 
-            pageableRequests.Add(GetRequest(searchCriteria, parameters));
+            pageableRequests.Add(GetPagedRequests(searchCriteria, parameters));
 
             return pageableRequests;
         }
@@ -181,28 +181,28 @@ namespace NzbDrone.Core.Indexers.Definitions
             var pageableRequests = new IndexerPageableRequestChain();
             var parameters = new NameValueCollection();
 
-            pageableRequests.Add(GetRequest(searchCriteria, parameters));
+            pageableRequests.Add(GetPagedRequests(searchCriteria, parameters));
 
             return pageableRequests;
         }
 
-        private IEnumerable<IndexerRequest> GetRequest(SearchCriteriaBase searchCriteria, NameValueCollection parameters)
+        private IEnumerable<IndexerRequest> GetPagedRequests(SearchCriteriaBase searchCriteria, NameValueCollection parameters)
         {
             var term = searchCriteria.SanitizedSearchTerm.Trim();
 
-            parameters.Add("action", "browse");
-            parameters.Add("order_by", "time");
-            parameters.Add("order_way", "desc");
-            parameters.Add("searchstr", term);
+            parameters.Set("action", "browse");
+            parameters.Set("order_by", "time");
+            parameters.Set("order_way", "desc");
+
+            if (term.IsNotNullOrWhiteSpace())
+            {
+                parameters.Set("searchstr", term);
+            }
 
             var queryCats = _capabilities.Categories.MapTorznabCapsToTrackers(searchCriteria.Categories);
-
-            if (queryCats.Count > 0)
+            if (queryCats.Any())
             {
-                foreach (var cat in queryCats)
-                {
-                    parameters.Add($"filter_cat[{cat}]", "1");
-                }
+                queryCats.ForEach(cat => parameters.Set($"filter_cat[{cat}]", "1"));
             }
 
             var request = RequestBuilder()
@@ -268,12 +268,14 @@ namespace NzbDrone.Core.Indexers.Definitions
                         var release = new GazelleInfo
                         {
                             Guid = infoUrl,
+                            InfoUrl = infoUrl,
+                            DownloadUrl = GetDownloadUrl(id, torrent.CanUseToken),
                             Title = WebUtility.HtmlDecode(title),
+                            Artist = WebUtility.HtmlDecode(result.Artist),
+                            Album = WebUtility.HtmlDecode(result.GroupName),
                             Container = torrent.Encoding,
                             Codec = torrent.Format,
                             Size = long.Parse(torrent.Size),
-                            DownloadUrl = GetDownloadUrl(id, torrent.CanUseToken),
-                            InfoUrl = infoUrl,
                             Seeders = int.Parse(torrent.Seeders),
                             Peers = int.Parse(torrent.Leechers) + int.Parse(torrent.Seeders),
                             PublishDate = torrent.Time.ToUniversalTime(),

--- a/src/NzbDrone.Core/Indexers/Definitions/Redacted.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Redacted.cs
@@ -118,22 +118,22 @@ namespace NzbDrone.Core.Indexers.Definitions
             var pageableRequests = new IndexerPageableRequestChain();
             var parameters = new NameValueCollection();
 
-            if (searchCriteria.Artist.IsNotNullOrWhiteSpace())
+            if (searchCriteria.SanitizedArtist.IsNotNullOrWhiteSpace() && searchCriteria.SanitizedArtist != "VA")
             {
-                parameters.Add("artistname", searchCriteria.Artist);
+                parameters.Set("artistname", searchCriteria.SanitizedArtist);
             }
 
-            if (searchCriteria.Album.IsNotNullOrWhiteSpace())
+            if (searchCriteria.SanitizedAlbum.IsNotNullOrWhiteSpace())
             {
-                parameters.Add("groupname", searchCriteria.Album);
+                parameters.Set("groupname", searchCriteria.SanitizedAlbum);
             }
 
             if (searchCriteria.Year.HasValue)
             {
-                parameters.Add("year", searchCriteria.Year.ToString());
+                parameters.Set("year", searchCriteria.Year.ToString());
             }
 
-            pageableRequests.Add(GetRequest(searchCriteria, parameters));
+            pageableRequests.Add(GetPagedRequests(searchCriteria, parameters));
 
             return pageableRequests;
         }
@@ -143,7 +143,7 @@ namespace NzbDrone.Core.Indexers.Definitions
             var pageableRequests = new IndexerPageableRequestChain();
             var parameters = new NameValueCollection();
 
-            pageableRequests.Add(GetRequest(searchCriteria, parameters));
+            pageableRequests.Add(GetPagedRequests(searchCriteria, parameters));
 
             return pageableRequests;
         }
@@ -163,27 +163,28 @@ namespace NzbDrone.Core.Indexers.Definitions
             var pageableRequests = new IndexerPageableRequestChain();
             var parameters = new NameValueCollection();
 
-            pageableRequests.Add(GetRequest(searchCriteria, parameters));
+            pageableRequests.Add(GetPagedRequests(searchCriteria, parameters));
 
             return pageableRequests;
         }
 
-        private IEnumerable<IndexerRequest> GetRequest(SearchCriteriaBase searchCriteria, NameValueCollection parameters)
+        private IEnumerable<IndexerRequest> GetPagedRequests(SearchCriteriaBase searchCriteria, NameValueCollection parameters)
         {
             var term = searchCriteria.SanitizedSearchTerm.Trim();
 
-            parameters.Add("action", "browse");
-            parameters.Add("order_by", "time");
-            parameters.Add("order_way", "desc");
-            parameters.Add("searchstr", term);
+            parameters.Set("action", "browse");
+            parameters.Set("order_by", "time");
+            parameters.Set("order_way", "desc");
+
+            if (term.IsNotNullOrWhiteSpace())
+            {
+                parameters.Set("searchstr", term);
+            }
 
             var queryCats = _capabilities.Categories.MapTorznabCapsToTrackers(searchCriteria.Categories);
             if (queryCats.Any())
             {
-                foreach (var cat in queryCats)
-                {
-                    parameters.Add($"filter_cat[{cat}]", "1");
-                }
+                queryCats.ForEach(cat => parameters.Set($"filter_cat[{cat}]", "1"));
             }
 
             var request = RequestBuilder()
@@ -249,12 +250,14 @@ namespace NzbDrone.Core.Indexers.Definitions
                         var release = new GazelleInfo
                         {
                             Guid = infoUrl,
+                            InfoUrl = infoUrl,
+                            DownloadUrl = GetDownloadUrl(id, torrent.CanUseToken),
                             Title = WebUtility.HtmlDecode(title),
+                            Artist = WebUtility.HtmlDecode(result.Artist),
+                            Album = WebUtility.HtmlDecode(result.GroupName),
                             Container = torrent.Encoding,
                             Codec = torrent.Format,
                             Size = long.Parse(torrent.Size),
-                            DownloadUrl = GetDownloadUrl(id, torrent.CanUseToken),
-                            InfoUrl = infoUrl,
                             Seeders = int.Parse(torrent.Seeders),
                             Peers = int.Parse(torrent.Leechers) + int.Parse(torrent.Seeders),
                             PublishDate = torrent.Time.ToUniversalTime(),

--- a/src/NzbDrone.Core/Indexers/Definitions/SecretCinema.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/SecretCinema.cs
@@ -147,13 +147,15 @@ public class SecretCinemaParser : IParseIndexerResponse
                         release.Title = $"{title} ({result.GroupYear}) {torrent.Media}";
 
                         // Replace media formats with standards
-                        release.Title = Regex.Replace(release.Title, "BDMV", "COMPLETE BLURAY", RegexOptions.IgnoreCase);
-                        release.Title = Regex.Replace(release.Title, "SD", "DVDRip", RegexOptions.IgnoreCase);
+                        release.Title = Regex.Replace(release.Title, @"\bBDMV\b", "COMPLETE BLURAY", RegexOptions.IgnoreCase);
+                        release.Title = Regex.Replace(release.Title, @"\bSD\b", "DVDRip", RegexOptions.IgnoreCase);
                     }
                     else
                     {
                         // SC API currently doesn't return anything but title.
                         release.Title = $"{artist} - {title} ({result.GroupYear}) [{torrent.Format} {torrent.Encoding}] [{torrent.Media}]";
+                        release.Artist = artist;
+                        release.Album = title;
                     }
 
                     if (torrent.HasCue)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Continuation for #1403

- Replace different variants of [dashes](https://www.fileformat.info/info/unicode/category/Pd/list.htm) to simply `-`.
- Replace different variants of single quotes to simply `'`, since [musicbrainz](https://beta.musicbrainz.org/doc/Style/Miscellaneous) prefers `’` but SanitizedSearchTerm discards anything else of `'`. 
- Set `release.Artist` and `release.Album` where it's possible
- Used a word boundary for regex used in SecretCinema
- Replace `Various Artists` with `VA` in `MusicSearchCriteria`, and don't search for the artist if the indexer doesn't support `VA/Various Artists`

I wonder if it wouldn't been a lot easier to just allow `'` in the *arr apps to be sent to prowlarr, after a cleanup CleanDashesRegex and CleanSingleQuotesRegex from this PR.

Feedback welcomed. 