### PR TITLE
New: Configurable per-indexer query timeout

### DIFF
--- a/src/NzbDrone.Core/Indexers/HttpIndexerBase.cs
+++ b/src/NzbDrone.Core/Indexers/HttpIndexerBase.cs
@@ -662,9 +662,9 @@ namespace NzbDrone.Core.Indexers
             request.HttpRequest.SuppressHttpError = true;
             request.HttpRequest.Encoding ??= Encoding;
 
-            if (request.HttpRequest.RequestTimeout == TimeSpan.Zero && Settings.BaseSettings != null)
+            if (request.HttpRequest.RequestTimeout == TimeSpan.Zero && Settings.BaseSettings is { QueryLimit: not null })
             {
-                request.HttpRequest.RequestTimeout = TimeSpan.FromSeconds(Settings.BaseSettings.QueryTimeout);
+                request.HttpRequest.RequestTimeout = TimeSpan.FromSeconds(Settings.BaseSettings.QueryTimeout.Value);
             }
 
             var response = await RetryStrategy

--- a/src/NzbDrone.Core/Indexers/HttpIndexerBase.cs
+++ b/src/NzbDrone.Core/Indexers/HttpIndexerBase.cs
@@ -526,7 +526,8 @@ namespace NzbDrone.Core.Indexers
             catch (TaskCanceledException ex)
             {
                 _indexerStatusService.RecordFailure(Definition.Id);
-                _logger.Warn(ex, "Unable to connect to indexer, possibly due to a timeout. [{0}]", url);
+                var timeoutMs = Settings.BaseSettings?.QueryTimeout ?? 100000;
+                _logger.Warn(ex, "Unable to connect to indexer, possibly due to a timeout ({0} ms). [{1}]", timeoutMs, url);
             }
             catch (Exception ex)
             {
@@ -660,6 +661,11 @@ namespace NzbDrone.Core.Indexers
 
             request.HttpRequest.SuppressHttpError = true;
             request.HttpRequest.Encoding ??= Encoding;
+
+            if (request.HttpRequest.RequestTimeout == TimeSpan.Zero && Settings.BaseSettings != null)
+            {
+                request.HttpRequest.RequestTimeout = TimeSpan.FromMilliseconds(Settings.BaseSettings.QueryTimeout);
+            }
 
             var response = await RetryStrategy
                 .ExecuteAsync(static async (state, _) => await state._httpClient.ExecuteProxiedAsync(state.HttpRequest, state.Definition), (_httpClient, request.HttpRequest, Definition))
@@ -836,8 +842,14 @@ namespace NzbDrone.Core.Indexers
                     return new ValidationFailure(string.Empty, "Unable to connect to indexer connection failure. Check your connection to the indexer's server and DNS." + webException.Message);
                 }
 
+                if (webException.Message.Contains("timed out"))
+                {
+                    var timeoutMs = Settings.BaseSettings?.QueryTimeout ?? 100000;
+                    return new ValidationFailure(string.Empty, "Unable to connect to indexer, request timed out after " + timeoutMs + " ms. Consider increasing the Query Timeout in the indexer advanced settings. " + webException.Message);
+                }
+
                 if (webException.Message.Contains("502") || webException.Message.Contains("503") ||
-                    webException.Message.Contains("504") || webException.Message.Contains("timed out"))
+                    webException.Message.Contains("504"))
                 {
                     return new ValidationFailure(string.Empty, "Unable to connect to indexer, indexer's server is unavailable. Try again later. " + webException.Message);
                 }

--- a/src/NzbDrone.Core/Indexers/HttpIndexerBase.cs
+++ b/src/NzbDrone.Core/Indexers/HttpIndexerBase.cs
@@ -526,8 +526,8 @@ namespace NzbDrone.Core.Indexers
             catch (TaskCanceledException ex)
             {
                 _indexerStatusService.RecordFailure(Definition.Id);
-                var timeoutMs = Settings.BaseSettings?.QueryTimeout ?? 100000;
-                _logger.Warn(ex, "Unable to connect to indexer, possibly due to a timeout ({0} ms). [{1}]", timeoutMs, url);
+                var timeoutSec = Settings.BaseSettings?.QueryTimeout ?? 100;
+                _logger.Warn(ex, "Unable to connect to indexer, possibly due to a timeout ({0}s). [{1}]", timeoutSec, url);
             }
             catch (Exception ex)
             {
@@ -664,7 +664,7 @@ namespace NzbDrone.Core.Indexers
 
             if (request.HttpRequest.RequestTimeout == TimeSpan.Zero && Settings.BaseSettings != null)
             {
-                request.HttpRequest.RequestTimeout = TimeSpan.FromMilliseconds(Settings.BaseSettings.QueryTimeout);
+                request.HttpRequest.RequestTimeout = TimeSpan.FromSeconds(Settings.BaseSettings.QueryTimeout);
             }
 
             var response = await RetryStrategy
@@ -844,8 +844,8 @@ namespace NzbDrone.Core.Indexers
 
                 if (webException.Message.Contains("timed out"))
                 {
-                    var timeoutMs = Settings.BaseSettings?.QueryTimeout ?? 100000;
-                    return new ValidationFailure(string.Empty, "Unable to connect to indexer, request timed out after " + timeoutMs + " ms. Consider increasing the Query Timeout in the indexer advanced settings. " + webException.Message);
+                    var timeoutSec = Settings.BaseSettings?.QueryTimeout ?? 100;
+                    return new ValidationFailure(string.Empty, "Unable to connect to indexer, request timed out after " + timeoutSec + "s. Consider increasing the Query Timeout in the indexer advanced settings. " + webException.Message);
                 }
 
                 if (webException.Message.Contains("502") || webException.Message.Contains("503") ||

--- a/src/NzbDrone.Core/Indexers/HttpIndexerBase.cs
+++ b/src/NzbDrone.Core/Indexers/HttpIndexerBase.cs
@@ -662,7 +662,8 @@ namespace NzbDrone.Core.Indexers
             request.HttpRequest.SuppressHttpError = true;
             request.HttpRequest.Encoding ??= Encoding;
 
-            if (request.HttpRequest.RequestTimeout == TimeSpan.Zero && Settings.BaseSettings is { QueryLimit: not null })
+            if (request.HttpRequest.RequestTimeout == TimeSpan.Zero && Settings is { BaseSettings.QueryLimit: > 0 })
+
             {
                 request.HttpRequest.RequestTimeout = TimeSpan.FromSeconds(Settings.BaseSettings.QueryTimeout.Value);
             }

--- a/src/NzbDrone.Core/Indexers/IndexerBaseSettings.cs
+++ b/src/NzbDrone.Core/Indexers/IndexerBaseSettings.cs
@@ -16,6 +16,10 @@ namespace NzbDrone.Core.Indexers
                 .GreaterThan(0)
                 .When(c => c.GrabLimit.HasValue)
                 .WithMessage("Should be greater than zero");
+
+            RuleFor(c => c.QueryTimeout)
+                .InclusiveBetween(50, 600000)
+                .WithMessage("Must be between 50 ms and 600000 ms (10 minutes)");
         }
     }
 
@@ -29,6 +33,9 @@ namespace NzbDrone.Core.Indexers
 
         [FieldDefinition(3, Type = FieldType.Select, Label = "IndexerSettingsLimitsUnit", SelectOptions = typeof(IndexerLimitsUnit), HelpText = "IndexerSettingsLimitsUnitHelpText", Advanced = true)]
         public int LimitsUnit { get; set; } = (int)IndexerLimitsUnit.Day;
+
+        [FieldDefinition(4, Type = FieldType.Number, Label = "IndexerSettingsQueryTimeout", Unit = "ms", HelpText = "IndexerSettingsQueryTimeoutHelpText", Advanced = true)]
+        public int QueryTimeout { get; set; } = 100000;
     }
 
     public enum IndexerLimitsUnit

--- a/src/NzbDrone.Core/Indexers/IndexerBaseSettings.cs
+++ b/src/NzbDrone.Core/Indexers/IndexerBaseSettings.cs
@@ -18,8 +18,8 @@ namespace NzbDrone.Core.Indexers
                 .WithMessage("Should be greater than zero");
 
             RuleFor(c => c.QueryTimeout)
-                .InclusiveBetween(50, 600000)
-                .WithMessage("Must be between 50 ms and 600000 ms (10 minutes)");
+                .InclusiveBetween(1, 300)
+                .WithMessage("Must be between 1 and 300 seconds (5 minutes)");
         }
     }
 
@@ -34,8 +34,8 @@ namespace NzbDrone.Core.Indexers
         [FieldDefinition(3, Type = FieldType.Select, Label = "IndexerSettingsLimitsUnit", SelectOptions = typeof(IndexerLimitsUnit), HelpText = "IndexerSettingsLimitsUnitHelpText", Advanced = true)]
         public int LimitsUnit { get; set; } = (int)IndexerLimitsUnit.Day;
 
-        [FieldDefinition(4, Type = FieldType.Number, Label = "IndexerSettingsQueryTimeout", Unit = "ms", HelpText = "IndexerSettingsQueryTimeoutHelpText", Advanced = true)]
-        public int QueryTimeout { get; set; } = 100000;
+        [FieldDefinition(4, Type = FieldType.Number, Label = "IndexerSettingsQueryTimeout", Unit = "seconds", HelpText = "IndexerSettingsQueryTimeoutHelpText", Advanced = true)]
+        public int QueryTimeout { get; set; } = 100;
     }
 
     public enum IndexerLimitsUnit

--- a/src/NzbDrone.Core/Indexers/IndexerBaseSettings.cs
+++ b/src/NzbDrone.Core/Indexers/IndexerBaseSettings.cs
@@ -19,6 +19,7 @@ namespace NzbDrone.Core.Indexers
 
             RuleFor(c => c.QueryTimeout)
                 .InclusiveBetween(1, 300)
+                .When(c => c.QueryLimit.HasValue)
                 .WithMessage("Must be between 1 and 300 seconds (5 minutes)");
         }
     }
@@ -35,7 +36,7 @@ namespace NzbDrone.Core.Indexers
         public int LimitsUnit { get; set; } = (int)IndexerLimitsUnit.Day;
 
         [FieldDefinition(4, Type = FieldType.Number, Label = "IndexerSettingsQueryTimeout", Unit = "seconds", HelpText = "IndexerSettingsQueryTimeoutHelpText", Advanced = true)]
-        public int QueryTimeout { get; set; } = 100;
+        public int? QueryTimeout { get; set; }
     }
 
     public enum IndexerLimitsUnit

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -429,7 +429,7 @@
   "IndexerSettingsQueryLimit": "Query Limit",
   "IndexerSettingsQueryLimitHelpText": "The number of max queries as specified by the respective unit that {appName} will allow to the site",
   "IndexerSettingsQueryTimeout": "Query Timeout",
-  "IndexerSettingsQueryTimeoutHelpText": "Query timeout in milliseconds for this indexer. Default is 100000 ms (100s). Increase for slow indexers, decrease for faster failure detection",
+  "IndexerSettingsQueryTimeoutHelpText": "Query timeout in seconds for this indexer. Default is 100s. Increase for slow indexers, decrease for faster failure detection",
   "IndexerSettingsRssKey": "RSS Key",
   "IndexerSettingsSeedRatio": "Seed Ratio",
   "IndexerSettingsSeedRatioHelpText": "The ratio a torrent should reach before stopping, empty uses the download client's default. Ratio should be at least 1.0 and follow the indexers rules",

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -428,6 +428,8 @@
   "IndexerSettingsPreferMagnetUrlHelpText": "When enabled, this indexer will prefer the use of magnet URLs for grabs with fallback to torrent links",
   "IndexerSettingsQueryLimit": "Query Limit",
   "IndexerSettingsQueryLimitHelpText": "The number of max queries as specified by the respective unit that {appName} will allow to the site",
+  "IndexerSettingsQueryTimeout": "Query Timeout",
+  "IndexerSettingsQueryTimeoutHelpText": "Query timeout in milliseconds for this indexer. Default is 100000 ms (100s). Increase for slow indexers, decrease for faster failure detection",
   "IndexerSettingsRssKey": "RSS Key",
   "IndexerSettingsSeedRatio": "Seed Ratio",
   "IndexerSettingsSeedRatioHelpText": "The ratio a torrent should reach before stopping, empty uses the download client's default. Ratio should be at least 1.0 and follow the indexers rules",


### PR DESCRIPTION
## Database Migration
No

## Description
Adds a configurable Query Timeout field (in milliseconds) to each indexer's advanced settings. Default is 100000 ms (100s), matching the previous hardcoded behavior. Valid range: 50 ms to 600000 ms (10 minutes). Improved timeout error messages to show the configured timeout value and suggest adjusting the setting.

Closes https://github.com/Prowlarr/Prowlarr/issues/586