### PR TITLE
Fixed: (PornoLab) Use correct download URL

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/PornoLab.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/PornoLab.cs
@@ -360,6 +360,8 @@ namespace NzbDrone.Core.Indexers.Definitions
                     var seeders = string.IsNullOrWhiteSpace(seederString) ? 0 : ParseUtil.CoerceInt(seederString);
 
                     var forumid = ParseUtil.GetArgumentFromQueryString(qForumLink?.GetAttribute("href"), "f");
+                    var detailsId = ParseUtil.GetArgumentFromQueryString(qDetailsLink.GetAttribute("href"), "t");
+                    var downloadUrl = _settings.BaseUrl + "forum/dl.php?t=" + detailsId;
                     var title = _settings.StripRussianLetters
                         ? StripRussianRegex.Replace(qDetailsLink.TextContent, string.Empty)
                         : qDetailsLink.TextContent;
@@ -371,7 +373,7 @@ namespace NzbDrone.Core.Indexers.Definitions
                     var release = new TorrentInfo
                     {
                         Guid = infoUrl,
-                        DownloadUrl = infoUrl,
+                        DownloadUrl = downloadUrl,
                         InfoUrl = infoUrl,
                         Title = title,
                         Description = qForumLink.TextContent,


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This indexer was previously using the `infoUrl` as the download URL, which cases downloads to fail when validating the torrent. The UI would show the download as started, but it would never show up in the torrent client, and Prowlarr logs would show a torrent parsing error (because of course an HTML page is not a valid torrent).

This change updates the `DownloadUrl` property to actually point at the torrent URL, enabling search results from this indexer to be sent to the torrent client for download.