### PR TITLE
Fixed: (UI) Replace `api.` only if it's a subdomain

### DIFF
--- a/frontend/src/Indexer/Index/Table/IndexerIndexRow.js
+++ b/frontend/src/Indexer/Index/Table/IndexerIndexRow.js
@@ -253,7 +253,7 @@ class IndexerIndexRow extends Component {
                         className={styles.externalLink}
                         name={icons.EXTERNAL_LINK}
                         title={translate('Website')}
-                        to={baseUrl.replace('api.', '')}
+                        to={baseUrl.replace(/(:\/\/)api\./, '$1')}
                       /> : null
                   }
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fix for `https://torrentapi.org/`