### PR TITLE
Fixed: (Myanonamouse) Allow aborting download if FL token purchase fails

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/MyAnonamouse.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/MyAnonamouse.cs
@@ -56,7 +56,7 @@ namespace NzbDrone.Core.Indexers.Definitions
 
         public override async Task<byte[]> Download(Uri link)
         {
-            if (Settings.Freeleech > 0)
+            if (Settings.Freeleech != (int)MyAnonamouseFreeleech.Never)
             {
                 _logger.Debug($"Attempting to use freeleech token for {link.AbsoluteUri}");
 
@@ -81,7 +81,7 @@ namespace NzbDrone.Core.Indexers.Definitions
                     {
                         _logger.Debug($"Failed to use freeleech token: {resource.Error}");
 
-                        if (Settings.Freeleech == 1)
+                        if (Settings.Freeleech == (int)MyAnonamouseFreeleech.Preferred)
                         {
                             _logger.Debug($"'Use Freeleech Token' option set to preferred, continuing download");
                         }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Updating the MAM indexer to allow for multiple freeleech token options; Never, Preferred, Required. Never should never spend any tokens, Preferred should attempt to buy and spend tokens but still download if it fails, and Required should abort the download if buying a token fails. The current behaviour is a binary choice between Never and Preferred.

This is not ready for merging yet, as I have multiple user facing issues. Here's a list of them, I would like some input:

* Is there a better way to abort non-fl downloads other than throwing ReleaseUnavailableException? I could return null and refactor everything that calls the indexer to check for it, or I could return an HTTP error status. I personally consider null returns dirty, and leads to other problems, such as not being descriptive of what actually went wrong. Returning an HTTP status feels out of scope for an indexer, but I'm a little more on the fence here.
* Is there a better way to check for something already being freeleech, other than just reading the response string after attempting to spend a token? MAM api docs are extremely bare bones and don't even list the current method of spending a token through the url queries.
* Should manually downloading a release bypass this setting and just force the download regardless of freeleech status? If it did that I could see users having issues not realizing they're manually downloading non-freeleech. If manual downloads are blocked as well, how would I go about providing a proper error message when hovering over the red icon when a download fails, per the screenshot below?

On an unrelated note, are there any servarr code style guidelines that I can read or just follow stylecop in the IDE? 

#### Screenshot (if UI related)
![image](https://github.com/Prowlarr/Prowlarr/assets/19289767/efdd871c-fc5d-4557-9215-557278f2010a)
![image](https://github.com/Prowlarr/Prowlarr/assets/19289767/732ce1e6-9168-48fd-84d2-e42c85b6a622)


#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Partially resolved #1839 