### PR TITLE
fixed:(unit3d) api missing infohash

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/Cardigann/CardigannBase.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Cardigann/CardigannBase.cs
@@ -30,7 +30,7 @@ namespace NzbDrone.Core.Indexers.Definitions.Cardigann
         protected readonly IndexerCapabilitiesCategories _categories = new();
         protected readonly List<string> _defaultCategories = new();
 
-        protected readonly string[] OptionalFields = new string[] { "imdb", "imdbid", "tmdbid", "rageid", "tvdbid", "tvmazeid", "traktid", "doubanid", "poster", "banner", "description", "genre" };
+        protected readonly string[] OptionalFields = new string[] { "imdb", "imdbid", "tmdbid", "rageid", "tvdbid", "tvmazeid", "traktid", "doubanid", "poster", "banner", "description", "genre", "infohash" };
 
         protected static readonly string[] _SupportedLogicFunctions =
         {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Adds infohash as an optional field for unit3d api calls to fix failure from their removal of infohash in v9.1.6

#### Issues Fixed or Closed by this PR

* Fixes https://github.com/Prowlarr/Prowlarr/issues/2485