### PR TITLE
Don't lowercase UrlBase in ConfigFileProvider

### DIFF
--- a/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
@@ -227,7 +227,7 @@ namespace NzbDrone.Core.Configuration
                     return urlBase;
                 }
 
-                return "/" + urlBase.Trim('/').ToLower();
+                return "/" + urlBase;
             }
         }
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
UrlBase should honour the case it is given.

(cherry picked from commit e1de523c89f7649e64f520b090bbdb2f56cc4b85) (cherry picked from commit 9ccefe00951d2959ef79bdaa5731d95f97162d46)
#### Screenshot (if UI related)

#### Todos

#### Issues Fixed or Closed by this PR

* Fixes #1988