### PR TITLE
BTN Fixes

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/BroadcastheNet/BroadcastheNetRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/BroadcastheNet/BroadcastheNetRequestGenerator.cs
@@ -60,14 +60,19 @@ namespace NzbDrone.Core.Indexers.BroadcastheNet
 
             var btnOffset = searchCriteria.Offset.GetValueOrDefault(0);
 
+            // ID searches act as AND searches, so only one should be used at a time
             if (searchCriteria.TvdbId > 0)
             {
                 parameters.Tvdb = $"{searchCriteria.TvdbId}";
             }
-
-            if (searchCriteria.RId > 0)
+            else if (searchCriteria.RId > 0)
             {
                 parameters.Tvrage = $"{searchCriteria.RId}";
+            }
+            else
+            {
+                // If NOT an ID search, then use the search string
+                parameters.Search = searchString.Replace(" ", "%");
             }
 
             // If only the season/episode is searched for then change format to match expected format
@@ -101,8 +106,6 @@ namespace NzbDrone.Core.Indexers.BroadcastheNet
             }
             else
             {
-                // Neither a season only search nor daily nor standard, fall back to query
-                parameters.Search = searchString.Replace(" ", "%");
                 pageableRequests.Add(GetPagedRequests(parameters, btnResults, btnOffset));
             }
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
- Fixed: (BTN) Use only one ID in query
Matches Sonarr logic

https://github.com/Sonarr/Sonarr/blob/83cee4b00e8c64d749d2ff1d8575d31570beecba/src/NzbDrone.Core/Indexers/BroadcastheNet/BroadcastheNetRequestGenerator.cs#L201-L217

```csharp
        private bool AddSeriesSearchParameters(BroadcastheNetTorrentQuery parameters, SearchCriteriaBase searchCriteria)
        {
            if (searchCriteria.Series.TvdbId != 0)
            {
                parameters.Tvdb = string.Format("{0}", searchCriteria.Series.TvdbId);
                return true;
            }

            if (searchCriteria.Series.TvRageId != 0)
            {
                parameters.Tvrage = string.Format("{0}", searchCriteria.Series.TvRageId);
                return true;
            }

            // BTN is very neatly managed, so it's unlikely they map tvrage/tvdb wrongly.
            return false;
        }
```
- Fixed: (BTN) Query String ignored if Season Episode Parameters exist

#### Screenshot (if UI related)

#### Todos
- [] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #1633
* https://discord.com/channels/264387956343570434/1028840523106107394/1101582686683943042
* 