### PR TITLE
Fixed: Prevent ProviderRepository to deserialize to a null config contract

### DIFF
--- a/src/NzbDrone.Core/ThingiProvider/ProviderFactory.cs
+++ b/src/NzbDrone.Core/ThingiProvider/ProviderFactory.cs
@@ -171,7 +171,6 @@ namespace NzbDrone.Core.ThingiProvider
             definition.Message = provider.Message;
         }
 
-        //TODO: Remove providers even if the ConfigContract can't be deserialized (this will fail to remove providers if the settings can't be deserialized).
         private void RemoveMissingImplementations()
         {
             var storedProvider = _providerRepository.All();

--- a/src/NzbDrone.Core/ThingiProvider/ProviderRepository.cs
+++ b/src/NzbDrone.Core/ThingiProvider/ProviderRepository.cs
@@ -55,7 +55,7 @@ namespace NzbDrone.Core.ThingiProvider
                     var item = parser(reader);
                     var impType = typeof(IProviderConfig).Assembly.FindTypeByName(item.ConfigContract);
 
-                    if (body.IsNullOrWhiteSpace())
+                    if (body.IsNullOrWhiteSpace() || impType == null)
                     {
                         item.Settings = NullConfig.Instance;
                     }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fix for `System.ArgumentNullException: Value cannot be null. (Parameter 'returnType')` when a config contract is missing.