### PR TITLE
Fixed: (Cardigann) Use cookies from captcha response

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/Cardigann/CardigannRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Cardigann/CardigannRequestGenerator.cs
@@ -666,7 +666,7 @@ namespace NzbDrone.Core.Indexers.Cardigann
                     var captchaUrl = ResolvePath(captchaElement.GetAttribute("src"), loginUrl);
 
                     var request = new HttpRequestBuilder(captchaUrl.ToString())
-                        .SetCookies(landingResult.GetCookies())
+                        .SetCookies(Cookies ?? new Dictionary<string, string>())
                         .SetHeaders(headers ?? new Dictionary<string, string>())
                         .SetHeader("Referer", loginUrl.AbsoluteUri)
                         .SetEncoding(_encoding)
@@ -674,6 +674,11 @@ namespace NzbDrone.Core.Indexers.Cardigann
                         .Build();
 
                     var response = await HttpClient.ExecuteProxiedAsync(request, Definition);
+
+                    if (response.GetCookies().Any())
+                    {
+                        Cookies = response.GetCookies();
+                    }
 
                     return new Captcha
                     {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fixes captcha issues with indexers like electro-torrent that have a new PHPSESSID on every refresh. 

Jackett doesn't have this issue because they update the cookies after every request.
https://github.com/Jackett/Jackett/blob/e80a43e8619a13d51eae8a5aa04e23a99809d967/src/Jackett.Common/Indexers/BaseIndexer.cs#L533