### PR TITLE
Fixed: (Indexers) Hide errors with SuppressHttpErrorStatusCodes

### DIFF
--- a/src/NzbDrone.Core/History/HistoryService.cs
+++ b/src/NzbDrone.Core/History/HistoryService.cs
@@ -118,12 +118,14 @@ namespace NzbDrone.Core.History
 
         public void Handle(IndexerQueryEvent message)
         {
+            var response = message.QueryResult.Response;
+
             var history = new History
             {
                 Date = DateTime.UtcNow,
                 IndexerId = message.IndexerId,
                 EventType = message.Query.IsRssSearch ? HistoryEventType.IndexerRss : HistoryEventType.IndexerQuery,
-                Successful = message.QueryResult.Response?.StatusCode == HttpStatusCode.OK
+                Successful = response?.StatusCode == HttpStatusCode.OK || (response is { Request: { SuppressHttpError: true, SuppressHttpErrorStatusCodes: not null } } && response.Request.SuppressHttpErrorStatusCodes.Contains(response.StatusCode))
             };
 
             if (message.Query is MovieSearchCriteria)

--- a/src/NzbDrone.Core/Indexers/Definitions/Avistaz/AvistazBase.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Avistaz/AvistazBase.cs
@@ -67,9 +67,9 @@ namespace NzbDrone.Core.Indexers.Definitions.Avistaz
             _logger.Debug("Avistaz authentication succeeded.");
         }
 
-        protected override bool CheckIfLoginNeeded(HttpResponse response)
+        protected override bool CheckIfLoginNeeded(HttpResponse httpResponse)
         {
-            return response.StatusCode == HttpStatusCode.Unauthorized || response.StatusCode == HttpStatusCode.PreconditionFailed;
+            return httpResponse.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.PreconditionFailed;
         }
 
         protected override void ModifyRequest(IndexerRequest request)

--- a/src/NzbDrone.Core/Indexers/Definitions/Avistaz/AvistazRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Avistaz/AvistazRequestGenerator.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using NLog;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Http;
@@ -85,10 +86,7 @@ namespace NzbDrone.Core.Indexers.Definitions.Avistaz
             var request = new IndexerRequest(searchUrl, HttpAccept.Html);
             request.HttpRequest.Headers.Add("Authorization", $"Bearer {Settings.Token}");
 
-            if (searchParameters.Any(p => p.Key is "imdb" or "tmdb" or "tvdb"))
-            {
-                request.HttpRequest.LogHttpError = false;
-            }
+            request.HttpRequest.SuppressHttpErrorStatusCodes = new[] { HttpStatusCode.NotFound };
 
             yield return request;
         }

--- a/src/NzbDrone.Core/Indexers/HttpIndexerBase.cs
+++ b/src/NzbDrone.Core/Indexers/HttpIndexerBase.cs
@@ -508,7 +508,7 @@ namespace NzbDrone.Core.Indexers
             }
 
             // Throw common http errors here before we try to parse
-            if (response.HasHttpError)
+            if (response.HasHttpError && (request.HttpRequest.SuppressHttpErrorStatusCodes == null || !request.HttpRequest.SuppressHttpErrorStatusCodes.Contains(response.StatusCode)))
             {
                 if (response.Request.LogHttpError)
                 {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
- Use `SuppressHttpErrorStatusCodes` to check if the query was successful in HistoryService
- Use `SuppressHttpErrorStatusCodes` to hide errors in HttpIndexerBase, but without checking for `SuppressHttpError` since it's [always set to true](https://github.com/Prowlarr/Prowlarr/blob/2811feb14ee39431a6f5e0eb64249d1e3a1ba56e/src/NzbDrone.Core/Indexers/HttpIndexerBase.cs#L492) 

* Fixes #1531
* Fixes #1532