### PR TITLE
New: Add Year filter to basic search

### DIFF
--- a/src/NzbDrone.Core.Test/IndexerSearchTests/ReleaseSearchServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerSearchTests/ReleaseSearchServiceFixture.cs
@@ -39,6 +39,10 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
                 .Callback<TvSearchCriteria>(s => result.Add(s))
                 .Returns(Task.FromResult(new IndexerPageableQueryResult()));
 
+            _mockIndexer.Setup(v => v.Fetch(It.IsAny<BasicSearchCriteria>()))
+                .Callback<BasicSearchCriteria>(s => result.Add(s))
+                .Returns(Task.FromResult(new IndexerPageableQueryResult()));
+
             return result;
         }
 
@@ -86,6 +90,26 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
 
             criteria.Count.Should().Be(1);
             criteria[0].ImdbId.Should().Be(expected);
+        }
+
+        [TestCase(2025, 2025)]
+        [TestCase(null, null)]
+        public void should_use_year_basic_search_criteria(int? input, int? expected)
+        {
+            var allCriteria = WatchForSearchCriteria();
+
+            var request = new NewznabRequest
+            {
+                t = "",
+                year = input
+            };
+
+            Subject.Search(request, new List<int> { 1 }, false);
+
+            var criteria = allCriteria.OfType<BasicSearchCriteria>().ToList();
+
+            criteria.Count.Should().Be(1);
+            criteria[0].Year.Should().Be(expected);
         }
     }
 }

--- a/src/NzbDrone.Core/IndexerSearch/Definitions/BasicSearchCriteria.cs
+++ b/src/NzbDrone.Core/IndexerSearch/Definitions/BasicSearchCriteria.cs
@@ -1,6 +1,30 @@
+using System.Text;
+using NzbDrone.Common.Extensions;
+
 namespace NzbDrone.Core.IndexerSearch.Definitions
 {
     public class BasicSearchCriteria : SearchCriteriaBase
     {
+        public int? Year { get; set; }
+
+        public override string SearchQuery
+        {
+            get
+            {
+                var searchQueryTerm = $"Term: []";
+                if (SearchTerm.IsNotNullOrWhiteSpace())
+                {
+                    searchQueryTerm = $"Term: [{SearchTerm}]";
+                }
+
+                var builder = new StringBuilder(searchQueryTerm);
+                if (Year.HasValue)
+                {
+                    builder = builder.Append($" Year:[{Year}]");
+                }
+
+                return builder.ToString().Trim();
+            }
+        }
     }
 }

--- a/src/NzbDrone.Core/IndexerSearch/NewznabRequest.cs
+++ b/src/NzbDrone.Core/IndexerSearch/NewznabRequest.cs
@@ -229,6 +229,21 @@ namespace NzbDrone.Core.IndexerSearch
                     q = q.Replace(match.Value, "").Trim();
                 }
             }
+
+            if (t == "search")
+            {
+                var matches = BookRegex.Matches(q);
+
+                foreach (Match match in matches)
+                {
+                    if (match.Groups["year"].Success)
+                    {
+                        year = int.TryParse(match.Groups["year"].Value, out var parsedYear) ? parsedYear : null;
+                    }
+
+                    q = q.Replace(match.Value, "").Trim();
+                }
+            }
         }
     }
 }

--- a/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
@@ -124,6 +124,7 @@ namespace NzbDrone.Core.IndexerSearch
         private async Task<NewznabResults> BasicSearch(NewznabRequest request, List<int> indexerIds, bool interactiveSearch)
         {
             var searchSpec = Get<BasicSearchCriteria>(request, indexerIds, interactiveSearch);
+            searchSpec.Year = request.year;
 
             var releases = await Dispatch(indexer => indexer.Fetch(searchSpec), searchSpec);
 

--- a/src/NzbDrone.Core/Indexers/Definitions/Cardigann/CardigannRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Cardigann/CardigannRequestGenerator.cs
@@ -141,6 +141,7 @@ namespace NzbDrone.Core.Indexers.Definitions.Cardigann
             var pageableRequests = new IndexerPageableRequestChain();
 
             var variables = GetQueryVariableDefaults(searchCriteria);
+            variables[".Query.Year"] = searchCriteria.Year?.ToString() ?? null;
 
             pageableRequests.Add(GetRequest(variables, searchCriteria));
 
@@ -162,7 +163,6 @@ namespace NzbDrone.Core.Indexers.Definitions.Cardigann
 
             //Movie
             variables[".Query.Movie"] = null;
-            variables[".Query.Year"] = null;
             variables[".Query.IMDBID"] = null;
             variables[".Query.IMDBIDShort"] = null;
             variables[".Query.TMDBID"] = null;


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Add the Year filter to the basic search. Some indexers have a different field for the year.

So we can search something like `Animal Kingdom {Year:2016}`

Or use it in a indexer definition :
```
search:
  path: torrents.php
  inputs:
    $raw: "{{ range .Categories }}filter_cat[{{.}}]=1&{{end}}"
    search: "{{ .Keywords }}"
    year: "{{ .Query.Year }}"
```

_If_ this is accepted, I'll push a PR to change  :
Radarr : https://github.com/Radarr/Radarr/blob/develop/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs#L171
from
```
$"&q={NewsnabifyTitle(searchQuery)}"));
```
to 
```
$"&q={NewsnabifyTitle(searchQuery)}&year={searchCriteria.Movie.Year}"));
```

In Sonarr : 
https://github.com/Sonarr/Sonarr/blob/develop/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs#L580 from 
```
$"&title={Uri.EscapeDataString(searchTerm)}{parameters}"));
```
to
```
$"&title={Uri.EscapeDataString(searchTerm)}&year={searchCriteria.Series.Year}{parameters}"));
```
https://github.com/Sonarr/Sonarr/blob/develop/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs#L591 from
```
$"&q={NewsnabifyTitle(queryTitle)}{parameters}"));
```
to 
```
$"&q={NewsnabifyTitle(queryTitle)}&year={searchCriteria.Series.Year}{parameters}"));
```