### PR TITLE
Fixed: (Apps) Prevent null reference exception on sync failure

### DIFF
--- a/src/NzbDrone.Core/Applications/LazyLibrarian/LazyLibrarian.cs
+++ b/src/NzbDrone.Core/Applications/LazyLibrarian/LazyLibrarian.cs
@@ -78,6 +78,14 @@ namespace NzbDrone.Core.Applications.LazyLibrarian
             var lazyLibrarianIndexer = BuildLazyLibrarianIndexer(indexer, indexer.Protocol);
 
             var remoteIndexer = _lazyLibrarianV1Proxy.AddIndexer(lazyLibrarianIndexer, Settings);
+
+            if (remoteIndexer == null)
+            {
+                _logger.Debug("Failed to add {0} [{1}]", indexer.Name, indexer.Id);
+
+                return;
+            }
+
             _appIndexerMapService.Insert(new AppIndexerMap { AppId = Definition.Id, IndexerId = indexer.Id, RemoteIndexerName = $"{remoteIndexer.Type},{remoteIndexer.Name}" });
         }
 

--- a/src/NzbDrone.Core/Applications/Lidarr/Lidarr.cs
+++ b/src/NzbDrone.Core/Applications/Lidarr/Lidarr.cs
@@ -95,6 +95,14 @@ namespace NzbDrone.Core.Applications.Lidarr
             var lidarrIndexer = BuildLidarrIndexer(indexer, indexer.Protocol);
 
             var remoteIndexer = _lidarrV1Proxy.AddIndexer(lidarrIndexer, Settings);
+
+            if (remoteIndexer == null)
+            {
+                _logger.Debug("Failed to add {0} [{1}]", indexer.Name, indexer.Id);
+
+                return;
+            }
+
             _appIndexerMapService.Insert(new AppIndexerMap { AppId = Definition.Id, IndexerId = indexer.Id, RemoteIndexerId = remoteIndexer.Id });
         }
 

--- a/src/NzbDrone.Core/Applications/Mylar/Mylar.cs
+++ b/src/NzbDrone.Core/Applications/Mylar/Mylar.cs
@@ -78,6 +78,14 @@ namespace NzbDrone.Core.Applications.Mylar
             var mylarIndexer = BuildMylarIndexer(indexer, indexer.Protocol);
 
             var remoteIndexer = _mylarV3Proxy.AddIndexer(mylarIndexer, Settings);
+
+            if (remoteIndexer == null)
+            {
+                _logger.Debug("Failed to add {0} [{1}]", indexer.Name, indexer.Id);
+
+                return;
+            }
+
             _appIndexerMapService.Insert(new AppIndexerMap { AppId = Definition.Id, IndexerId = indexer.Id, RemoteIndexerName = $"{remoteIndexer.Type},{remoteIndexer.Name}" });
         }
 

--- a/src/NzbDrone.Core/Applications/Radarr/Radarr.cs
+++ b/src/NzbDrone.Core/Applications/Radarr/Radarr.cs
@@ -95,6 +95,14 @@ namespace NzbDrone.Core.Applications.Radarr
             var radarrIndexer = BuildRadarrIndexer(indexer, indexer.Protocol);
 
             var remoteIndexer = _radarrV3Proxy.AddIndexer(radarrIndexer, Settings);
+
+            if (remoteIndexer == null)
+            {
+                _logger.Debug("Failed to add {0} [{1}]", indexer.Name, indexer.Id);
+
+                return;
+            }
+
             _appIndexerMapService.Insert(new AppIndexerMap { AppId = Definition.Id, IndexerId = indexer.Id, RemoteIndexerId = remoteIndexer.Id });
         }
 

--- a/src/NzbDrone.Core/Applications/Readarr/Readarr.cs
+++ b/src/NzbDrone.Core/Applications/Readarr/Readarr.cs
@@ -96,6 +96,14 @@ namespace NzbDrone.Core.Applications.Readarr
             var readarrIndexer = BuildReadarrIndexer(indexer, indexer.Protocol);
 
             var remoteIndexer = _readarrV1Proxy.AddIndexer(readarrIndexer, Settings);
+
+            if (remoteIndexer == null)
+            {
+                _logger.Debug("Failed to add {0} [{1}]", indexer.Name, indexer.Id);
+
+                return;
+            }
+
             _appIndexerMapService.Insert(new AppIndexerMap { AppId = Definition.Id, IndexerId = indexer.Id, RemoteIndexerId = remoteIndexer.Id });
         }
 

--- a/src/NzbDrone.Core/Applications/Sonarr/Sonarr.cs
+++ b/src/NzbDrone.Core/Applications/Sonarr/Sonarr.cs
@@ -96,6 +96,14 @@ namespace NzbDrone.Core.Applications.Sonarr
             var sonarrIndexer = BuildSonarrIndexer(indexer, indexer.Protocol);
 
             var remoteIndexer = _sonarrV3Proxy.AddIndexer(sonarrIndexer, Settings);
+
+            if (remoteIndexer == null)
+            {
+                _logger.Debug("Failed to add {0} [{1}]", indexer.Name, indexer.Id);
+
+                return;
+            }
+
             _appIndexerMapService.Insert(new AppIndexerMap { AppId = Definition.Id, IndexerId = indexer.Id, RemoteIndexerId = remoteIndexer.Id });
         }
 

--- a/src/NzbDrone.Core/Applications/Whisparr/Whisparr.cs
+++ b/src/NzbDrone.Core/Applications/Whisparr/Whisparr.cs
@@ -96,6 +96,14 @@ namespace NzbDrone.Core.Applications.Whisparr
             var whisparrIndexer = BuildWhisparrIndexer(indexer, indexer.Protocol);
 
             var remoteIndexer = _whisparrV3Proxy.AddIndexer(whisparrIndexer, Settings);
+
+            if (remoteIndexer == null)
+            {
+                _logger.Debug("Failed to add {0} [{1}]", indexer.Name, indexer.Id);
+
+                return;
+            }
+
             _appIndexerMapService.Insert(new AppIndexerMap { AppId = Definition.Id, IndexerId = indexer.Id, RemoteIndexerId = remoteIndexer.Id });
         }
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fix for empty remote indexer, eg. validation failures.

```
2023-06-01 16:18:35.5|Error|ApplicationService|An error occurred while talking to remote application.

[v1.4.1.3258] System.NullReferenceException: Object reference not set to an instance of an object.
   at NzbDrone.Core.Applications.Radarr.Radarr.AddIndexer(IndexerDefinition indexer) in ./Prowlarr.Core/Applications/Radarr/Radarr.cs:line 99
   at NzbDrone.Core.Applications.ApplicationService.ExecuteAction(Action`1 applicationAction, IApplication application) in ./Prowlarr.Core/Applications/ApplicationService.cs:line 267
```