### PR TITLE
Fixed: UserAgent Parsing Ignores Dashes

### DIFF
--- a/src/NzbDrone.Common/Http/UserAgentParser.cs
+++ b/src/NzbDrone.Common/Http/UserAgentParser.cs
@@ -21,7 +21,7 @@ namespace NzbDrone.Common.Http
         {
             var match = AppSourceRegex.Match(SimplifyUserAgent(userAgent) ?? string.Empty);
 
-            if (match.Groups["agent"].Success)
+            if (match.Groups["agent"].Success && match.Groups["agent"].Value.IsNotNullOrWhiteSpace())
             {
                 return match.Groups["agent"].Value;
             }

--- a/src/NzbDrone.Common/Http/UserAgentParser.cs
+++ b/src/NzbDrone.Common/Http/UserAgentParser.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using NzbDrone.Common.Extensions;
 
 namespace NzbDrone.Common.Http
 {

--- a/src/NzbDrone.Common/Http/UserAgentParser.cs
+++ b/src/NzbDrone.Common/Http/UserAgentParser.cs
@@ -4,7 +4,7 @@ namespace NzbDrone.Common.Http
 {
     public static class UserAgentParser
     {
-        private static readonly Regex AppSourceRegex = new Regex(@"(?<agent>[a-z0-9]*)\/.*(?:\(.*\))?",
+        private static readonly Regex AppSourceRegex = new Regex(@"(?<agent>[a-z0-9-]*)\/?.*(?:\(.*\))?",
                                                         RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         public static string SimplifyUserAgent(string userAgent)


### PR DESCRIPTION
#### Database Migration
No

#### Description
The current UserAgent parser doesn't ignore dashes and requires a version number.
[Cross-seed's UserAgent](https://github.com/cross-seed/cross-seed/blob/1b65a0ec71ca823cfcfde04a52adcfc402df82d7/src/torznab.ts#L423) contains a dash and no version number and thus is not matched.

Also whats up with the `(?:\(.*\))?` non-capturing group at the end?

#### Todos
- Tests