### PR TITLE
New: Use instance name in forms authentication cookie name

### DIFF
--- a/src/Prowlarr.Http/Authentication/AuthenticationBuilderExtensions.cs
+++ b/src/Prowlarr.Http/Authentication/AuthenticationBuilderExtensions.cs
@@ -1,7 +1,10 @@
 using System;
+using System.Web;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.Extensions.DependencyInjection;
 using NzbDrone.Core.Authentication;
+using NzbDrone.Core.Configuration;
 
 namespace Prowlarr.Http.Authentication
 {
@@ -29,19 +32,25 @@ namespace Prowlarr.Http.Authentication
 
         public static AuthenticationBuilder AddAppAuthentication(this IServiceCollection services)
         {
-            return services.AddAuthentication()
-                .AddNone(AuthenticationType.None.ToString())
-                .AddExternal(AuthenticationType.External.ToString())
-                .AddBasic(AuthenticationType.Basic.ToString())
-                .AddCookie(AuthenticationType.Forms.ToString(), options =>
+            services.AddOptions<CookieAuthenticationOptions>(AuthenticationType.Forms.ToString())
+                .Configure<IConfigFileProvider>((options, configFileProvider) =>
                 {
-                    options.Cookie.Name = "ProwlarrAuth";
+                    // Url Encode the cookie name to account for spaces or other invalid characters in the configured instance name
+                    var instanceName = HttpUtility.UrlEncode(configFileProvider.InstanceName);
+
+                    options.Cookie.Name = $"{instanceName}Auth";
                     options.AccessDeniedPath = "/login?loginFailed=true";
                     options.LoginPath = "/login";
                     options.ExpireTimeSpan = TimeSpan.FromDays(7);
                     options.SlidingExpiration = true;
                     options.ReturnUrlParameter = "returnUrl";
-                })
+                });
+
+            return services.AddAuthentication()
+                .AddNone(AuthenticationType.None.ToString())
+                .AddExternal(AuthenticationType.External.ToString())
+                .AddBasic(AuthenticationType.Basic.ToString())
+                .AddCookie(AuthenticationType.Forms.ToString())
                 .AddApiKey("API", options =>
                 {
                     options.HeaderName = "X-Api-Key";


### PR DESCRIPTION
Closes #2224

#### Database Migration
NO

#### Description
Uses AddOptions so we can inject IConfigFileProvider when creating the auth cookie name.

#### Issues Fixed or Closed by this PR

* Fixes #2224