### PR TITLE
Remove the requirement for "search": [q]

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/Headphones/HeadphonesRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Headphones/HeadphonesRequestGenerator.cs
@@ -54,14 +54,14 @@ namespace NzbDrone.Core.Indexers.Headphones
             {
                 searchCriteria.SearchType = "search";
 
-                if (searchCriteria.SearchTerm.IsNotNullOrWhiteSpace() && capabilities.SearchAvailable)
+                if (searchCriteria.SearchTerm.IsNotNullOrWhiteSpace() && capabilities.SearchQueryAvailable)
                 {
                     parameters.Add("q", NewsnabifyTitle(searchCriteria.SearchTerm));
                 }
             }
             else
             {
-                if (searchCriteria.SearchTerm.IsNotNullOrWhiteSpace() && capabilities.MusicSearchAvailable)
+                if (searchCriteria.SearchTerm.IsNotNullOrWhiteSpace() && capabilities.MusicSearchQueryAvailable)
                 {
                     parameters.Add("q", NewsnabifyTitle(searchCriteria.SearchTerm));
                 }
@@ -94,7 +94,7 @@ namespace NzbDrone.Core.Indexers.Headphones
 
             var parameters = new NameValueCollection();
 
-            if (searchCriteria.SearchTerm.IsNotNullOrWhiteSpace() && capabilities.SearchAvailable)
+            if (searchCriteria.SearchTerm.IsNotNullOrWhiteSpace() && capabilities.SearchQueryAvailable)
             {
                 parameters.Add("q", NewsnabifyTitle(searchCriteria.SearchTerm));
             }

--- a/src/NzbDrone.Core/Indexers/Definitions/Newznab/NewznabRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Newznab/NewznabRequestGenerator.cs
@@ -53,14 +53,14 @@ namespace NzbDrone.Core.Indexers.Newznab
             {
                 searchCriteria.SearchType = "search";
 
-                if (searchCriteria.SearchTerm.IsNotNullOrWhiteSpace() && capabilities.SearchAvailable)
+                if (searchCriteria.SearchTerm.IsNotNullOrWhiteSpace() && capabilities.SearchQueryAvailable)
                 {
                     parameters.Set("q", NewsnabifyTitle(searchCriteria.SearchTerm));
                 }
             }
             else
             {
-                if (searchCriteria.SearchTerm.IsNotNullOrWhiteSpace() && capabilities.MovieSearchAvailable)
+                if (searchCriteria.SearchTerm.IsNotNullOrWhiteSpace() && capabilities.MovieSearchQueryAvailable)
                 {
                     parameters.Set("q", NewsnabifyTitle(searchCriteria.SearchTerm));
                 }
@@ -95,14 +95,14 @@ namespace NzbDrone.Core.Indexers.Newznab
             {
                 searchCriteria.SearchType = "search";
 
-                if (searchCriteria.SearchTerm.IsNotNullOrWhiteSpace() && capabilities.SearchAvailable)
+                if (searchCriteria.SearchTerm.IsNotNullOrWhiteSpace() && capabilities.SearchQueryAvailable)
                 {
                     parameters.Set("q", NewsnabifyTitle(searchCriteria.SearchTerm));
                 }
             }
             else
             {
-                if (searchCriteria.SearchTerm.IsNotNullOrWhiteSpace() && capabilities.MusicSearchAvailable)
+                if (searchCriteria.SearchTerm.IsNotNullOrWhiteSpace() && capabilities.MusicSearchQueryAvailable)
                 {
                     parameters.Set("q", NewsnabifyTitle(searchCriteria.SearchTerm));
                 }
@@ -162,14 +162,14 @@ namespace NzbDrone.Core.Indexers.Newznab
             {
                 searchCriteria.SearchType = "search";
 
-                if (searchCriteria.SearchTerm.IsNotNullOrWhiteSpace() && capabilities.SearchAvailable)
+                if (searchCriteria.SearchTerm.IsNotNullOrWhiteSpace() && capabilities.SearchQueryAvailable)
                 {
                     parameters.Set("q", NewsnabifyTitle(searchCriteria.SearchTerm));
                 }
             }
             else
             {
-                if (searchCriteria.SearchTerm.IsNotNullOrWhiteSpace() && capabilities.TvSearchAvailable)
+                if (searchCriteria.SearchTerm.IsNotNullOrWhiteSpace() && capabilities.TvSearchQueryAvailable)
                 {
                     parameters.Set("q", NewsnabifyTitle(searchCriteria.SearchTerm));
                 }
@@ -204,14 +204,14 @@ namespace NzbDrone.Core.Indexers.Newznab
             {
                 searchCriteria.SearchType = "search";
 
-                if (searchCriteria.SearchTerm.IsNotNullOrWhiteSpace() && capabilities.SearchAvailable)
+                if (searchCriteria.SearchTerm.IsNotNullOrWhiteSpace() && capabilities.SearchQueryAvailable)
                 {
                     parameters.Set("q", NewsnabifyTitle(searchCriteria.SearchTerm));
                 }
             }
             else
             {
-                if (searchCriteria.SearchTerm.IsNotNullOrWhiteSpace() && capabilities.BookSearchAvailable)
+                if (searchCriteria.SearchTerm.IsNotNullOrWhiteSpace() && capabilities.BookSearchQueryAvailable)
                 {
                     parameters.Set("q", NewsnabifyTitle(searchCriteria.SearchTerm));
                 }
@@ -231,7 +231,7 @@ namespace NzbDrone.Core.Indexers.Newznab
 
             var parameters = new NameValueCollection();
 
-            if (searchCriteria.SearchTerm.IsNotNullOrWhiteSpace() && capabilities.SearchAvailable)
+            if (searchCriteria.SearchTerm.IsNotNullOrWhiteSpace() && capabilities.SearchQueryAvailable)
             {
                 parameters.Set("q", NewsnabifyTitle(searchCriteria.SearchTerm));
             }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Currently, "search": [q] is a mandatory parameter. However this changes how sonarr and radarr search, forcing a mandatory text-search fallback if a query returns 0 results for e.g. tvdbId or imdbId. Some trackers don't support this, and radarr / sonarr seem to support ID-only based indexers.

This changes the code so that:
1) The ?t=caps endpoint only reflects the capabilities listed in the indexer definition (previously it implicitly added "q" for tvsearch, movie, etc, even if not specified in the yaml)
2) The "search: [q]" field is no longer required. Removing it implies your indexer doesn't support text-based search.

This is my first PR for Prowlarr, but I was able to build and run [most of] the tests locally just fine. I tested adding prowlarr as an indexer to sonarr, which worked well -- no text-search fallback after an empty tvdb result. However radarr had an issue: https://github.com/Radarr/Radarr/pull/8177

#### Screenshot (if UI related)
N/A

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com) -- **this is important, currently the wiki says the "search: [q]" bit is required.**
- [ ] Wait for https://github.com/Radarr/Radarr/pull/8177 to merge

#### Issues Fixed or Closed by this PR

* Fixes #1512 