### PR TITLE
Fixed: Remove Defunct Tracker PirateTheNet

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/PirateTheNet.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/PirateTheNet.cs
@@ -19,7 +19,7 @@ using NzbDrone.Core.Parser;
 using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.Indexers.Definitions;
-
+[Obsolete("PirateTheNet has shutdown 2023-10-14")]
 public class PirateTheNet : TorrentIndexerBase<UserPassTorrentBaseSettings>
 {
     public override string Name => "PirateTheNet";


### PR DESCRIPTION
PTN closed down for good.

They had an official announcement to close down on the 14th October.

Aither offered to accept refugees. See /forums/topics/2535 on aither for more context. Description


#### Description
The definition is no longer needed as the tracker ceased all operation.
