### PR TITLE
add Peers to ReleaseResource

### DIFF
--- a/src/Prowlarr.Api.V1/Search/ReleaseResource.cs
+++ b/src/Prowlarr.Api.V1/Search/ReleaseResource.cs
@@ -37,6 +37,7 @@ namespace Prowlarr.Api.V1.Search
         public string InfoHash { get; set; }
         public int? Seeders { get; set; }
         public int? Leechers { get; set; }
+        public int? Peers => Seeders + Leechers;
         public DownloadProtocol Protocol { get; set; }
 
         public string FileName


### PR DESCRIPTION
#### Database Migration
NO

#### Description
The filter for Peers is currently broken, as the logic looks for a property on the release item of the filter name 'peers'. Since no such property is found, the item is automatically discarded, meaning the filter will never return any results, valid or otherwise.

The simplest resolution to this is to add the Peers property as the sum of the existing Seeders and Leechers properties. This then allows the filtering system to function as expected.

#### Screenshot (if UI related)
![image](https://github.com/Prowlarr/Prowlarr/assets/35006874/68d3a01f-b460-4568-8c63-f979a6729a7e)


#### Todos
- [N/A ] Tests
- [ N/A] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ N/A] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR
N/A

* Added Peers to ReleaseResource so that it can be used by the filtering system