### PR TITLE
Fixed: (UI) Replace `api.` only if it's a subdomain

### DIFF
--- a/frontend/src/Indexer/Index/Table/IndexerIndexRow.tsx
+++ b/frontend/src/Indexer/Index/Table/IndexerIndexRow.tsx
@@ -226,7 +226,7 @@ function IndexerIndexRow(props: IndexerIndexRowProps) {
                   className={styles.externalLink}
                   name={icons.EXTERNAL_LINK}
                   title={translate('Website')}
-                  to={baseUrl.replace('api.', '')}
+                  to={baseUrl.replace(/(:\/\/)api\./, '$1')}
                 />
               ) : null}
 

--- a/frontend/src/Indexer/Info/IndexerInfoModalContent.tsx
+++ b/frontend/src/Indexer/Info/IndexerInfoModalContent.tsx
@@ -124,7 +124,9 @@ function IndexerInfoModalContent(props: IndexerInfoModalContentProps) {
                 {translate('IndexerSite')}
               </DescriptionListItemTitle>
               <DescriptionListItemDescription>
-                <Link to={baseUrl}>{baseUrl.replace('api.', '')}</Link>
+                <Link to={baseUrl}>
+                  {baseUrl.replace(/(:\/\/)api\./, '$1')}
+                </Link>
               </DescriptionListItemDescription>
               <DescriptionListItemTitle>{`${
                 protocol === 'usenet' ? 'Newznab' : 'Torznab'


### PR DESCRIPTION
#### Database Migration
NO

#### Description
The changes from #1457 are missing since c0383ad5f5f34db844e5ce514c57dd3dfc91da4b