### PR TITLE
Ignore "Percona Distribution" in Postgres version string

### DIFF
--- a/src/NzbDrone.Core/Datastore/Database.cs
+++ b/src/NzbDrone.Core/Datastore/Database.cs
@@ -52,7 +52,7 @@ namespace NzbDrone.Core.Datastore
             {
                 using var db = _datamapperFactory();
                 var dbConnection = db as DbConnection;
-                var version = Regex.Replace(dbConnection.ServerVersion, @"\(.*?\)", "");
+                var version = Regex.Replace(dbConnection.ServerVersion, @"\(.*?\)", "").Replace(" - Percona Distribution", "");
 
                 return new Version(version);
             }


### PR DESCRIPTION
Drop the ` - Percona Distribution` suffix before passing the version string to `System.Version`.

#### Description
I tried using Sonarr with Percona Everest (a k8s operator that provisions various databases, including PostgreSQL). However, Percona Everest provisions a custom version of PostgreSQL, that reports its version as "16.3 - Percona Distribution". This causes an exception when that version is passed to the `System.Version` constructor.