### PR TITLE
Fixed: Properly display capabilities for Newznab and Torznab feeds

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/Newznab/Newznab.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Newznab/Newznab.cs
@@ -44,7 +44,7 @@ namespace NzbDrone.Core.Indexers.Newznab
 
         public string[] GetBaseUrlFromSettings()
         {
-            if (Definition == null || Settings?.Categories == null)
+            if (Definition == null || Settings?.Capabilities == null)
             {
                 return new[] { "" };
             }
@@ -61,14 +61,24 @@ namespace NzbDrone.Core.Indexers.Newznab
         {
             var caps = new IndexerCapabilities();
 
-            if (Definition == null || Settings?.Categories == null)
+            if (Definition == null || Settings?.Capabilities == null)
             {
                 return caps;
             }
 
-            foreach (var category in Settings.Categories)
+            caps.SupportsRawSearch = Settings.Capabilities?.SupportsRawSearch ?? false;
+            caps.SearchParams = Settings.Capabilities?.SearchParams ?? new List<SearchParam> { SearchParam.Q };
+            caps.TvSearchParams = Settings.Capabilities?.TvSearchParams ?? new List<TvSearchParam>();
+            caps.MovieSearchParams = Settings.Capabilities?.MovieSearchParams ?? new List<MovieSearchParam>();
+            caps.MusicSearchParams = Settings.Capabilities?.MusicSearchParams ?? new List<MusicSearchParam>();
+            caps.BookSearchParams = Settings.Capabilities?.BookSearchParams ?? new List<BookSearchParam>();
+
+            if (Settings.Capabilities?.Categories != null)
             {
-                caps.Categories.AddCategoryMapping(category.Name, category);
+                foreach (var category in Settings.Capabilities.Categories)
+                {
+                    caps.Categories.AddCategoryMapping(category.Name, category);
+                }
             }
 
             return caps;

--- a/src/NzbDrone.Core/Indexers/Definitions/Newznab/NewznabCapabilitiesProvider.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Newznab/NewznabCapabilitiesProvider.cs
@@ -124,7 +124,7 @@ namespace NzbDrone.Core.Indexers.Newznab
                 {
                     foreach (var param in xmlBasicSearch.Attribute("supportedParams").Value.Split(','))
                     {
-                        if (Enum.TryParse(param, true, out SearchParam searchParam))
+                        if (Enum.TryParse(param, true, out SearchParam searchParam) && !capabilities.SearchParams.Contains(searchParam))
                         {
                             capabilities.SearchParams.AddIfNotNull(searchParam);
                         }
@@ -146,7 +146,7 @@ namespace NzbDrone.Core.Indexers.Newznab
                 {
                     foreach (var param in xmlMovieSearch.Attribute("supportedParams").Value.Split(','))
                     {
-                        if (Enum.TryParse(param, true, out MovieSearchParam searchParam))
+                        if (Enum.TryParse(param, true, out MovieSearchParam searchParam) && !capabilities.MovieSearchParams.Contains(searchParam))
                         {
                             capabilities.MovieSearchParams.AddIfNotNull(searchParam);
                         }
@@ -166,7 +166,7 @@ namespace NzbDrone.Core.Indexers.Newznab
                 {
                     foreach (var param in xmlTvSearch.Attribute("supportedParams").Value.Split(','))
                     {
-                        if (Enum.TryParse(param, true, out TvSearchParam searchParam))
+                        if (Enum.TryParse(param, true, out TvSearchParam searchParam) && !capabilities.TvSearchParams.Contains(searchParam))
                         {
                             capabilities.TvSearchParams.AddIfNotNull(searchParam);
                         }
@@ -186,7 +186,7 @@ namespace NzbDrone.Core.Indexers.Newznab
                 {
                     foreach (var param in xmlAudioSearch.Attribute("supportedParams").Value.Split(','))
                     {
-                        if (Enum.TryParse(param, true, out MusicSearchParam searchParam))
+                        if (Enum.TryParse(param, true, out MusicSearchParam searchParam) && !capabilities.MusicSearchParams.Contains(searchParam))
                         {
                             capabilities.MusicSearchParams.AddIfNotNull(searchParam);
                         }
@@ -206,7 +206,7 @@ namespace NzbDrone.Core.Indexers.Newznab
                 {
                     foreach (var param in xmlBookSearch.Attribute("supportedParams").Value.Split(','))
                     {
-                        if (Enum.TryParse(param, true, out BookSearchParam searchParam))
+                        if (Enum.TryParse(param, true, out BookSearchParam searchParam) && !capabilities.BookSearchParams.Contains(searchParam))
                         {
                             capabilities.BookSearchParams.AddIfNotNull(searchParam);
                         }

--- a/src/NzbDrone.Core/Indexers/Definitions/Newznab/NewznabCapabilitiesSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Newznab/NewznabCapabilitiesSettings.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+
+namespace NzbDrone.Core.Indexers.Newznab;
+
+public class NewznabCapabilitiesSettings
+{
+    public bool SupportsRawSearch { get; set; }
+
+    public List<SearchParam> SearchParams { get; set; } = new ();
+
+    public List<TvSearchParam> TvSearchParams { get; set; } = new ();
+
+    public List<MovieSearchParam> MovieSearchParams { get; set; } = new ();
+
+    public List<MusicSearchParam> MusicSearchParams { get; set; } = new ();
+
+    public List<BookSearchParam> BookSearchParams { get; set; } = new ();
+
+    public List<IndexerCategory> Categories { get; set; } = new ();
+
+    public NewznabCapabilitiesSettings()
+    {
+    }
+
+    public NewznabCapabilitiesSettings(IndexerCapabilities capabilities)
+    {
+        SupportsRawSearch = capabilities?.SupportsRawSearch ?? false;
+        SearchParams = capabilities?.SearchParams;
+        TvSearchParams = capabilities?.TvSearchParams;
+        MovieSearchParams = capabilities?.MovieSearchParams;
+        MusicSearchParams = capabilities?.MusicSearchParams;
+        BookSearchParams = capabilities?.BookSearchParams;
+        Categories = capabilities?.Categories.GetTorznabCategoryList();
+    }
+}

--- a/src/NzbDrone.Core/Indexers/Definitions/Newznab/NewznabSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Newznab/NewznabSettings.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using FluentValidation;
@@ -76,7 +75,7 @@ namespace NzbDrone.Core.Indexers.Newznab
         [FieldDefinition(7)]
         public IndexerBaseSettings BaseSettings { get; set; } = new ();
 
-        public List<IndexerCategory> Categories { get; set; }
+        public NewznabCapabilitiesSettings Capabilities { get; set; }
 
         // Field 8 is used by TorznabSettings MinimumSeeders
         // If you need to add another field here, update TorznabSettings as well and this comment

--- a/src/NzbDrone.Core/Indexers/Definitions/Torznab/Torznab.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Torznab/Torznab.cs
@@ -44,7 +44,7 @@ namespace NzbDrone.Core.Indexers.Torznab
 
         public string[] GetBaseUrlFromSettings()
         {
-            if (Definition == null || Settings?.Categories == null)
+            if (Definition == null || Settings?.Capabilities == null)
             {
                 return new[] { "" };
             }
@@ -61,14 +61,24 @@ namespace NzbDrone.Core.Indexers.Torznab
         {
             var caps = new IndexerCapabilities();
 
-            if (Definition == null || Settings?.Categories == null)
+            if (Definition == null || Settings?.Capabilities == null)
             {
                 return caps;
             }
 
-            foreach (var category in Settings.Categories)
+            caps.SupportsRawSearch = Settings.Capabilities?.SupportsRawSearch ?? false;
+            caps.SearchParams = Settings.Capabilities?.SearchParams ?? new List<SearchParam> { SearchParam.Q };
+            caps.TvSearchParams = Settings.Capabilities?.TvSearchParams ?? new List<TvSearchParam>();
+            caps.MovieSearchParams = Settings.Capabilities?.MovieSearchParams ?? new List<MovieSearchParam>();
+            caps.MusicSearchParams = Settings.Capabilities?.MusicSearchParams ?? new List<MusicSearchParam>();
+            caps.BookSearchParams = Settings.Capabilities?.BookSearchParams ?? new List<BookSearchParam>();
+
+            if (Settings.Capabilities?.Categories != null)
             {
-                caps.Categories.AddCategoryMapping(category.Name, category);
+                foreach (var category in Settings.Capabilities.Categories)
+                {
+                    caps.Categories.AddCategoryMapping(category.Name, category);
+                }
             }
 
             return caps;

--- a/src/NzbDrone.Core/Indexers/IndexerFactory.cs
+++ b/src/NzbDrone.Core/Indexers/IndexerFactory.cs
@@ -284,7 +284,9 @@ namespace NzbDrone.Core.Indexers
             if (definition.Enable && definition.Implementation is nameof(Newznab.Newznab) or nameof(Torznab.Torznab))
             {
                 var settings = (NewznabSettings)definition.Settings;
-                settings.Categories = _newznabCapabilitiesProvider.GetCapabilities(settings, definition)?.Categories.GetTorznabCategoryList();
+                var capabilities = _newznabCapabilitiesProvider.GetCapabilities(settings, definition);
+
+                settings.Capabilities = new NewznabCapabilitiesSettings(capabilities);
             }
 
             if (definition.Implementation == nameof(Cardigann))
@@ -304,7 +306,9 @@ namespace NzbDrone.Core.Indexers
             if (definition.Enable && definition.Implementation is nameof(Newznab.Newznab) or nameof(Torznab.Torznab))
             {
                 var settings = (NewznabSettings)definition.Settings;
-                settings.Categories = _newznabCapabilitiesProvider.GetCapabilities(settings, definition)?.Categories.GetTorznabCategoryList();
+                var capabilities = _newznabCapabilitiesProvider.GetCapabilities(settings, definition);
+
+                settings.Capabilities = new NewznabCapabilitiesSettings(capabilities);
             }
 
             if (definition.Implementation == nameof(Cardigann))


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Persist search capabilities in settings so we can properly display them in the info modal.

Also avoid having duplicated params in NewznabCapabilitiesProvider.