### PR TITLE
feat: Fix category and dateTime parsing for tracker NorBits

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/NorBits.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/NorBits.cs
@@ -287,8 +287,8 @@ public class NorBitsParser : IParseIndexerResponse
             var title = qDetails?.GetAttribute("title").Trim();
             var details = _settings.BaseUrl + qDetails?.GetAttribute("href").TrimStart('/');
 
-            var mainCategory = row.QuerySelector("td:nth-of-type(1) > div > a[href*=\"main_cat[]\"]")?.GetAttribute("href")?.Split('?').Last();
-            var secondCategory = row.QuerySelector("td:nth-of-type(1) > div > a[href*=\"sub2_cat[]\"]")?.GetAttribute("href")?.Split('?').Last();
+            var mainCategory = row.QuerySelector("td:nth-of-type(1) > a[href*=\"main_cat[]\"]")?.GetAttribute("href")?.Split('?').Last();
+            var secondCategory = row.QuerySelector("td:nth-of-type(1) > a[href*=\"sub2_cat[]\"]")?.GetAttribute("href")?.Split('?').Last();
 
             var categoryList = new[] { mainCategory, secondCategory };
             var cat = string.Join("&", categoryList.Where(c => !string.IsNullOrWhiteSpace(c)));
@@ -308,7 +308,7 @@ public class NorBitsParser : IParseIndexerResponse
                 Grabs = ParseUtil.CoerceInt(row.QuerySelector("td:nth-of-type(8)")?.FirstChild?.TextContent.Trim()),
                 Seeders = seeders,
                 Peers = seeders + leechers,
-                PublishDate = DateTime.ParseExact(row.QuerySelector("td:nth-of-type(5)")?.TextContent.Trim(), "yyyy-MM-ddHH:mm:ss", CultureInfo.InvariantCulture),
+                PublishDate = DateTime.ParseExact(row.QuerySelector("td:nth-of-type(5)")?.TextContent.Replace("\n", string.Empty).Replace("\r", string.Empty).Trim(), "yyyy-MM-ddHH:mm:ss", CultureInfo.InvariantCulture),
                 DownloadVolumeFactor = 1,
                 UploadVolumeFactor = 1,
                 MinimumRatio = 1,


### PR DESCRIPTION
## Description
### Categories
The HTML has probably changed since this definition was made, as there is no div, so it can't parse the category correctly.
#2337 did not fix the issue of `|Warn|NorBits|Invalid Release: '<redacted>' from indexer: NorBits. No categories provided.`

The HTML looks like this
```html
<table id="torrentTable" class="torrentTable listTable" style="margin: 0px auto;">
  <tbody>
    <tr>
    <th></th>
    <th></th>
    </tr>
    <tr>
      <td>
        <a href="browse.php?main_cat[]=x&sub1_cat[]=y&sub3_cat[]=z"> 
          <img src="/style/pic/blank2.gif" title="category / subcategory / subcategory2">
        </a>
      </td>
    </tr>
  </tbody>
</table>
```

### DateTime
Maybe the HTML for DateTime has also been changed since this definition was made.. 
The HTML looks like this
```html
<td>
  yyyy-MM-dd<br>HH:mm:ss
</td>
```

This PR fixes parsing for both.