### PR TITLE
Fixed: (BroadcasTheNet) Improve daily episode searching

### DIFF
--- a/src/NzbDrone.Core.Test/IndexerTests/BroadcastheNetTests/BroadcastheNetRequestGeneratorFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/BroadcastheNetTests/BroadcastheNetRequestGeneratorFixture.cs
@@ -140,7 +140,7 @@ namespace NzbDrone.Core.Test.IndexerTests.BroadcastheNetTests
             query.Tvrage.Should().BeNull();
             query.Search.Should().BeNull();
             query.Category.Should().Be("Episode");
-            query.Name.Should().Be("2023.01.03");
+            query.Name.Should().Be("2023.01.03%");
         }
 
         [Test]
@@ -275,7 +275,7 @@ namespace NzbDrone.Core.Test.IndexerTests.BroadcastheNetTests
             query.Tvrage.Should().BeNull();
             query.Search.Should().Be("The%Late%Show%with%Stephen%Colbert");
             query.Category.Should().Be("Episode");
-            query.Name.Should().Be("2023.01.03");
+            query.Name.Should().Be("2023.01.03%");
         }
 
         private static BroadcastheNetTorrentQuery ParseTorrentQueryFromRequest(HttpRequest httpRequest)

--- a/src/NzbDrone.Core/Indexers/Definitions/BroadcastheNet/BroadcastheNetRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/BroadcastheNet/BroadcastheNetRequestGenerator.cs
@@ -74,7 +74,7 @@ namespace NzbDrone.Core.Indexers.BroadcastheNet
             else if (DateTime.TryParseExact($"{searchCriteria.Season} {searchCriteria.Episode}", "yyyy MM/dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out var showDate))
             {
                 // Daily Episode
-                parameters.Name = showDate.ToString("yyyy.MM.dd", CultureInfo.InvariantCulture);
+                parameters.Name = showDate.ToString("yyyy.MM.dd", CultureInfo.InvariantCulture) + "%";
                 parameters.Category = "Episode";
                 pageableRequests.Add(GetPagedRequests(parameters, btnResults, btnOffset));
             }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Named episodes such as `1970.01.01 - Episode Title` were not previously picked up. This should fix that.