### PR TITLE
Fixed: (UI) Reset header search offset value

### DIFF
--- a/frontend/src/Search/SearchFooter.js
+++ b/frontend/src/Search/SearchFooter.js
@@ -78,6 +78,8 @@ class SearchFooter extends Component {
 
     if (defaultSearchQuery && defaultSearchQuery !== prevProps.defaultSearchQuery) {
       newState.searchQuery = defaultSearchQuery;
+      newState.searchOffset = 0;
+      newState.newSearch = true;
     }
 
     if (searchType !== defaultSearchType) {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
In the UI, if you search using the header input, the offset param continues to increase, even if you change the search terms. This gives unexpected search results (they're empty, since the backend doesn't like paged requests yet.) 

This fixes the search to reset the offset when you search via the header input.

#### Screenshot
1. Do a search
![search1](https://user-images.githubusercontent.com/1896399/223366019-d1ca5a64-014c-4c55-ac55-36d8f3ece08c.png)

2. Do another search, via header (not footer)
##### Before
![search2](https://user-images.githubusercontent.com/1896399/223366035-102eb649-4769-4d69-98d2-a92be9b1354a.png)
##### After
![searchafter](https://user-images.githubusercontent.com/1896399/223367569-65d9c1a9-4284-4abb-9ba7-1a2561904a52.png)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR
N/A