### PR TITLE
return error status if unsupported capabilities are used.

### DIFF
--- a/src/NzbDrone.Core/Indexers/Exceptions/UnsupportedCapabilitiesException.cs
+++ b/src/NzbDrone.Core/Indexers/Exceptions/UnsupportedCapabilitiesException.cs
@@ -1,0 +1,17 @@
+using NzbDrone.Common.Exceptions;
+
+namespace NzbDrone.Core.Indexers.Exceptions
+{
+    public class UnsupportedCapabilitiesException : NzbDroneException
+    {
+        public UnsupportedCapabilitiesException(string message, params object[] args)
+            : base(message, args)
+        {
+        }
+
+        public UnsupportedCapabilitiesException(string message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/src/NzbDrone.Core/Indexers/HttpIndexerBase.cs
+++ b/src/NzbDrone.Core/Indexers/HttpIndexerBase.cs
@@ -112,9 +112,8 @@ namespace NzbDrone.Core.Indexers
                 (searchCriteria.Genre.IsNotNullOrWhiteSpace() && !caps.MovieSearchGenreAvailable) ||
                 (searchCriteria.Year.HasValue && !caps.MovieSearchYearAvailable))
             {
-                _logger.Debug("Movie search skipped due to unsupported capabilities used: {0}", Definition.Name);
-
-                return Task.FromResult(new IndexerPageableQueryResult());
+                _logger.Error("Movie search used unsupported capabilities: {0}", Definition.Name);
+                throw new UnsupportedCapabilitiesException("Unsupported capabilities used: {0}", Definition.Name);
             }
 
             return FetchReleases(g => SetCookieFunctions(g).GetSearchRequests(searchCriteria), searchCriteria);
@@ -141,9 +140,8 @@ namespace NzbDrone.Core.Indexers
                 (searchCriteria.Genre.IsNotNullOrWhiteSpace() && !caps.MusicSearchGenreAvailable) ||
                 (searchCriteria.Year.HasValue && !caps.MusicSearchYearAvailable))
             {
-                _logger.Debug("Music search skipped due to unsupported capabilities used: {0}", Definition.Name);
-
-                return Task.FromResult(new IndexerPageableQueryResult());
+                _logger.Error("Music search used unsupported capabilities: {0}", Definition.Name);
+                throw new UnsupportedCapabilitiesException("Unsupported capabilities used: {0}", Definition.Name);
             }
 
             return FetchReleases(g => SetCookieFunctions(g).GetSearchRequests(searchCriteria), searchCriteria);
@@ -173,9 +171,8 @@ namespace NzbDrone.Core.Indexers
                 (searchCriteria.Genre.IsNotNullOrWhiteSpace() && !caps.TvSearchGenreAvailable) ||
                 (searchCriteria.Year.HasValue && !caps.TvSearchYearAvailable))
             {
-                _logger.Debug("TV search skipped due to unsupported capabilities used: {0}", Definition.Name);
-
-                return Task.FromResult(new IndexerPageableQueryResult());
+                _logger.Error("TV search used unsupported capabilities: {0}", Definition.Name);
+                throw new UnsupportedCapabilitiesException("Unsupported capabilities used: {0}", Definition.Name);
             }
 
             return FetchReleases(g => SetCookieFunctions(g).GetSearchRequests(searchCriteria), searchCriteria);
@@ -201,9 +198,8 @@ namespace NzbDrone.Core.Indexers
                 (searchCriteria.Genre.IsNotNullOrWhiteSpace() && !caps.BookSearchGenreAvailable) ||
                 (searchCriteria.Year.HasValue && !caps.BookSearchYearAvailable))
             {
-                _logger.Debug("Book search skipped due to unsupported capabilities used: {0}", Definition.Name);
-
-                return Task.FromResult(new IndexerPageableQueryResult());
+                _logger.Error("Book search used unsupported capabilities: {0}", Definition.Name);
+                throw new UnsupportedCapabilitiesException("Unsupported capabilities used: {0}", Definition.Name);
             }
 
             return FetchReleases(g => SetCookieFunctions(g).GetSearchRequests(searchCriteria), searchCriteria);

--- a/src/Prowlarr.Api.V1/Indexers/NewznabController.cs
+++ b/src/Prowlarr.Api.V1/Indexers/NewznabController.cs
@@ -15,6 +15,7 @@ using NzbDrone.Common.Http;
 using NzbDrone.Core.Download;
 using NzbDrone.Core.Exceptions;
 using NzbDrone.Core.Indexers;
+using NzbDrone.Core.Indexers.Exceptions;
 using NzbDrone.Core.IndexerSearch;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.ThingiProvider.Status;
@@ -177,7 +178,15 @@ namespace NzbDrone.Api.V1.Indexers
                 case "music":
                 case "book":
                 case "movie":
-                    var results = await _releaseSearchService.Search(request, new List<int> { indexerDef.Id }, false);
+                    NewznabResults results;
+                    try
+                    {
+                        results = await _releaseSearchService.Search(request, new List<int> { indexerDef.Id }, false);
+                    }
+                    catch (UnsupportedCapabilitiesException e)
+                    {
+                        return CreateResponse(CreateErrorXML(201, e.Message)); // 201: incorrect parameter
+                    }
 
                     var blockedIndexerStatusPost = GetBlockedIndexerStatus(indexer);
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Report errors instead of empty results in case of unsupported capabilities used in search.

I wanted to check with you if something like this is generally acceptable and made a rudimentary implmentation.

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json) - No UI impact
- [ ] [Wiki Updates](https://wiki.servarr.com) - I don't think there's anything to update.
