### PR TITLE
Fixed: Clarify App Sync-Indexer Logging for tags

### DIFF
--- a/src/NzbDrone.Core/Applications/ApplicationService.cs
+++ b/src/NzbDrone.Core/Applications/ApplicationService.cs
@@ -210,11 +210,11 @@ namespace NzbDrone.Core.Applications
 
             if (intersectingTags.Any())
             {
-                _logger.Debug("Application {0} and indexer {1} [{2}] have {3} intersecting tags.", app.Name, indexer.Name, indexer.Id, intersectingTags.Length);
+                _logger.Debug("Application {0} and indexer {1} [{2}] have {3} intersecting (matching) tags.", app.Name, indexer.Name, indexer.Id, intersectingTags.Length);
                 return true;
             }
 
-            _logger.Info("Application {0} does not have any intersecting tags with {1} [{2}]. Indexer will not be handled.", app.Name, indexer.Name, indexer.Id);
+            _logger.Info("Application {0} does not have any intersecting (matching) tags with {1} [{2}]. Indexer will neither be synced to nor removed from the application.", app.Name, indexer.Name, indexer.Id);
             return false;
         }
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
improve logging;  users constantly have support issues with indexers not syncing to apps due to tags
`intersecting` and `handled` while accurate are not intuitive to users

#### Screenshot (if UI related)

#### Todos
- Tests
- Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes Support Hell