### PR TITLE
Remove http being added to proxy for flaresolverr

### DIFF
--- a/src/NzbDrone.Core/IndexerProxies/FlareSolverr/FlareSolverr.cs
+++ b/src/NzbDrone.Core/IndexerProxies/FlareSolverr/FlareSolverr.cs
@@ -209,7 +209,7 @@ namespace NzbDrone.Core.IndexerProxies.FlareSolverr
             switch (proxySettings.Type)
             {
                 case ProxyType.Http:
-                    return new Uri("http://" + proxySettings.Host + ":" + proxySettings.Port);
+                    return new Uri(proxySettings.Host + ":" + proxySettings.Port);
                 case ProxyType.Socks4:
                     return new Uri("socks4://" + proxySettings.Host + ":" + proxySettings.Port);
                 case ProxyType.Socks5:


### PR DESCRIPTION

#### Database Migration
NO

#### Description
Removes the http prefix that is added to the proxy url when passing a proxy to flaresolverr. Flaresolverr doesn't seem to like the http:// being added and fails to work properly.

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)
