### PR TITLE
Fixed: Sync indexers to apps only if search is available

### DIFF
--- a/src/NzbDrone.Core/Applications/Lidarr/Lidarr.cs
+++ b/src/NzbDrone.Core/Applications/Lidarr/Lidarr.cs
@@ -121,9 +121,16 @@ namespace NzbDrone.Core.Applications.Lidarr
         {
             var indexerCapabilities = GetIndexerCapabilities(indexer);
 
+            if (!indexerCapabilities.MusicSearchAvailable)
+            {
+                _logger.Debug("Skipping add for indexer {0} [{1}] due to missing music search support by the indexer", indexer.Name, indexer.Id);
+
+                return;
+            }
+
             if (indexerCapabilities.Categories.SupportedCategories(Settings.SyncCategories.ToArray()).Empty())
             {
-                _logger.Trace("Skipping add for indexer {0} [{1}] due to no app Sync Categories supported by the indexer", indexer.Name, indexer.Id);
+                _logger.Debug("Skipping add for indexer {0} [{1}] due to no app Sync Categories supported by the indexer", indexer.Name, indexer.Id);
 
                 return;
             }
@@ -178,7 +185,7 @@ namespace NzbDrone.Core.Applications.Lidarr
                 {
                     _logger.Debug("Syncing remote indexer with current settings");
 
-                    if (indexerCapabilities.Categories.SupportedCategories(Settings.SyncCategories.ToArray()).Any())
+                    if (indexerCapabilities.MusicSearchAvailable && indexerCapabilities.Categories.SupportedCategories(Settings.SyncCategories.ToArray()).Any())
                     {
                         // Retain user fields not-affiliated with Prowlarr
                         lidarrIndexer.Fields.AddRange(remoteIndexer.Fields.Where(f => lidarrIndexer.Fields.All(s => s.Name != f.Name)));
@@ -204,7 +211,7 @@ namespace NzbDrone.Core.Applications.Lidarr
             {
                 _appIndexerMapService.Delete(indexerMapping.Id);
 
-                if (indexerCapabilities.Categories.SupportedCategories(Settings.SyncCategories.ToArray()).Any())
+                if (indexerCapabilities.MusicSearchAvailable && indexerCapabilities.Categories.SupportedCategories(Settings.SyncCategories.ToArray()).Any())
                 {
                     _logger.Debug("Remote indexer not found, re-adding {0} [{1}] to Lidarr", indexer.Name, indexer.Id);
                     lidarrIndexer.Id = 0;

--- a/src/NzbDrone.Core/Applications/Radarr/Radarr.cs
+++ b/src/NzbDrone.Core/Applications/Radarr/Radarr.cs
@@ -121,9 +121,16 @@ namespace NzbDrone.Core.Applications.Radarr
         {
             var indexerCapabilities = GetIndexerCapabilities(indexer);
 
+            if (!indexerCapabilities.MovieSearchAvailable)
+            {
+                _logger.Debug("Skipping add for indexer {0} [{1}] due to missing movie search support by the indexer", indexer.Name, indexer.Id);
+
+                return;
+            }
+
             if (indexerCapabilities.Categories.SupportedCategories(Settings.SyncCategories.ToArray()).Empty())
             {
-                _logger.Trace("Skipping add for indexer {0} [{1}] due to no app Sync Categories supported by the indexer", indexer.Name, indexer.Id);
+                _logger.Debug("Skipping add for indexer {0} [{1}] due to no app Sync Categories supported by the indexer", indexer.Name, indexer.Id);
 
                 return;
             }
@@ -176,7 +183,7 @@ namespace NzbDrone.Core.Applications.Radarr
 
                 if (!radarrIndexer.Equals(remoteIndexer) || forceSync)
                 {
-                    if (indexerCapabilities.Categories.SupportedCategories(Settings.SyncCategories.ToArray()).Any())
+                    if (indexerCapabilities.MovieSearchAvailable && indexerCapabilities.Categories.SupportedCategories(Settings.SyncCategories.ToArray()).Any())
                     {
                         // Retain user fields not-affiliated with Prowlarr
                         radarrIndexer.Fields.AddRange(remoteIndexer.Fields.Where(f => radarrIndexer.Fields.All(s => s.Name != f.Name)));
@@ -202,7 +209,7 @@ namespace NzbDrone.Core.Applications.Radarr
             {
                 _appIndexerMapService.Delete(indexerMapping.Id);
 
-                if (indexerCapabilities.Categories.SupportedCategories(Settings.SyncCategories.ToArray()).Any())
+                if (indexerCapabilities.MovieSearchAvailable && indexerCapabilities.Categories.SupportedCategories(Settings.SyncCategories.ToArray()).Any())
                 {
                     _logger.Debug("Remote indexer not found, re-adding {0} [{1}] to Radarr", indexer.Name, indexer.Id);
                     radarrIndexer.Id = 0;

--- a/src/NzbDrone.Core/Applications/Readarr/Readarr.cs
+++ b/src/NzbDrone.Core/Applications/Readarr/Readarr.cs
@@ -121,9 +121,16 @@ namespace NzbDrone.Core.Applications.Readarr
         {
             var indexerCapabilities = GetIndexerCapabilities(indexer);
 
+            if (!indexerCapabilities.BookSearchAvailable)
+            {
+                _logger.Debug("Skipping add for indexer {0} [{1}] due to missing book search support by the indexer", indexer.Name, indexer.Id);
+
+                return;
+            }
+
             if (indexerCapabilities.Categories.SupportedCategories(Settings.SyncCategories.ToArray()).Empty())
             {
-                _logger.Trace("Skipping add for indexer {0} [{1}] due to no app Sync Categories supported by the indexer", indexer.Name, indexer.Id);
+                _logger.Debug("Skipping add for indexer {0} [{1}] due to no app Sync Categories supported by the indexer", indexer.Name, indexer.Id);
 
                 return;
             }
@@ -178,7 +185,7 @@ namespace NzbDrone.Core.Applications.Readarr
                 {
                     _logger.Debug("Syncing remote indexer with current settings");
 
-                    if (indexerCapabilities.Categories.SupportedCategories(Settings.SyncCategories.ToArray()).Any())
+                    if (indexerCapabilities.BookSearchAvailable && indexerCapabilities.Categories.SupportedCategories(Settings.SyncCategories.ToArray()).Any())
                     {
                         // Retain user fields not-affiliated with Prowlarr
                         readarrIndexer.Fields.AddRange(remoteIndexer.Fields.Where(f => readarrIndexer.Fields.All(s => s.Name != f.Name)));
@@ -204,7 +211,7 @@ namespace NzbDrone.Core.Applications.Readarr
             {
                 _appIndexerMapService.Delete(indexerMapping.Id);
 
-                if (indexerCapabilities.Categories.SupportedCategories(Settings.SyncCategories.ToArray()).Any())
+                if (indexerCapabilities.BookSearchAvailable && indexerCapabilities.Categories.SupportedCategories(Settings.SyncCategories.ToArray()).Any())
                 {
                     _logger.Debug("Remote indexer not found, re-adding {0} [{1}] to Readarr", indexer.Name, indexer.Id);
                     readarrIndexer.Id = 0;

--- a/src/NzbDrone.Core/Applications/Sonarr/Sonarr.cs
+++ b/src/NzbDrone.Core/Applications/Sonarr/Sonarr.cs
@@ -125,10 +125,17 @@ namespace NzbDrone.Core.Applications.Sonarr
         {
             var indexerCapabilities = GetIndexerCapabilities(indexer);
 
+            if (!indexerCapabilities.TvSearchAvailable)
+            {
+                _logger.Debug("Skipping add for indexer {0} [{1}] due to missing TV search support by the indexer", indexer.Name, indexer.Id);
+
+                return;
+            }
+
             if (indexerCapabilities.Categories.SupportedCategories(Settings.SyncCategories.ToArray()).Empty() &&
                 indexerCapabilities.Categories.SupportedCategories(Settings.AnimeSyncCategories.ToArray()).Empty())
             {
-                _logger.Trace("Skipping add for indexer {0} [{1}] due to no app Sync Categories supported by the indexer", indexer.Name, indexer.Id);
+                _logger.Debug("Skipping add for indexer {0} [{1}] due to no app Sync Categories supported by the indexer", indexer.Name, indexer.Id);
 
                 return;
             }
@@ -183,7 +190,7 @@ namespace NzbDrone.Core.Applications.Sonarr
                 {
                     _logger.Debug("Syncing remote indexer with current settings");
 
-                    if (indexerCapabilities.Categories.SupportedCategories(Settings.SyncCategories.ToArray()).Any() || indexerCapabilities.Categories.SupportedCategories(Settings.AnimeSyncCategories.ToArray()).Any())
+                    if (indexerCapabilities.TvSearchAvailable && (indexerCapabilities.Categories.SupportedCategories(Settings.SyncCategories.ToArray()).Any() || indexerCapabilities.Categories.SupportedCategories(Settings.AnimeSyncCategories.ToArray()).Any()))
                     {
                         // Retain user fields not-affiliated with Prowlarr
                         sonarrIndexer.Fields.AddRange(remoteIndexer.Fields.Where(f => sonarrIndexer.Fields.All(s => s.Name != f.Name)));
@@ -210,7 +217,7 @@ namespace NzbDrone.Core.Applications.Sonarr
             {
                 _appIndexerMapService.Delete(indexerMapping.Id);
 
-                if (indexerCapabilities.Categories.SupportedCategories(Settings.SyncCategories.ToArray()).Any() || indexerCapabilities.Categories.SupportedCategories(Settings.AnimeSyncCategories.ToArray()).Any())
+                if (indexerCapabilities.TvSearchAvailable && (indexerCapabilities.Categories.SupportedCategories(Settings.SyncCategories.ToArray()).Any() || indexerCapabilities.Categories.SupportedCategories(Settings.AnimeSyncCategories.ToArray()).Any()))
                 {
                     _logger.Debug("Remote indexer not found, re-adding {0} [{1}] to Sonarr", indexer.Name, indexer.Id);
                     sonarrIndexer.Id = 0;


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Prevent attempts of syncing where we have indexers with category mapping but without search mode in the caps.