### PR TITLE
add support for seeders, seed_ratio and seed_duration for LazyLibrarian

### DIFF
--- a/src/NzbDrone.Core/Applications/LazyLibrarian/LazyLibrarian.cs
+++ b/src/NzbDrone.Core/Applications/LazyLibrarian/LazyLibrarian.cs
@@ -165,6 +165,13 @@ namespace NzbDrone.Core.Applications.LazyLibrarian
                 Priority = indexer.Priority
             };
 
+            if (indexer.Protocol == DownloadProtocol.Torrent)
+            {
+                lazyLibrarianIndexer.MinimumSeeders = ((ITorrentIndexerSettings)indexer.Settings).TorrentBaseSettings.AppMinimumSeeders ?? indexer.AppProfile.Value.MinimumSeeders;
+                lazyLibrarianIndexer.SeedRatio = ((ITorrentIndexerSettings)indexer.Settings).TorrentBaseSettings.SeedRatio.GetValueOrDefault();
+                lazyLibrarianIndexer.SeedTime = ((ITorrentIndexerSettings)indexer.Settings).TorrentBaseSettings.SeedTime.GetValueOrDefault();
+            }
+
             return lazyLibrarianIndexer;
         }
     }

--- a/src/NzbDrone.Core/Applications/LazyLibrarian/LazyLibrarianIndexer.cs
+++ b/src/NzbDrone.Core/Applications/LazyLibrarian/LazyLibrarianIndexer.cs
@@ -31,6 +31,9 @@ namespace NzbDrone.Core.Applications.LazyLibrarian
         public string Altername { get; set; }
         public LazyLibrarianProviderType Type { get; set; }
         public int Priority { get; set; }
+        public double SeedRatio { get; set; }
+        public int SeedTime { get; set; }
+        public int MinimumSeeders { get; set; }
 
         public bool Equals(LazyLibrarianIndexer other)
         {
@@ -45,7 +48,10 @@ namespace NzbDrone.Core.Applications.LazyLibrarian
                 other.Categories == Categories &&
                 other.Enabled == Enabled &&
                 other.Altername == Altername &&
-                other.Priority == Priority;
+                other.Priority == Priority &&
+                other.SeedRatio == SeedRatio &&
+                other.SeedTime == SeedTime &&
+                other.MinimumSeeders == MinimumSeeders;
         }
     }
 }

--- a/src/NzbDrone.Core/Applications/LazyLibrarian/LazyLibrarianV1Proxy.cs
+++ b/src/NzbDrone.Core/Applications/LazyLibrarian/LazyLibrarianV1Proxy.cs
@@ -96,6 +96,13 @@ namespace NzbDrone.Core.Applications.LazyLibrarian
                 { "dlpriority", CalculatePriority(indexer.Priority).ToString() }
             };
 
+            if (indexer.Type == LazyLibrarianProviderType.Torznab)
+            {
+                parameters.Add("seeders", indexer.MinimumSeeders.ToString());
+                parameters.Add("seed_ratio", indexer.SeedRatio.ToString());
+                parameters.Add("seed_duration", indexer.SeedTime.ToString());
+            }
+
             var request = BuildRequest(settings, "/api", "addProvider", HttpMethod.Get, parameters);
             CheckForError(Execute<LazyLibrarianStatus>(request));
             return indexer;
@@ -114,6 +121,13 @@ namespace NzbDrone.Core.Applications.LazyLibrarian
                 { "altername", indexer.Altername },
                 { "dlpriority", CalculatePriority(indexer.Priority).ToString() }
             };
+
+            if (indexer.Type == LazyLibrarianProviderType.Torznab)
+            {
+                parameters.Add("seeders", indexer.MinimumSeeders.ToString());
+                parameters.Add("seed_ratio", indexer.SeedRatio.ToString());
+                parameters.Add("seed_duration", indexer.SeedTime.ToString());
+            }
 
             var request = BuildRequest(settings, "/api", "changeProvider", HttpMethod.Get, parameters);
             CheckForError(Execute<LazyLibrarianStatus>(request));


### PR DESCRIPTION
#### Database Migration
 NO

#### Description
LazyLibrarian has newly added feature to have provider specific seed ration and duration. This change sets these values.

#### Screenshot (if UI related)

#### Todos
- [ ] Tests - No tests for LazyLibarian exist that would need to be updated.
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json) - No UI changes
- [ ] [Wiki Updates](https://wiki.servarr.com) - No changes needed

#### Issues Fixed or Closed by this PR

None