### PR TITLE
Fixed: (Rarbg) Check for rate limits before parsing token errors

### DIFF
--- a/src/NzbDrone.Core.Test/IndexerTests/RarbgTests/RarbgFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/RarbgTests/RarbgFixture.cs
@@ -23,14 +23,14 @@ namespace NzbDrone.Core.Test.IndexerTests.RarbgTests
         [SetUp]
         public void Setup()
         {
-            Subject.Definition = new IndexerDefinition()
+            Subject.Definition = new IndexerDefinition
             {
                 Name = "Rarbg",
                 Settings = new RarbgSettings()
             };
 
             Mocker.GetMock<IRarbgTokenProvider>()
-                .Setup(v => v.GetToken(It.IsAny<RarbgSettings>()))
+                .Setup(v => v.GetToken(It.IsAny<RarbgSettings>(), Subject.RateLimit))
                 .Returns("validtoken");
         }
 

--- a/src/NzbDrone.Core/Indexers/Definitions/Rarbg/Rarbg.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Rarbg/Rarbg.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 using System.Web;
 using NLog;
@@ -9,6 +10,7 @@ using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Http;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Exceptions;
+using NzbDrone.Core.Indexers.Exceptions;
 using NzbDrone.Core.Messaging.Events;
 using NzbDrone.Core.Parser;
 using NzbDrone.Core.Validation;
@@ -24,7 +26,7 @@ namespace NzbDrone.Core.Indexers.Definitions.Rarbg
         public override DownloadProtocol Protocol => DownloadProtocol.Torrent;
         public override IndexerPrivacy Privacy => IndexerPrivacy.Public;
         public override IndexerCapabilities Capabilities => SetCapabilities();
-        public override TimeSpan RateLimit => TimeSpan.FromSeconds(5);
+        public override TimeSpan RateLimit => TimeSpan.FromSeconds(7);
         private readonly IRarbgTokenProvider _tokenProvider;
 
         public Rarbg(IRarbgTokenProvider tokenProvider, IIndexerHttpClient httpClient, IEventAggregator eventAggregator, IIndexerStatusService indexerStatusService, IConfigService configService, Logger logger)
@@ -35,12 +37,29 @@ namespace NzbDrone.Core.Indexers.Definitions.Rarbg
 
         public override IIndexerRequestGenerator GetRequestGenerator()
         {
-            return new RarbgRequestGenerator(_tokenProvider) { Settings = Settings, Categories = Capabilities.Categories };
+            return new RarbgRequestGenerator(_tokenProvider, RateLimit) { Settings = Settings, Categories = Capabilities.Categories };
         }
 
         public override IParseIndexerResponse GetParser()
         {
             return new RarbgParser(Capabilities, _logger);
+        }
+
+        public static void CheckResponseByStatusCode(IndexerResponse response)
+        {
+            var responseCode = (int)response.HttpResponse.StatusCode;
+
+            switch (responseCode)
+            {
+                case (int)HttpStatusCode.TooManyRequests:
+                    throw new TooManyRequestsException(response.HttpRequest, response.HttpResponse, TimeSpan.FromMinutes(2));
+                case 520:
+                    throw new TooManyRequestsException(response.HttpRequest, response.HttpResponse, TimeSpan.FromMinutes(3));
+                case (int)HttpStatusCode.OK:
+                    break;
+                default:
+                    throw new IndexerException(response, "Indexer API call returned an unexpected StatusCode [{0}]", responseCode);
+            }
         }
 
         private IndexerCapabilities SetCapabilities()
@@ -97,6 +116,8 @@ namespace NzbDrone.Core.Indexers.Definitions.Rarbg
         {
             var response = await FetchIndexerResponse(request);
 
+            CheckResponseByStatusCode(response);
+
             // try and recover from token errors
             var jsonResponse = new HttpResponse<RarbgResponse>(response.HttpResponse);
 
@@ -106,7 +127,7 @@ namespace NzbDrone.Core.Indexers.Definitions.Rarbg
                 {
                     _logger.Debug("Invalid or expired token, refreshing token from Rarbg");
                     _tokenProvider.ExpireToken(Settings);
-                    var newToken = _tokenProvider.GetToken(Settings);
+                    var newToken = _tokenProvider.GetToken(Settings, RateLimit);
 
                     var qs = HttpUtility.ParseQueryString(request.HttpRequest.Url.Query);
                     qs.Set("token", newToken);

--- a/src/NzbDrone.Core/Indexers/Definitions/Rarbg/RarbgParser.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Rarbg/RarbgParser.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Net;
 using System.Text.RegularExpressions;
 using NLog;
 using NzbDrone.Common.EnvironmentInfo;
@@ -28,19 +27,8 @@ namespace NzbDrone.Core.Indexers.Definitions.Rarbg
         public IList<ReleaseInfo> ParseResponse(IndexerResponse indexerResponse)
         {
             var results = new List<ReleaseInfo>();
-            var responseCode = (int)indexerResponse.HttpResponse.StatusCode;
 
-            switch (responseCode)
-            {
-                case (int)HttpStatusCode.TooManyRequests:
-                    throw new TooManyRequestsException(indexerResponse.HttpRequest, indexerResponse.HttpResponse, TimeSpan.FromMinutes(2));
-                case 520:
-                    throw new TooManyRequestsException(indexerResponse.HttpRequest, indexerResponse.HttpResponse, TimeSpan.FromMinutes(3));
-                case (int)HttpStatusCode.OK:
-                    break;
-                default:
-                    throw new IndexerException(indexerResponse, "Indexer API call returned an unexpected StatusCode [{0}]", responseCode);
-            }
+            Rarbg.CheckResponseByStatusCode(indexerResponse);
 
             var jsonResponse = new HttpResponse<RarbgResponse>(indexerResponse.HttpResponse);
 

--- a/src/NzbDrone.Core/Indexers/Definitions/Rarbg/RarbgRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Rarbg/RarbgRequestGenerator.cs
@@ -11,13 +11,15 @@ namespace NzbDrone.Core.Indexers.Definitions.Rarbg
     public class RarbgRequestGenerator : IIndexerRequestGenerator
     {
         private readonly IRarbgTokenProvider _tokenProvider;
+        private readonly TimeSpan _rateLimit;
 
         public RarbgSettings Settings { get; set; }
         public IndexerCapabilitiesCategories Categories { get; set; }
 
-        public RarbgRequestGenerator(IRarbgTokenProvider tokenProvider)
+        public RarbgRequestGenerator(IRarbgTokenProvider tokenProvider, TimeSpan rateLimit)
         {
             _tokenProvider = tokenProvider;
+            _rateLimit = rateLimit;
         }
 
         private IEnumerable<IndexerRequest> GetRequest(string term, int[] categories, string imdbId = null, int? tmdbId = null, int? tvdbId = null)
@@ -59,7 +61,7 @@ namespace NzbDrone.Core.Indexers.Definitions.Rarbg
             }
 
             requestBuilder.AddQueryParam("limit", "100");
-            requestBuilder.AddQueryParam("token", _tokenProvider.GetToken(Settings));
+            requestBuilder.AddQueryParam("token", _tokenProvider.GetToken(Settings, _rateLimit));
             requestBuilder.AddQueryParam("format", "json_extended");
             requestBuilder.AddQueryParam("app_id", $"rralworP_{BuildInfo.Version}");
 

--- a/src/NzbDrone.Core/Indexers/Definitions/Rarbg/RarbgTokenProvider.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Rarbg/RarbgTokenProvider.cs
@@ -9,7 +9,7 @@ namespace NzbDrone.Core.Indexers.Definitions.Rarbg
 {
     public interface IRarbgTokenProvider
     {
-        string GetToken(RarbgSettings settings);
+        string GetToken(RarbgSettings settings, TimeSpan rateLimit);
         void ExpireToken(RarbgSettings settings);
     }
 
@@ -31,15 +31,17 @@ namespace NzbDrone.Core.Indexers.Definitions.Rarbg
             _tokenCache.Remove(settings.BaseUrl);
         }
 
-        public string GetToken(RarbgSettings settings)
+        public string GetToken(RarbgSettings settings, TimeSpan rateLimit)
         {
             return _tokenCache.Get(settings.BaseUrl,
                 () =>
                 {
                     var requestBuilder = new HttpRequestBuilder(settings.BaseUrl.Trim('/'))
-                        .WithRateLimit(5.0)
+                        .WithRateLimit(rateLimit.TotalSeconds)
                         .Resource($"/pubapi_v2.php?get_token=get_token&app_id=rralworP_{BuildInfo.Version}")
                         .Accept(HttpAccept.Json);
+
+                    requestBuilder.LogResponseContent = true;
 
                     var response = _httpClient.Get<JObject>(requestBuilder.Build());
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
When the error is Cloudflare 520, it breaks when trying to parse the HTML as JSON. 