### PR TITLE
Add logic to throw away the previously used http client on any failed request

### DIFF
--- a/src/NzbDrone.Common/Http/Dispatchers/IHttpDispatcher.cs
+++ b/src/NzbDrone.Common/Http/Dispatchers/IHttpDispatcher.cs
@@ -6,5 +6,7 @@ namespace NzbDrone.Common.Http.Dispatchers
     public interface IHttpDispatcher
     {
         Task<HttpResponse> GetResponseAsync(HttpRequest request, CookieContainer cookies);
+
+        void ForceHttpClientRefresh(HttpRequest request);
     }
 }

--- a/src/NzbDrone.Common/Http/Dispatchers/ManagedHttpDispatcher.cs
+++ b/src/NzbDrone.Common/Http/Dispatchers/ManagedHttpDispatcher.cs
@@ -171,6 +171,17 @@ namespace NzbDrone.Common.Http.Dispatchers
             }
         }
 
+        public void ForceHttpClientRefresh(HttpRequest request)
+        {
+            var requestUri = request.Url as HttpUri;
+            var requestProxy = request.ProxySettings;
+            var proxySettings = requestProxy ?? _proxySettingsProvider.GetProxySettings(requestUri);
+
+            var key = proxySettings?.Key ?? NO_PROXY_KEY;
+            _httpClientCache.Remove(key);
+            _httpClientCache.Set(key, CreateHttpClient(proxySettings));
+        }
+
         protected virtual System.Net.Http.HttpClient GetClient(HttpUri uri, HttpProxySettings requestProxy)
         {
             var proxySettings = requestProxy ?? _proxySettingsProvider.GetProxySettings(uri);

--- a/src/NzbDrone.Common/Http/HttpClient.cs
+++ b/src/NzbDrone.Common/Http/HttpClient.cs
@@ -36,6 +36,8 @@ namespace NzbDrone.Common.Http
         Task<HttpResponse> PostAsync(HttpRequest request);
         Task<HttpResponse<T>> PostAsync<T>(HttpRequest request)
             where T : new();
+
+        void ForceHttpClientRefresh(HttpRequest request);
     }
 
     public class HttpClient : IHttpClient
@@ -135,6 +137,15 @@ namespace NzbDrone.Common.Http
         public HttpResponse Execute(HttpRequest request)
         {
             return ExecuteAsync(request).GetAwaiter().GetResult();
+        }
+
+        public void ForceHttpClientRefresh(HttpRequest request)
+        {
+            // Clear the cookie container cache to force a new CookieContainer to be created
+            lock (_httpDispatcher)
+            {
+                _httpDispatcher.ForceHttpClientRefresh(request);
+            }
         }
 
         private static bool RequestRequiresForceGet(HttpStatusCode statusCode, HttpMethod requestMethod)

--- a/src/NzbDrone.Core/Indexers/HttpIndexerBase.cs
+++ b/src/NzbDrone.Core/Indexers/HttpIndexerBase.cs
@@ -399,6 +399,7 @@ namespace NzbDrone.Core.Indexers
             var result = new IndexerPageableQueryResult();
             var url = string.Empty;
             var minimumBackoff = TimeSpan.FromHours(1);
+            IndexerRequest lastRequest = null;
 
             try
             {
@@ -425,6 +426,7 @@ namespace NzbDrone.Core.Indexers
                         {
                             url = request.Url.FullUri;
 
+                            lastRequest = request;
                             var page = await FetchPage(request, parser);
 
                             pageSize = pageSize == 1 ? page.Releases.Count : pageSize;
@@ -469,6 +471,12 @@ namespace NzbDrone.Core.Indexers
                 else
                 {
                     _logger.Warn(webException, "{0} {1} {2}", this, url, webException.Message);
+                }
+
+                if (lastRequest != null && lastRequest.HttpRequest != null)
+                {
+                    _logger.Info($"Forcing refresh of http client because of failed request.");
+                    _httpClient.ForceHttpClientRefresh(lastRequest.HttpRequest);
                 }
             }
             catch (TooManyRequestsException ex)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Add logic to throw away the previously used http client on any failed request. This is just in case .NET gets into a weird state where the http clients are corrupted for whatever reason, this can let Prowlarr recover. .NET 8.0 should reduce the amount of httpclient corruption that happens, but this is a safeguard in case that happens. 

#### Todos
- [ ] Tests - No existing tests in this infra space.
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json) - N/A
- [ ] [Wiki Updates](https://wiki.servarr.com) - N/A

#### Issues Fixed or Closed by this PR

* Fixes #1992 