### PR TITLE
Fixed: Form data encoding for non-UTF8 indexers

### DIFF
--- a/src/NzbDrone.Common.Test/Http/HttpRequestBuilderFixture.cs
+++ b/src/NzbDrone.Common.Test/Http/HttpRequestBuilderFixture.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text;
 using FluentAssertions;
 using NUnit.Framework;
 using NzbDrone.Common.Http;
@@ -9,6 +10,12 @@ namespace NzbDrone.Common.Test.Http
     [TestFixture]
     public class HttpRequestBuilderFixture : TestBase
     {
+        [OneTimeSetUp]
+        public void RegisterEncodingProvider()
+        {
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+        }
+
         [TestCase("http://host/{seg}/some", "http://host/dir/some")]
         [TestCase("http://host/some/{seg}", "http://host/some/dir")]
         public void should_add_single_segment_url_segments(string url, string result)
@@ -35,6 +42,71 @@ namespace NzbDrone.Common.Test.Http
             var request = builder.Resource("/v1/").Build();
 
             request.Url.FullUri.Should().Be("http://domain/v1/");
+        }
+
+        [Test]
+        public void should_encode_form_parameters_with_utf8_by_default()
+        {
+            var builder = new HttpRequestBuilder("http://domain/login")
+                .Post()
+                .AddFormParameter("username", "Привет");
+
+            var request = builder.Build();
+            var body = Encoding.UTF8.GetString(request.ContentData);
+
+            // UTF-8 encoding: Привет = %D0%9F%D1%80%D0%B8%D0%B2%D0%B5%D1%82
+            body.Should().Contain("username=%D0%9F%D1%80%D0%B8%D0%B2%D0%B5%D1%82");
+        }
+
+        [Test]
+        public void should_encode_form_parameters_with_windows_1251_for_cyrillic()
+        {
+            var windows1251 = Encoding.GetEncoding("windows-1251");
+
+            var builder = new HttpRequestBuilder("http://domain/login")
+                .Post()
+                .SetEncoding(windows1251)
+                .AddFormParameter("username", "Привет");
+
+            var request = builder.Build();
+            var body = windows1251.GetString(request.ContentData);
+
+            // Windows-1251 encoding: Привет = %CF%F0%E8%E2%E5%F2
+            body.Should().Contain("username=%CF%F0%E8%E2%E5%F2");
+        }
+
+        [Test]
+        public void should_encode_form_parameters_with_iso_8859_1_for_extended_latin()
+        {
+            var iso88591 = Encoding.GetEncoding("iso-8859-1");
+
+            var builder = new HttpRequestBuilder("http://domain/login")
+                .Post()
+                .SetEncoding(iso88591)
+                .AddFormParameter("username", "café");
+
+            var request = builder.Build();
+            var body = iso88591.GetString(request.ContentData);
+
+            // ISO-8859-1 encoding: é = %E9
+            body.Should().Contain("username=caf%E9");
+        }
+
+        [Test]
+        public void should_encode_form_parameters_ascii_same_regardless_of_encoding()
+        {
+            var windows1251 = Encoding.GetEncoding("windows-1251");
+
+            var builder = new HttpRequestBuilder("http://domain/login")
+                .Post()
+                .SetEncoding(windows1251)
+                .AddFormParameter("username", "testuser")
+                .AddFormParameter("password", "pass123");
+
+            var request = builder.Build();
+            var body = windows1251.GetString(request.ContentData);
+
+            body.Should().Be("username=testuser&password=pass123");
         }
     }
 }

--- a/src/NzbDrone.Common/Http/HttpRequestBuilder.cs
+++ b/src/NzbDrone.Common/Http/HttpRequestBuilder.cs
@@ -231,7 +231,7 @@ namespace NzbDrone.Common.Http
             }
             else
             {
-                var parameters = FormData.Select(v => string.Format("{0}={1}", v.Name, Uri.EscapeDataString(Encoding.GetString(v.ContentData))));
+                var parameters = FormData.Select(v => string.Format("{0}={1}", v.Name, Encoding.GetString(v.ContentData).UrlEncode(Encoding)));
                 var urlencoded = string.Join("&", parameters);
                 var body = Encoding.GetBytes(urlencoded);
 

--- a/src/NzbDrone.Core/Indexers/Definitions/FunFile.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/FunFile.cs
@@ -58,6 +58,7 @@ public class FunFile : TorrentIndexerBase<UserPassTorrentBaseSettings>
         };
 
         var authLoginRequest = requestBuilder
+            .SetEncoding(Encoding)
             .AddFormParameter("username", Settings.Username)
             .AddFormParameter("password", Settings.Password)
             .AddFormParameter("returnto", "")

--- a/src/NzbDrone.Core/Indexers/Definitions/PornoLab.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/PornoLab.cs
@@ -57,6 +57,7 @@ namespace NzbDrone.Core.Indexers.Definitions
             };
 
             var authLoginRequest = requestBuilder
+                .SetEncoding(Encoding)
                 .AddFormParameter("login_username", Settings.Username)
                 .AddFormParameter("login_password", Settings.Password)
                 .AddFormParameter("login", "Login")

--- a/src/NzbDrone.Core/Indexers/Definitions/PreToMe.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/PreToMe.cs
@@ -66,6 +66,7 @@ public class PreToMe : TorrentIndexerBase<PreToMeSettings>
         };
 
         var authLoginRequest = requestBuilder
+            .SetEncoding(Encoding)
             .SetCookies(loginPage.GetCookies())
             .AddFormParameter("username", Settings.Username)
             .AddFormParameter("password", Settings.Password)

--- a/src/NzbDrone.Core/Indexers/Definitions/RuTracker.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/RuTracker.cs
@@ -91,6 +91,7 @@ namespace NzbDrone.Core.Indexers.Definitions
             Cookies = null;
 
             var authLoginRequest = requestBuilder.Post()
+                .SetEncoding(Encoding)
                 .AddFormParameter("login_username", Settings.Username)
                 .AddFormParameter("login_password", Settings.Password)
                 .AddFormParameter("login", "Login")

--- a/src/NzbDrone.Core/Indexers/Definitions/TorrentBytes.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/TorrentBytes.cs
@@ -58,6 +58,7 @@ namespace NzbDrone.Core.Indexers.Definitions
             Cookies = null;
 
             var authLoginRequest = requestBuilder
+                .SetEncoding(Encoding)
                 .AddFormParameter("username", Settings.Username)
                 .AddFormParameter("password", Settings.Password)
                 .AddFormParameter("returnto", "/")


### PR DESCRIPTION
#### Database Migration
NO

#### Description
When logging into indexers that use non-UTF8 encodings (like RuTracker with windows-1251), usernames or passwords containing non-ASCII characters would fail authentication. The issue was that Uri.EscapeDataString always percent encodes using UTF-8, ignoring the encoding set on the request builder.

This changes HttpRequestBuilder.ApplyFormData to use the encoding-aware UrlEncode method instead, so form data is properly encoded according to what the indexer expects.

Also added explicit SetEncoding() calls to the login flows of affected indexers (RuTracker, PornoLab, TorrentBytes, PreToMe, FunFile) to ensure the correct encoding is used when building form parameters.

#### Todos
- [x] Tests

#### Issues Fixed or Closed by this PR

* Fixes #1871