### PR TITLE
Parse `languages` and `subs` fields on Cardigann indexers

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/Cardigann/CardigannBase.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Cardigann/CardigannBase.cs
@@ -30,7 +30,7 @@ namespace NzbDrone.Core.Indexers.Definitions.Cardigann
         protected readonly IndexerCapabilitiesCategories _categories = new();
         protected readonly List<string> _defaultCategories = new();
 
-        protected readonly string[] OptionalFields = new string[] { "imdb", "imdbid", "tmdbid", "rageid", "tvdbid", "tvmazeid", "traktid", "doubanid", "poster", "banner", "description", "genre" };
+        protected readonly string[] OptionalFields = new string[] { "imdb", "imdbid", "tmdbid", "rageid", "tvdbid", "tvmazeid", "traktid", "doubanid", "poster", "banner", "description", "genre", "languages", "subs" };
 
         protected static readonly string[] _SupportedLogicFunctions =
         {

--- a/src/NzbDrone.Core/Indexers/Definitions/Cardigann/CardigannParser.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Cardigann/CardigannParser.cs
@@ -657,12 +657,26 @@ namespace NzbDrone.Core.Indexers.Definitions.Cardigann
                     break;
                 case "genre":
                     release.Genres ??= new List<string>();
-                    char[] delimiters = { ',', ' ', '/', ')', '(', '.', ';', '[', ']', '"', '|', ':' };
+                    char[] delimitersG = { ',', ' ', '/', ')', '(', '.', ';', '[', ']', '"', '|', ':' };
                     release.Genres = release.Genres
-                        .Union(value.Split(delimiters, StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
+                        .Union(value.Split(delimitersG, StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
                         .Select(x => x.Replace("_", " "))
                         .ToList();
                     value = string.Join(", ", release.Genres);
+                    break;
+                case "languages":
+                    release.Languages ??= new List<string>();
+                    char[] delimitersL = { ',', ' ', '/', ')', '(', '.', ';', '[', ']', '"', '|', ':' };
+                    var releaseLanguages = release.Languages.Union(value.Split(delimitersL, StringSplitOptions.RemoveEmptyEntries));
+                    release.Languages = releaseLanguages.Select(x => x.Replace("_", " ")).ToList();
+                    value = string.Join(",", release.Languages);
+                    break;
+                case "subs":
+                    release.Subs ??= new List<string>();
+                    char[] delimitersS = { ',', ' ', '/', ')', '(', '.', ';', '[', ']', '"', '|', ':' };
+                    var releaseSubs = release.Subs.Union(value.Split(delimitersS, StringSplitOptions.RemoveEmptyEntries));
+                    release.Subs = releaseSubs.Select(x => x.Replace("_", " ")).ToList();
+                    value = string.Join(",", release.Subs);
                     break;
                 case "year":
                     release.Year = ParseUtil.CoerceInt(value);

--- a/src/NzbDrone.Core/Indexers/Definitions/Cardigann/CardigannParser.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Cardigann/CardigannParser.cs
@@ -666,15 +666,15 @@ namespace NzbDrone.Core.Indexers.Definitions.Cardigann
                     break;
                 case "languages":
                     release.Languages ??= new List<string>();
-                    char[] delimitersL = { ',', ' ', '/', ')', '(', '.', ';', '[', ']', '"', '|', ':' };
-                    var releaseLanguages = release.Languages.Union(value.Split(delimitersL, StringSplitOptions.RemoveEmptyEntries));
+                    char[] delimitersL = { ',' };
+                    var releaseLanguages = release.Languages.Union(value.Split(delimitersL, StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries));
                     release.Languages = releaseLanguages.Select(x => x.Replace("_", " ")).ToList();
                     value = string.Join(",", release.Languages);
                     break;
                 case "subs":
                     release.Subs ??= new List<string>();
-                    char[] delimitersS = { ',', ' ', '/', ')', '(', '.', ';', '[', ']', '"', '|', ':' };
-                    var releaseSubs = release.Subs.Union(value.Split(delimitersS, StringSplitOptions.RemoveEmptyEntries));
+                    char[] delimitersS = { ',' };
+                    var releaseSubs = release.Subs.Union(value.Split(delimitersS, StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries));
                     release.Subs = releaseSubs.Select(x => x.Replace("_", " ")).ToList();
                     value = string.Join(",", release.Subs);
                     break;


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Allow tracker definitions that uses Cardigann implementation to leverage `languages` and `subs` that will populate torznab metadata.

#### Screenshot (if UI related)
<img width="565" height="320" alt="image" src="https://github.com/user-attachments/assets/fab8f884-a12e-481f-bcfc-0b01fa104949" />

<img width="1594" height="358" alt="Screenshot 2025-11-20 at 12 31 59" src="https://github.com/user-attachments/assets/e5b99888-aa5e-4c20-87a6-9aa26182e3f3" />
<img width="1592" height="726" alt="Screenshot 2025-11-20 at 12 27 23" src="https://github.com/user-attachments/assets/2bcda1d6-4332-4e1c-88ed-588143c2a264" />


#### Issues Fixed or Closed by this PR

* Fixes [#2550](https://github.com/Prowlarr/Prowlarr/issues/2550)