### PR TITLE
New: Display Parameters on History by default

### DIFF
--- a/frontend/src/Store/Actions/historyActions.js
+++ b/frontend/src/Store/Actions/historyActions.js
@@ -50,7 +50,7 @@ export const defaultState = {
       name: 'parameters',
       label: translate('Parameters'),
       isSortable: false,
-      isVisible: false
+      isVisible: true
     },
     {
       name: 'grabTitle',


### PR DESCRIPTION
#### Database Migration
NO

#### Description
title; now is explicitly clear to users by default what was searched (site/terms/parameters/cats)

#### Screenshot (if UI related)

#### Todos
- Tests
- Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX