### PR TITLE
Remove the database credentials from the connectionString when logging.

### DIFF
--- a/src/NzbDrone.Core/Datastore/Migration/Framework/MigrationController.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/Framework/MigrationController.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NLog;
 using NLog.Extensions.Logging;
+using NzbDrone.Common.Instrumentation;
 
 namespace NzbDrone.Core.Datastore.Migration.Framework
 {
@@ -33,7 +34,7 @@ namespace NzbDrone.Core.Datastore.Migration.Framework
         {
             var sw = Stopwatch.StartNew();
 
-            _logger.Info("*** Migrating {0} ***", connectionString);
+            _logger.Info("*** Migrating {0} ***", CleanseLogMessage.Cleanse(connectionString));
 
             ServiceProvider serviceProvider;
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
When using Postgresql as database, the connectionString logged when applying the migration contains the username and the password of the database.
This PR removed them from the log. 
