### PR TITLE
fix: norwegian characters in NorBits searchTerm

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/NorBits.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/NorBits.cs
@@ -191,6 +191,14 @@ public class NorBitsRequestGenerator : IIndexerRequestGenerator
         else if (!string.IsNullOrWhiteSpace(term))
         {
             searchTerm = "search=" + term.UrlEncode(Encoding.GetEncoding(28591));
+            
+            searchTerm = searchTerm
+            .Replace("%E6", "æ")
+            .Replace("%F8", "ø")
+            .Replace("%E5", "å")
+            .Replace("%C6", "Æ")
+            .Replace("%D8", "Ø")
+            .Replace("%C5", "Å");
         }
 
         searchUrl += "?" + searchTerm + "&" + parameters.GetQueryString();


### PR DESCRIPTION
#### Description
Prowlarr handles Norwegian special characters very well, by searching both with the actual character and with the non special variation (e.g. `ø` becomes `oe`).

The special character is encoded, as it should be.
The issue however, is that the search query in the URL for NorBits requires the actual special character.

So if someone uploads something on NorBits and uses `ø` in the name instead of `oe`, it's not searchable by Prowlarr, because it searches with `%F8` which is interpreted literally on NorBits.

This PR fixes this issue by replacing the encoded version of the Norwegian characters back to their non-encoded version, after the rest of the searchTerm has been encoded (which is needed, because + is still needed for space etc.).

An example ID is `223078`.