### PR TITLE
Fixed: Ignore terms with digits only in filter releases by query

### DIFF
--- a/src/NzbDrone.Core/Indexers/IndexerBase.cs
+++ b/src/NzbDrone.Core/Indexers/IndexerBase.cs
@@ -171,10 +171,13 @@ namespace NzbDrone.Core.Indexers
                 var splitRegex = new Regex("[^\\w]+");
 
                 // split search term to individual terms for less aggressive filtering, filter common terms
-                var terms = splitRegex.Split(searchCriteria.SearchTerm).Where(t => t.IsNotNullOrWhiteSpace() && t.Length > 1 && !commonWords.ContainsIgnoreCase(t));
+                var terms = splitRegex.Split(searchCriteria.SearchTerm).Where(t => t.IsNotNullOrWhiteSpace() && t.Length > 1 && !commonWords.ContainsIgnoreCase(t) && !t.IsAllDigits()).ToArray();
 
-                // check in title and description for any term searched for
-                releases = releases.Where(r => terms.Any(t => (r.Title.IsNotNullOrWhiteSpace() && r.Title.ContainsIgnoreCase(t)) || (r.Description.IsNotNullOrWhiteSpace() && r.Description.ContainsIgnoreCase(t)))).ToList();
+                if (terms.Any())
+                {
+                    // check in title and description for any term searched for
+                    releases = releases.Where(r => terms.Any(t => (r.Title.IsNotNullOrWhiteSpace() && r.Title.ContainsIgnoreCase(t)) || (r.Description.IsNotNullOrWhiteSpace() && r.Description.ContainsIgnoreCase(t)))).ToList();
+                }
             }
 
             return releases;


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Since some trackers seem to remove everything non-alphanumeric on a search, eg. `你想活出怎样的人生 2023` returns results for everything with `2023`, this change is trying to filter by at least one term with alphabetical characters.