### PR TITLE
Fixed: (AnimeTosho) Mapping of Subcategory as Parent

### DIFF
--- a/src/NzbDrone.Core.Test/Files/Indexers/Torznab/torznab_animetosho_caps.xml
+++ b/src/NzbDrone.Core.Test/Files/Indexers/Torznab/torznab_animetosho_caps.xml
@@ -1,15 +1,16 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <caps>
-	<server version="1.0" title="Anime Tosho" strapline="Anime NZB/DDL mirror" url="https://animetosho.org/"/>
-	<limits max="200" default="75"/>
-	<retention days="9999"/>
-	<registration available="no" open="yes" />
-	<searching>
-		<search available="yes" supportedParams="q" />
-		<tv-search available="no" supportedParams="q" />
-		<movie-search available="no" supportedParams="q" />
-	</searching>
-	<categories>
-		<category id="5070" name="Anime" description="Anime"/>
-	</categories>
+    <server version="1.0" title="Anime Tosho" strapline="Anime NZB/DDL mirror" url="https://animetosho.org/" />
+    <limits max="200" default="75" />
+    <retention days="9999" />
+    <registration available="no" open="yes" />
+    <searching>
+        <search available="yes" supportedParams="q" />
+        <tv-search available="no" supportedParams="q" />
+        <movie-search available="no" supportedParams="q" />
+    </searching>
+    <categories>
+        <category id="5070" name="Anime" description="Anime" />
+        <category id="2020" name="Movies/Other" description="Movies (Anime)" />
+    </categories>
 </caps>

--- a/src/NzbDrone.Core.Test/IndexerTests/NewznabTests/NewznabCapabilitiesProviderFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/NewznabTests/NewznabCapabilitiesProviderFixture.cs
@@ -83,17 +83,18 @@ namespace NzbDrone.Core.Test.IndexerTests.NewznabTests
             bookCats.Should().Contain("8000");
         }
 
-        [Test]
-        public void should_find_sub_categories_as_main_categories()
+        [TestCase(5070)]
+        [TestCase(2020)]
+        public void should_find_sub_categories_as_main_categories(int category)
         {
             GivenCapsResponse(ReadAllText("Files/Indexers/Torznab/torznab_animetosho_caps.xml"));
 
             var caps = Subject.GetCapabilities(_settings, _definition);
 
-            var bookCats = caps.Categories.MapTrackerCatToNewznab("5070");
+            var indexerCategories = caps.Categories.MapTrackerCatToNewznab(category.ToString());
 
-            bookCats.Count.Should().Be(2);
-            bookCats.First().Id.Should().Be(5070);
+            indexerCategories.Count.Should().Be(2);
+            indexerCategories.First().Id.Should().Be(category);
         }
 
         [Test]

--- a/src/NzbDrone.Core/Indexers/Definitions/Newznab/NewznabCapabilitiesProvider.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Newznab/NewznabCapabilitiesProvider.cs
@@ -224,24 +224,28 @@ namespace NzbDrone.Core.Indexers.Newznab
                 foreach (var xmlCategory in xmlCategories.Elements("category"))
                 {
                     var parentName = xmlCategory.Attribute("name").Value;
-                    var parentNameLower = parentName?.ToLowerInvariant();
                     var parentId = int.Parse(xmlCategory.Attribute("id").Value);
 
-                    var mappedCat = NewznabStandardCategory.ParentCats.FirstOrDefault(x => parentNameLower.Contains(x.Name.ToLower()));
+                    var mappedCat = NewznabStandardCategory.ParentCats.FirstOrDefault(x => parentName.Equals(x.Name, StringComparison.OrdinalIgnoreCase));
 
-                    if (mappedCat == null)
+                    if (mappedCat is null)
                     {
-                        // Try to find name and Id in AllCats for sub cats that are mapped as parents
-                        mappedCat = NewznabStandardCategory.AllCats.FirstOrDefault(x => x.Id == parentId && x.Name.ToLower().Contains(parentNameLower));
+                        // Try to find name and ID in AllCats for sub cats that are mapped as parents
+                        mappedCat = NewznabStandardCategory.AllCats.FirstOrDefault(x => x.Id == parentId && x.Name.Contains(parentName, StringComparison.OrdinalIgnoreCase));
                     }
 
-                    if (mappedCat == null)
+                    if (mappedCat is null)
+                    {
+                        mappedCat = NewznabStandardCategory.ParentCats.FirstOrDefault(x => parentName.Contains(x.Name, StringComparison.OrdinalIgnoreCase));
+                    }
+
+                    if (mappedCat is null)
                     {
                         // Try by parent id if name fails
                         mappedCat = NewznabStandardCategory.ParentCats.FirstOrDefault(x => x.Id == parentId);
                     }
 
-                    if (mappedCat == null)
+                    if (mappedCat is null)
                     {
                         // Fallback to Other
                         mappedCat = NewznabStandardCategory.Other;

--- a/src/NzbDrone.Core/Indexers/NewznabStandardCategory.cs
+++ b/src/NzbDrone.Core/Indexers/NewznabStandardCategory.cs
@@ -92,7 +92,6 @@ namespace NzbDrone.Core.Indexers
 
         public static readonly IndexerCategory[] ParentCats =
         {
-            ZedOther,
             Console,
             Movies,
             Audio,
@@ -100,7 +99,8 @@ namespace NzbDrone.Core.Indexers
             TV,
             XXX,
             Books,
-            Other
+            Other,
+            ZedOther
         };
 
         public static readonly IndexerCategory[] AllCats =


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Improving support for mapping subcategory as parent to avoid `movies/other` being mapped to `other` 8000 or 0.