### PR TITLE
Fixed: (TorrentIndexerBase) Validate downloaded torrent data

### DIFF
--- a/src/NzbDrone.Core/Download/DownloadService.cs
+++ b/src/NzbDrone.Core/Download/DownloadService.cs
@@ -155,7 +155,9 @@ namespace NzbDrone.Core.Download
                 throw;
             }
 
+            _logger.Trace("Downloaded {0} bytes from {1}", downloadedBytes.Length, link);
             _eventAggregator.PublishEvent(new IndexerDownloadEvent(indexerId, success, source, host, title, url.AbsoluteUri));
+
             return downloadedBytes;
         }
 

--- a/src/NzbDrone.Core/Indexers/Definitions/Cardigann/Cardigann.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Cardigann/Cardigann.cs
@@ -189,6 +189,7 @@ namespace NzbDrone.Core.Indexers.Cardigann
             if (request.Url.Scheme == "magnet")
             {
                 ValidateMagnet(request.Url.FullUri);
+
                 return Encoding.UTF8.GetBytes(request.Url.FullUri);
             }
 
@@ -232,6 +233,8 @@ namespace NzbDrone.Core.Indexers.Cardigann
                 _logger.Error("Downloading torrent failed");
                 throw;
             }
+
+            ValidateTorrent(downloadBytes);
 
             return downloadBytes;
         }

--- a/src/NzbDrone.Core/Indexers/Definitions/Orpheus.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Orpheus.cs
@@ -112,6 +112,8 @@ namespace NzbDrone.Core.Indexers.Definitions
                 _logger.Error("Download failed");
             }
 
+            ValidateTorrent(downloadBytes);
+
             return downloadBytes;
         }
     }

--- a/src/NzbDrone.Core/Indexers/Definitions/Redacted.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Redacted.cs
@@ -94,6 +94,8 @@ namespace NzbDrone.Core.Indexers.Definitions
                 _logger.Error("Download failed");
             }
 
+            ValidateTorrent(downloadBytes);
+
             return downloadBytes;
         }
     }

--- a/src/NzbDrone.Core/Indexers/Definitions/SpeedApp/SpeedAppBase.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/SpeedApp/SpeedAppBase.cs
@@ -111,6 +111,7 @@ namespace NzbDrone.Core.Indexers.Definitions
             if (link.Scheme == "magnet")
             {
                 ValidateMagnet(link.OriginalString);
+
                 return Encoding.UTF8.GetBytes(link.OriginalString);
             }
 
@@ -163,6 +164,8 @@ namespace NzbDrone.Core.Indexers.Definitions
                 _logger.Error("Downloading torrent failed");
                 throw;
             }
+
+            ValidateTorrent(torrentData);
 
             return torrentData;
         }

--- a/src/NzbDrone.Core/Indexers/TorrentIndexerBase.cs
+++ b/src/NzbDrone.Core/Indexers/TorrentIndexerBase.cs
@@ -26,6 +26,7 @@ namespace NzbDrone.Core.Indexers
             if (link.Scheme == "magnet")
             {
                 ValidateMagnet(link.OriginalString);
+
                 return Encoding.UTF8.GetBytes(link.OriginalString);
             }
 
@@ -78,12 +79,27 @@ namespace NzbDrone.Core.Indexers
                 throw;
             }
 
+            ValidateTorrent(torrentData);
+
             return torrentData;
         }
 
         protected void ValidateMagnet(string link)
         {
             MagnetLink.Parse(link);
+        }
+
+        protected void ValidateTorrent(byte[] torrentData)
+        {
+            try
+            {
+                Torrent.Load(torrentData);
+            }
+            catch
+            {
+                _logger.Trace("Invalid torrent file contents: {0}", Encoding.ASCII.GetString(torrentData));
+                throw;
+            }
         }
     }
 }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
I'm having issues with NBL on my "prod" installation returning `HTTP/1.1 200 OK`&`Content-Length: 0`, the logs don't show anything and I can't replicate it on my dev machine. :)