### PR TITLE
Fixed: (AnimeBytes) Add `limit` and refactor parser

### DIFF
--- a/src/NzbDrone.Core.Test/Files/Indexers/AnimeBytes/recentfeed.json
+++ b/src/NzbDrone.Core.Test/Files/Indexers/AnimeBytes/recentfeed.json
@@ -1,0 +1,371 @@
+{
+  "Results": 9999,
+  "Pagination": {
+    "Current": 1,
+    "Max": 99,
+    "Limit": {
+      "Min": 15,
+      "Coerced": 15,
+      "Max": 50
+    }
+  },
+  "Matches": 2,
+  "Groups": [
+    {
+      "ID": 575,
+      "CategoryName": "Anime",
+      "FullName": "Cowboy Bebop: Tengoku no Tobira - Movie&nbsp;&nbsp;[2001]",
+      "GroupName": "Movie",
+      "SeriesID": "141",
+      "SeriesName": "Cowboy Bebop: Tengoku no Tobira",
+      "Artists": null,
+      "Year": "2001",
+      "Image": "https://mei.animebytes.tv/2bac1a04148be77ce41251d3cb44bbd5.jpg",
+      "Synonymns": [
+        "カウボーイビバップ天国の扉",
+        "Cowboy Bebop: Knockin' on Heaven's Door"
+      ],
+      "SynonymnsV2": {
+        "Japanese": "カウボーイビバップ天国の扉",
+        "Romaji": "",
+        "Alternative": "Cowboy Bebop: Knockin' on Heaven's Door"
+      },
+      "Snatched": 4900,
+      "Comments": 11,
+      "Links": {
+        "AniDB": "https://anidb.net/anime/219",
+        "ANN": "https://www.animenewsnetwork.com/encyclopedia/anime.php?id=353",
+        "Wikipedia": "https://en.wikipedia.org/wiki/Cowboy_Bebop:_The_Movie",
+        "MAL": "https://myanimelist.net/anime/5"
+      },
+      "Votes": 572,
+      "AvgVote": 8.3,
+      "Associations": null,
+      "Description": "Mars is under siege! Just before Halloween 2071, a terrorist bomb destroys a tanker truck on Highway One, close to the densely-populated crater city. There are casualties up to half a mile from the blast — 500 killed or injured by what appears to be a biochemical weapon. The reward for the bomber's capture is a massive 300,000,000 woolongs... and there are four humans and a dog who really need the money. Down on their luck as usual, the crew of the Bebop get on the case.\r\n\r\n[i]Note: The movie takes place between (in the time period of) the Cowboy Bebop episodes 22 and 23.[/i]",
+      "DescriptionHTML": "Mars is under siege! Just before Halloween 2071, a terrorist bomb destroys a tanker truck on Highway One, close to the densely-populated crater city. There are casualties up to half a mile from the blast — 500 killed or injured by what appears to be a biochemical weapon. The reward for the bomber&#039;s capture is a massive 300,000,000 woolongs... and there are four humans and a dog who really need the money. Down on their luck as usual, the crew of the Bebop get on the case.<br />\r\n<br />\r\n<em>Note: The movie takes place between (in the time period of) the Cowboy Bebop episodes 22 and 23.</em>",
+      "EpCount": 0,
+      "StudioList": "Sunrise///28|BONES///35",
+      "PastWeek": 2,
+      "Incomplete": false,
+      "Ongoing": false,
+      "Tags": [
+        "adventure",
+        "comedy",
+        "drama",
+        "scifi",
+        "seinen",
+        "action"
+      ],
+      "Torrents": [
+        {
+          "ID": 959397,
+          "EditionData": {
+            "EditionTitle": ""
+          },
+          "RawDownMultiplier": 0,
+          "RawUpMultiplier": 1,
+          "Link": "https://animebytes.tv/torrent/959397/download/somepass",
+          "Property": "Blu-ray | MKV | h265 10-bit | 1080p | Opus 5.1 | Softsubs (Polarwindz) | Freeleech",
+          "Snatched": 16,
+          "Seeders": 5,
+          "Leechers": 1,
+          "Status": 0,
+          "Size": 13090646841,
+          "FileCount": 1,
+          "FileList": [
+            {
+              "filename": "[Polarwindz] Cowboy Bebop The Movie - Knockin' on Heaven's Door [BD 1080p x265 10bit Opus 5.1].mkv",
+              "size": "13090646841"
+            }
+          ],
+          "UploadTime": "2023-04-02 05:00:43"
+        },
+        {
+          "ID": 909565,
+          "EditionData": {
+            "EditionTitle": ""
+          },
+          "RawDownMultiplier": 0,
+          "RawUpMultiplier": 1,
+          "Link": "https://animebytes.tv/torrent/909565/download/somepass",
+          "Property": "Blu-ray | MKV | h265 10-bit | 1080p | Opus 5.1 | Dual Audio | Softsubs (Yūrei) | Freeleech",
+          "Snatched": 29,
+          "Seeders": 6,
+          "Leechers": 0,
+          "Status": 0,
+          "Size": 15717521349,
+          "FileCount": 1,
+          "FileList": [
+            {
+              "filename": "Cowboy Bebop - Tengoku no Tobira.mkv",
+              "size": "15717521349"
+            }
+          ],
+          "UploadTime": "2020-09-03 18:04:38"
+        }
+      ]
+    },
+    {
+      "ID": 2709,
+      "CategoryName": "Anime",
+      "FullName": "BLEACH - TV Series&nbsp;&nbsp;[2004]",
+      "GroupName": "TV Series",
+      "SeriesID": "191",
+      "SeriesName": "BLEACH",
+      "Artists": null,
+      "Year": "2004",
+      "Image": "https://mei.animebytes.tv/997c8ec3ca0e70254b182b0a176f0161.jpg",
+      "Synonymns": [
+        "ブリーチ"
+      ],
+      "SynonymnsV2": {
+        "Japanese": "ブリーチ",
+        "Romaji": "",
+        "Alternative": ""
+      },
+      "Snatched": 22653,
+      "Comments": 51,
+      "Links": {
+        "AniDB": "https://anidb.net/anime/2369",
+        "ANN": "https://www.animenewsnetwork.com/encyclopedia/anime.php?id=4240",
+        "Wikipedia": "https://en.wikipedia.org/wiki/Bleach_(anime)",
+        "MAL": "https://myanimelist.net/anime/269"
+      },
+      "Votes": 530,
+      "AvgVote": 7.3,
+      "Associations": null,
+      "Description": "Kurosaki Ichigo is a teenager gifted with the ability to see spirits. His life is drastically changed by the sudden appearance of a Shinigami (literally, Death god) - one who governs the flow of souls between the human world and the afterlife - named Kuchiki Rukia, who arrives in search of a Hollow, a dangerous lost soul. When Rukia is severely wounded while trying to defeat the Hollow, she attempts to transfer half of her Reiatsu (literally, Spiritual pressure) energy to Ichigo so that he can defeat the Hollow. However, Ichigo takes almost all of her energy, transforming into a Shinigami and allowing him to defeat the Hollow with ease. With her powers diminished, Rukia is left stranded in the human world until she can recover her strength. In the meantime, Ichigo must take over Rukia's role as a Shinigami, battling Hollows and guiding souls to the afterlife realm known as the Soul Society.",
+      "DescriptionHTML": "Kurosaki Ichigo is a teenager gifted with the ability to see spirits. His life is drastically changed by the sudden appearance of a Shinigami (literally, Death god) - one who governs the flow of souls between the human world and the afterlife - named Kuchiki Rukia, who arrives in search of a Hollow, a dangerous lost soul. When Rukia is severely wounded while trying to defeat the Hollow, she attempts to transfer half of her Reiatsu (literally, Spiritual pressure) energy to Ichigo so that he can defeat the Hollow. However, Ichigo takes almost all of her energy, transforming into a Shinigami and allowing him to defeat the Hollow with ease. With her powers diminished, Rukia is left stranded in the human world until she can recover her strength. In the meantime, Ichigo must take over Rukia&#039;s role as a Shinigami, battling Hollows and guiding souls to the afterlife realm known as the Soul Society.",
+      "EpCount": 366,
+      "StudioList": "Studio Pierrot///45",
+      "PastWeek": 26,
+      "Incomplete": false,
+      "Ongoing": false,
+      "Tags": [
+        "adventure",
+        "comedy",
+        "fantasy",
+        "martial.arts",
+        "school.life",
+        "shounen",
+        "super.power",
+        "contemporary.fantasy",
+        "swordplay",
+        "action",
+        "supernatural"
+      ],
+      "Torrents": [
+        {
+          "ID": 1031199,
+          "EditionData": {
+            "EditionTitle": "Season 02: The Entry (021-041)"
+          },
+          "RawDownMultiplier": 0,
+          "RawUpMultiplier": 1,
+          "Link": "https://animebytes.tv/torrent/1031199/download/somepass",
+          "Property": "Blu-ray | MKV | h265 10-bit | 1080p | AAC 2.0 | Dual Audio | Softsubs (GHOST) | Freeleech",
+          "Snatched": 20,
+          "Seeders": 24,
+          "Leechers": 0,
+          "Status": 0,
+          "Size": 19584943785,
+          "FileCount": 21,
+          "FileList": [
+            {
+              "filename": "[GHOST][1080p] Bleach - 021 [BD HEVC 10bit Dual Audio AC3][035452C3].mkv",
+              "size": "880693454"
+            },
+            {
+              "filename": "[GHOST][1080p] Bleach - 022 [BD HEVC 10bit Dual Audio AC3][0E923AAD].mkv",
+              "size": "851531918"
+            },
+            {
+              "filename": "[GHOST][1080p] Bleach - 023 [BD HEVC 10bit Dual Audio AC3][604A0EC6].mkv",
+              "size": "882518038"
+            },
+            {
+              "filename": "[GHOST][1080p] Bleach - 024 [BD HEVC 10bit Dual Audio AC3][ABABE9B3].mkv",
+              "size": "837335522"
+            },
+            {
+              "filename": "[GHOST][1080p] Bleach - 025 [BD HEVC 10bit Dual Audio AC3][17AEB0C1].mkv",
+              "size": "933034706"
+            },
+            {
+              "filename": "[GHOST][1080p] Bleach - 026 [BD HEVC 10bit Dual Audio AC3][E6F0017C].mkv",
+              "size": "891916996"
+            },
+            {
+              "filename": "[GHOST][1080p] Bleach - 027 [BD HEVC 10bit Dual Audio AC3][317791C7].mkv",
+              "size": "896856044"
+            },
+            {
+              "filename": "[GHOST][1080p] Bleach - 028 [BD HEVC 10bit Dual Audio AC3][5CA4DF06].mkv",
+              "size": "1010510386"
+            },
+            {
+              "filename": "[GHOST][1080p] Bleach - 029 [BD HEVC 10bit Dual Audio AC3][549CF25A].mkv",
+              "size": "995648398"
+            },
+            {
+              "filename": "[GHOST][1080p] Bleach - 030 [BD HEVC 10bit Dual Audio AC3][CED479F9].mkv",
+              "size": "991633973"
+            },
+            {
+              "filename": "[GHOST][1080p] Bleach - 031 [BD HEVC 10bit Dual Audio AC3][1EEFAB0E].mkv",
+              "size": "950195341"
+            },
+            {
+              "filename": "[GHOST][1080p] Bleach - 032 [BD HEVC 10bit Dual Audio AC3][C6F3C39A].mkv",
+              "size": "859218784"
+            },
+            {
+              "filename": "[GHOST][1080p] Bleach - 033 [BD HEVC 10bit Dual Audio AC3][A8424897].mkv",
+              "size": "933230823"
+            },
+            {
+              "filename": "[GHOST][1080p] Bleach - 034 [BD HEVC 10bit Dual Audio AC3][96C94DB8].mkv",
+              "size": "818179634"
+            },
+            {
+              "filename": "[GHOST][1080p] Bleach - 035 [BD HEVC 10bit Dual Audio AC3][A07831AE].mkv",
+              "size": "882457138"
+            },
+            {
+              "filename": "[GHOST][1080p] Bleach - 036 [BD HEVC 10bit Dual Audio AC3][D984C169].mkv",
+              "size": "895683290"
+            },
+            {
+              "filename": "[GHOST][1080p] Bleach - 037 [BD HEVC 10bit Dual Audio AC3][32C05A7E].mkv",
+              "size": "970033716"
+            },
+            {
+              "filename": "[GHOST][1080p] Bleach - 038 [BD HEVC 10bit Dual Audio AC3][824B3EEC].mkv",
+              "size": "956573899"
+            },
+            {
+              "filename": "[GHOST][1080p] Bleach - 039 [BD HEVC 10bit Dual Audio AC3][A45233DF].mkv",
+              "size": "1238240707"
+            },
+            {
+              "filename": "[GHOST][1080p] Bleach - 040 [BD HEVC 10bit Dual Audio AC3][5334A7F1].mkv",
+              "size": "894491562"
+            },
+            {
+              "filename": "[GHOST][1080p] Bleach - 041 [BD HEVC 10bit Dual Audio AC3][A4F17363].mkv",
+              "size": "1014959456"
+            }
+          ],
+          "UploadTime": "2023-03-03 03:03:17"
+        },
+        {
+          "ID": 1031203,
+          "EditionData": {
+            "EditionTitle": "Season 03: The Rescue (042-063)"
+          },
+          "RawDownMultiplier": 0,
+          "RawUpMultiplier": 1,
+          "Link": "https://animebytes.tv/torrent/1031203/download/somepass",
+          "Property": "Blu-ray | MKV | h265 10-bit | 1080p | AC3 2.0 | Dual Audio | Softsubs (GHOST) | Freeleech",
+          "Snatched": 6,
+          "Seeders": 12,
+          "Leechers": 2,
+          "Status": 0,
+          "Size": 24498538059,
+          "FileCount": 22,
+          "FileList": [
+            {
+              "filename": "[GHOST][1080p] Bleach - 042 [BD HEVC 10bit Dual Audio AC3][55763BF6].mkv",
+              "size": "899825828"
+            },
+            {
+              "filename": "[GHOST][1080p] Bleach - 043 [BD HEVC 10bit Dual Audio AC3][70B71ECC].mkv",
+              "size": "902256094"
+            },
+            {
+              "filename": "[GHOST][1080p] Bleach - 044 [BD HEVC 10bit Dual Audio AC3][35F5526B].mkv",
+              "size": "885323344"
+            },
+            {
+              "filename": "[GHOST][1080p] Bleach - 045 [BD HEVC 10bit Dual Audio AC3][9C1DAE4E].mkv",
+              "size": "1082465042"
+            },
+            {
+              "filename": "[GHOST][1080p] Bleach - 046 [BD HEVC 10bit Dual Audio AC3][869EF5B6].mkv",
+              "size": "957433930"
+            },
+            {
+              "filename": "[GHOST][1080p] Bleach - 047 [BD HEVC 10bit Dual Audio AC3][890DA7CE].mkv",
+              "size": "997124540"
+            },
+            {
+              "filename": "[GHOST][1080p] Bleach - 048 [BD HEVC 10bit Dual Audio AC3][39064E08].mkv",
+              "size": "1026751383"
+            },
+            {
+              "filename": "[GHOST][1080p] Bleach - 049 [BD HEVC 10bit Dual Audio AC3][C536D3DB].mkv",
+              "size": "994918391"
+            },
+            {
+              "filename": "[GHOST][1080p] Bleach - 050 [BD HEVC 10bit Dual Audio AC3][A7A0CB24].mkv",
+              "size": "1141146920"
+            },
+            {
+              "filename": "[GHOST][1080p] Bleach - 051 [BD HEVC 10bit Dual Audio AC3][25C06D9D].mkv",
+              "size": "951751791"
+            },
+            {
+              "filename": "[GHOST][1080p] Bleach - 052 [BD HEVC 10bit Dual Audio AC3][FB506194].mkv",
+              "size": "1131756065"
+            },
+            {
+              "filename": "[GHOST][1080p] Bleach - 053 [BD HEVC 10bit Dual Audio AC3][4A76C66D].mkv",
+              "size": "1076952986"
+            },
+            {
+              "filename": "[GHOST][1080p] Bleach - 054 [BD HEVC 10bit Dual Audio AC3][51D8E5F8].mkv",
+              "size": "1369454462"
+            },
+            {
+              "filename": "[GHOST][1080p] Bleach - 055 [BD HEVC 10bit Dual Audio AC3][DCF20007].mkv",
+              "size": "1428073116"
+            },
+            {
+              "filename": "[GHOST][1080p] Bleach - 056 [BD HEVC 10bit Dual Audio AC3][34A28687].mkv",
+              "size": "1304804717"
+            },
+            {
+              "filename": "[GHOST][1080p] Bleach - 057 [BD HEVC 10bit Dual Audio AC3][D1D5FE29].mkv",
+              "size": "1056220730"
+            },
+            {
+              "filename": "[GHOST][1080p] Bleach - 058 [BD HEVC 10bit Dual Audio AC3][C6EAC278].mkv",
+              "size": "1551455953"
+            },
+            {
+              "filename": "[GHOST][1080p] Bleach - 059 [BD HEVC 10bit Dual Audio AC3][E7B25869].mkv",
+              "size": "1026910923"
+            },
+            {
+              "filename": "[GHOST][1080p] Bleach - 060 [BD HEVC 10bit Dual Audio AC3][C9D257D4].mkv",
+              "size": "1059631177"
+            },
+            {
+              "filename": "[GHOST][1080p] Bleach - 061 [BD HEVC 10bit Dual Audio AC3][0521C8D3].mkv",
+              "size": "1457893287"
+            },
+            {
+              "filename": "[GHOST][1080p] Bleach - 062 [BD HEVC 10bit Dual Audio AC3][65CBA616].mkv",
+              "size": "1262863946"
+            },
+            {
+              "filename": "[GHOST][1080p] Bleach - 063 [BD HEVC 10bit Dual Audio AC3][CF63E244].mkv",
+              "size": "933523434"
+            }
+          ],
+          "UploadTime": "2023-04-03 03:14:35"
+        }
+      ]
+    }
+  ]
+}

--- a/src/NzbDrone.Core.Test/IndexerTests/AnimeBytesTests/AnimeBytesFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/AnimeBytesTests/AnimeBytesFixture.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using NzbDrone.Common.Http;
+using NzbDrone.Core.Indexers;
+using NzbDrone.Core.Indexers.Definitions;
+using NzbDrone.Core.IndexerSearch.Definitions;
+using NzbDrone.Core.Parser.Model;
+using NzbDrone.Core.Test.Framework;
+
+namespace NzbDrone.Core.Test.IndexerTests.AnimeBytesTests
+{
+    [TestFixture]
+    public class AnimeBytesFixture : CoreTest<AnimeBytes>
+    {
+        [SetUp]
+        public void Setup()
+        {
+            Subject.Definition = new IndexerDefinition
+            {
+                Name = "AnimeBytes",
+                Settings = new AnimeBytesSettings
+                {
+                    BaseUrl = "https://animebytes.tv/",
+                    Username = "someuser",
+                    Passkey = "somepass"
+                }
+            };
+        }
+
+        [Test]
+        public async Task should_parse_recent_feed_from_animebytes()
+        {
+            var recentFeed = ReadAllText(@"Files/Indexers/AnimeBytes/recentfeed.json");
+
+            Mocker.GetMock<IIndexerHttpClient>()
+                .Setup(o => o.ExecuteProxiedAsync(It.Is<HttpRequest>(v => v.Method == HttpMethod.Get), Subject.Definition))
+                .Returns<HttpRequest, IndexerDefinition>((r, d) => Task.FromResult(new HttpResponse(r, new HttpHeader { { "Content-Type", "application/json" } }, new CookieCollection(), recentFeed)));
+
+            var releases = (await Subject.Fetch(new BasicSearchCriteria { Categories = new[] { 2000, 5000 } })).Releases;
+
+            releases.Should().HaveCount(10);
+            releases.First().Should().BeOfType<TorrentInfo>();
+
+            var firstTorrentInfo = releases.First() as TorrentInfo;
+
+            firstTorrentInfo.Title.Should().Be("[GHOST] BLEACH S03 [Blu-ray][MKV][h265 10-bit][1080p][AC3 2.0][Dual Audio][Softsubs (GHOST)]");
+            firstTorrentInfo.DownloadProtocol.Should().Be(DownloadProtocol.Torrent);
+            firstTorrentInfo.DownloadUrl.Should().Be("https://animebytes.tv/torrent/1031203/download/somepass");
+            firstTorrentInfo.InfoUrl.Should().Be("https://animebytes.tv/torrent/1031203/group");
+            firstTorrentInfo.Guid.Should().Be("https://animebytes.tv/torrent/1031203/group?nh=F7C73EF631FE269D3A7F10BD12EC99A1");
+            firstTorrentInfo.CommentUrl.Should().BeNullOrEmpty();
+            firstTorrentInfo.Indexer.Should().Be(Subject.Definition.Name);
+            firstTorrentInfo.PublishDate.Should().Be(DateTime.Parse("2023-04-03 03:14:35", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal));
+            firstTorrentInfo.Size.Should().Be(24498538059);
+            firstTorrentInfo.InfoHash.Should().Be(null);
+            firstTorrentInfo.MagnetUrl.Should().Be(null);
+            firstTorrentInfo.Peers.Should().Be(2 + 12);
+            firstTorrentInfo.Seeders.Should().Be(12);
+            firstTorrentInfo.Files.Should().Be(22);
+            firstTorrentInfo.MinimumSeedTime.Should().Be(655200);
+
+            var secondTorrentInfo = releases.Skip(2).First() as TorrentInfo;
+
+            secondTorrentInfo.Title.Should().Be("Cowboy Bebop: Tengoku no Tobira 2001 [Polarwindz] [Blu-ray][MKV][h265 10-bit][1080p][Opus 5.1][Softsubs (Polarwindz)]");
+            secondTorrentInfo.DownloadProtocol.Should().Be(DownloadProtocol.Torrent);
+            secondTorrentInfo.DownloadUrl.Should().Be("https://animebytes.tv/torrent/959397/download/somepass");
+            secondTorrentInfo.InfoUrl.Should().Be("https://animebytes.tv/torrent/959397/group");
+            secondTorrentInfo.Guid.Should().Be("https://animebytes.tv/torrent/959397/group?nh=D63895DA87A25239C11F9823F46000E1");
+            secondTorrentInfo.CommentUrl.Should().BeNullOrEmpty();
+            secondTorrentInfo.Indexer.Should().Be(Subject.Definition.Name);
+            secondTorrentInfo.PublishDate.Should().Be(DateTime.Parse("2023-04-02 05:00:43", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal));
+            secondTorrentInfo.Size.Should().Be(13090646841);
+            secondTorrentInfo.InfoHash.Should().Be(null);
+            secondTorrentInfo.MagnetUrl.Should().Be(null);
+            secondTorrentInfo.Peers.Should().Be(1 + 5);
+            secondTorrentInfo.Seeders.Should().Be(5);
+            secondTorrentInfo.Files.Should().Be(1);
+            secondTorrentInfo.MinimumSeedTime.Should().Be(475200);
+        }
+    }
+}


### PR DESCRIPTION
#### Database Migration
NO

#### Description
- Added limit depending on search query
- Added Freeleech Only setting
- Added Exclude RAW setting
- Added Exclude Hentai setting
- Set sorting to `grouptime desc`
- Refactor Synonymns to manage only nullable array of strings
- Change UploadTime type to string and parse with AssumeUniversal
- Refactor MST with additional 5 hours per GB 
- Use properties as list
- Fix when EnableSonarrCompatibility is true by not adding S01 to title for books, etc.
- Refactor episode/season padding
- Added new category parsing (PS2/PS3/SNES/NES/Switch/etc.)
- Order releases descending 