### PR TITLE
Fixed: (SpeedAppBase) Add pagination

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/RetroFlix.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/RetroFlix.cs
@@ -40,7 +40,7 @@ namespace NzbDrone.Core.Indexers.Definitions
                 BookSearchParams = new List<BookSearchParam>
                 {
                     BookSearchParam.Q,
-                },
+                }
             };
 
             caps.Categories.AddCategoryMapping(401, NewznabStandardCategory.Movies, "Movies");

--- a/src/NzbDrone.Core/Indexers/Definitions/SpeedApp.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/SpeedApp.cs
@@ -8,8 +8,8 @@ namespace NzbDrone.Core.Indexers.Definitions
     public class SpeedApp : SpeedAppBase
     {
         public override string Name => "SpeedApp.io";
-        public override string[] IndexerUrls => new string[] { "https://speedapp.io/" };
-        public override string[] LegacyUrls => new string[] { "https://speedapp.io" };
+        public override string[] IndexerUrls => new[] { "https://speedapp.io/" };
+        public override string[] LegacyUrls => new[] { "https://speedapp.io" };
         public override string Description => "SpeedApp is a ROMANIAN Private Torrent Tracker for MOVIES / TV / GENERAL";
         public override string Language => "ro-RO";
         public override IndexerPrivacy Privacy => IndexerPrivacy.Private;
@@ -38,7 +38,7 @@ namespace NzbDrone.Core.Indexers.Definitions
                 BookSearchParams = new List<BookSearchParam>
                 {
                     BookSearchParam.Q,
-                },
+                }
             };
 
             caps.Categories.AddCategoryMapping(38, NewznabStandardCategory.Movies, "Movie Packs");


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This indexer returns so many irrelevant results and still tries to fetch 10 pages of page=1, let's try to "fix" it with pagination to fetch fewer pages.

Btw is there a way to tell Sonarr to fetch for example maximum 500 results, not 1000?