### PR TITLE
New: INTERNAL flag support for Cardigann Indexers based on Description

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/Cardigann/CardigannParser.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Cardigann/CardigannParser.cs
@@ -426,6 +426,12 @@ namespace NzbDrone.Core.Indexers.Definitions.Cardigann
                 {
                     ((TorrentInfo)c).InfoHash = MagnetLinkBuilder.GetInfoHashFromMagnet(((TorrentInfo)c).MagnetUrl);
                 }
+
+                // Add Internal flag if description starts with Internal
+                if (c.Description.IsNotNullOrWhiteSpace() && c.Description.StartsWith("Internal"))
+                {
+                    c.IndexerFlags.Add(IndexerFlag.Internal);
+                }
             });
 
             _logger.Trace("Cardigann ({0}): Got {1} releases", _definition.Id, releases.Count);


### PR DESCRIPTION
#### Database Migration
NO

#### Description
For Cardigann if "Description" from the definition contains INTERNAL - add indexer flag of internal

#### Screenshot (if UI related)

#### Todos
- Tests
- Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #2494