### PR TITLE
Fixed: Use cookies from response to avoid invalid credentials after original mam_id expires

### DIFF
--- a/src/NzbDrone.Core/Indexers/HttpIndexerBase.cs
+++ b/src/NzbDrone.Core/Indexers/HttpIndexerBase.cs
@@ -607,12 +607,7 @@ namespace NzbDrone.Core.Indexers
 
         protected virtual bool CheckIfLoginNeeded(HttpResponse httpResponse)
         {
-            if (httpResponse.StatusCode == HttpStatusCode.Unauthorized)
-            {
-                return true;
-            }
-
-            return false;
+            return httpResponse.StatusCode == HttpStatusCode.Unauthorized;
         }
 
         protected virtual Task DoLogin()


### PR DESCRIPTION
#### Description
This should avoid invalid credentials since mam_id is updated to a new one every time after a request.



> [!WARNING]  
> PS: These changes won't update the mam_id in the settings, just the cookie jar internally in the application for future use.