### PR TITLE
fix: unknown categories

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/NorBits.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/NorBits.cs
@@ -130,29 +130,13 @@ public class NorBits : TorrentIndexerBase<NorBitsSettings>
         };
 
         caps.Categories.AddCategoryMapping("main_cat[]=1", NewznabStandardCategory.Movies, "Filmer");
-        caps.Categories.AddCategoryMapping("main_cat[]=1&sub2_cat[]=49", NewznabStandardCategory.MoviesUHD, "Filmer - UHD-2160p");
-        caps.Categories.AddCategoryMapping("main_cat[]=1&sub2_cat[]=19", NewznabStandardCategory.MoviesHD, "Filmer - HD-1080p/i");
-        caps.Categories.AddCategoryMapping("main_cat[]=1&sub2_cat[]=20", NewznabStandardCategory.MoviesHD, "Filmer - HD-720p");
-        caps.Categories.AddCategoryMapping("main_cat[]=1&sub2_cat[]=22", NewznabStandardCategory.MoviesSD, "Filmer - SD");
         caps.Categories.AddCategoryMapping("main_cat[]=2", NewznabStandardCategory.TV, "TV");
-        caps.Categories.AddCategoryMapping("main_cat[]=2&sub2_cat[]=49", NewznabStandardCategory.TVUHD, "TV - UHD-2160p");
-        caps.Categories.AddCategoryMapping("main_cat[]=2&sub2_cat[]=19", NewznabStandardCategory.TVHD, "TV - HD-1080p/i");
-        caps.Categories.AddCategoryMapping("main_cat[]=2&sub2_cat[]=20", NewznabStandardCategory.TVHD, "TV - HD-720p");
-        caps.Categories.AddCategoryMapping("main_cat[]=2&sub2_cat[]=22", NewznabStandardCategory.TVSD, "TV - SD");
         caps.Categories.AddCategoryMapping("main_cat[]=3", NewznabStandardCategory.PC, "Programmer");
         caps.Categories.AddCategoryMapping("main_cat[]=4", NewznabStandardCategory.Console, "Spill");
         caps.Categories.AddCategoryMapping("main_cat[]=5", NewznabStandardCategory.Audio, "Musikk");
-        caps.Categories.AddCategoryMapping("main_cat[]=5&sub2_cat[]=42", NewznabStandardCategory.AudioMP3, "Musikk - 192");
-        caps.Categories.AddCategoryMapping("main_cat[]=5&sub2_cat[]=43", NewznabStandardCategory.AudioMP3, "Musikk - 256");
-        caps.Categories.AddCategoryMapping("main_cat[]=5&sub2_cat[]=44", NewznabStandardCategory.AudioMP3, "Musikk - 320");
-        caps.Categories.AddCategoryMapping("main_cat[]=5&sub2_cat[]=45", NewznabStandardCategory.AudioMP3, "Musikk - VBR");
-        caps.Categories.AddCategoryMapping("main_cat[]=5&sub2_cat[]=46", NewznabStandardCategory.AudioLossless, "Musikk - Lossless");
         caps.Categories.AddCategoryMapping("main_cat[]=6", NewznabStandardCategory.Books, "Tidsskrift");
         caps.Categories.AddCategoryMapping("main_cat[]=7", NewznabStandardCategory.AudioAudiobook, "Lydbøker");
         caps.Categories.AddCategoryMapping("main_cat[]=8", NewznabStandardCategory.AudioVideo, "Musikkvideoer");
-        caps.Categories.AddCategoryMapping("main_cat[]=8&sub2_cat[]=19", NewznabStandardCategory.AudioVideo, "Musikkvideoer - HD-1080p/i");
-        caps.Categories.AddCategoryMapping("main_cat[]=8&sub2_cat[]=20", NewznabStandardCategory.AudioVideo, "Musikkvideoer - HD-720p");
-        caps.Categories.AddCategoryMapping("main_cat[]=8&sub2_cat[]=22", NewznabStandardCategory.AudioVideo, "Musikkvideoer - SD");
         caps.Categories.AddCategoryMapping("main_cat[]=40", NewznabStandardCategory.AudioOther, "Podcasts");
 
         return caps;
@@ -287,11 +271,9 @@ public class NorBitsParser : IParseIndexerResponse
             var title = qDetails?.GetAttribute("title").Trim();
             var details = _settings.BaseUrl + qDetails?.GetAttribute("href").TrimStart('/');
 
-            var mainCategory = row.QuerySelector("td:nth-of-type(1) a[href*=\"main_cat[]\"]")?.GetAttribute("href")?.Split('?').Last();
-            var secondCategory = row.QuerySelector("td:nth-of-type(1) a[href*=\"sub2_cat[]\"]")?.GetAttribute("href")?.Split('?').Last();
-
-            var categoryList = new[] { mainCategory, secondCategory };
-            var cat = string.Join("&", categoryList.Where(c => !string.IsNullOrWhiteSpace(c)));
+            var catQuery = row.QuerySelector("td:nth-of-type(1) a[href*=\"main_cat[]\"]")?.GetAttribute("href")?.Split('?').Last();
+            var catParams = catQuery.Split('&', StringSplitOptions.RemoveEmptyEntries);
+            var cat = catParams.FirstOrDefault(x => x.StartsWith("main_cat[]=", StringComparison.OrdinalIgnoreCase));
 
             var seeders = ParseUtil.CoerceInt(row.QuerySelector("td:nth-of-type(9)").TextContent);
             var leechers = ParseUtil.CoerceInt(row.QuerySelector("td:nth-of-type(10)").TextContent);


### PR DESCRIPTION
### Description
My other PRs didn't fully fix the category issues for this tracker.
This time I've set up a test environment and tested the code and ensured the problem is fixed once and for all. Apologies for not doing that earlier.

The issue visualised:
![image](https://github.com/user-attachments/assets/706c849d-07dd-46db-97bc-e57ee3dbed31)

#### Details
As this parsed HTML, it's obviously prone to break when the HTML is changed, and it turns out it _never_ returns `sub2_cat[]` anymore.  This makes the category mapping useless as it does an exact match on the entire query(/all the params).
It almost never returns a (new?) `sub3_cat[]` either, and none of those can be mapped to the standard newznab categories anyway.

#### Changes
The updated code now only parses main category (as anything else is impossible in the new HTML presented, unfortunately).

It does it by finding the key in the params named `main_cat[]`, so even if the HTML changes in the future, it should work (as long as the link always contains `main_cat[]` and the numbers for the categories (TV, Movies etc.) don't change, obviously).

This also means it doesn't break anymore when the query is not an exact match (like when the query contains `sub3_cat[]` which is not handled in the parsing), since it extracts only the `main_cat[]=int` and sends to the parser.

Let's hope this is the last time we see an issue with parsing categories from this tracker 🙏 