### PR TITLE
fixed:(unit3d) handle missing torrent hash in infodict

### DIFF
--- a/src/NzbDrone.Core/Download/TorrentClientBase.cs
+++ b/src/NzbDrone.Core/Download/TorrentClientBase.cs
@@ -148,6 +148,15 @@ namespace NzbDrone.Core.Download
 
             var filename = string.Format("{0}.torrent", StringUtil.CleanFileName(release.Title));
             var hash = _torrentFileInfoReader.GetHashFromTorrentFile(torrentFile);
+            
+            // If we couldn't extract infohash from torrent file (e.g., Unit3d sites with missing infohash)
+            // fall back to using the infohash from the release info
+            if (string.IsNullOrWhiteSpace(hash) && !string.IsNullOrWhiteSpace(release.InfoHash))
+            {
+                hash = release.InfoHash;
+                _logger.Debug("Could not extract infohash from torrent file, using infohash from release info: {0}", hash);
+            }
+            
             var actualHash = AddFromTorrentFile(release, hash, filename, torrentFile);
 
             if (actualHash.IsNotNullOrWhiteSpace() && hash != actualHash)

--- a/src/NzbDrone.Core/Download/TorrentFileInfoReader.cs
+++ b/src/NzbDrone.Core/Download/TorrentFileInfoReader.cs
@@ -1,4 +1,7 @@
 using MonoTorrent;
+using System;
+using System.Linq;
+using NLog;
 
 namespace NzbDrone.Core.Download
 {
@@ -9,9 +12,29 @@ namespace NzbDrone.Core.Download
 
     public class TorrentFileInfoReader : ITorrentFileInfoReader
     {
+        private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
         public string GetHashFromTorrentFile(byte[] fileContents)
         {
-            return Torrent.Load(fileContents).InfoHash.ToHex();
+            try
+            {
+                var torrent = Torrent.Load(fileContents);
+                var infoHash = torrent.InfoHash.ToHex();
+                
+                // Check if we got a valid infohash (not all zeros or empty)
+                if (string.IsNullOrEmpty(infoHash) || infoHash.All(c => c == '0'))
+                {
+                    Logger.Debug("Torrent file contains invalid or missing infohash, returning empty string");
+                    return string.Empty;
+                }
+                
+                return infoHash;
+            }
+            catch (Exception ex)
+            {
+                Logger.Debug(ex, "Failed to extract infohash from torrent file, returning empty string");
+                return string.Empty;
+            }
         }
     }
 }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
torrent files from unit3d based sites, v9.1.6 and higher, no longer contain hash in the info dict. This pr returns an empty string on hash parsing failure, relying on hash from the release info instead