### PR TITLE
Fixed: (Indexers) Include exception message in ValidationFailure

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/Cardigann/Exceptions/CardigannConfigException.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Cardigann/Exceptions/CardigannConfigException.cs
@@ -1,4 +1,3 @@
-using NzbDrone.Common.Exceptions;
 using NzbDrone.Core.Indexers.Cardigann;
 
 namespace NzbDrone.Core.Indexers.Definitions.Cardigann.Exceptions

--- a/src/NzbDrone.Core/Indexers/Definitions/Cardigann/Exceptions/CardigannException.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Cardigann/Exceptions/CardigannException.cs
@@ -1,8 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using NzbDrone.Common.Exceptions;
 
 namespace NzbDrone.Core.Indexers.Definitions.Cardigann.Exceptions

--- a/src/NzbDrone.Core/Indexers/HttpIndexerBase.cs
+++ b/src/NzbDrone.Core/Indexers/HttpIndexerBase.cs
@@ -644,7 +644,7 @@ namespace NzbDrone.Core.Indexers
             {
                 _logger.Warn(ex, "Unable to connect to indexer");
 
-                return new ValidationFailure(string.Empty, "Unable to connect to indexer, check the log above the ValidationFailure for more details");
+                return new ValidationFailure(string.Empty, "Unable to connect to indexer, check the log above the ValidationFailure for more details. " + ex.Message);
             }
 
             return null;


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Validation errors aren't shown since `CardigannException` aren't catched.

* Fixes issues like #1549