### PR TITLE
Fixed: map DanishBytes links to NordicBytes

### DIFF
--- a/src/NzbDrone.Core/IndexerVersions/IndexerDefinitionUpdateService.cs
+++ b/src/NzbDrone.Core/IndexerVersions/IndexerDefinitionUpdateService.cs
@@ -31,6 +31,9 @@ namespace NzbDrone.Core.IndexerVersions
 
         private const string DEFINITION_BRANCH = "master";
         private const int DEFINITION_VERSION = 11;
+        private const string DANISHBYTES_API_DEFINITION = "danishbytes-api";
+        private const string DANISHBYTES_URL = "https://danishbytes.club/";
+        private const string NORDICBYTES_URL = "https://nordicbytes.org/";
 
         // Used when moving yml to C#
         private readonly List<string> _definitionBlocklist = new()
@@ -108,6 +111,7 @@ namespace NzbDrone.Core.IndexerVersions
                 var customDefinitionFolder = Path.Combine(_appFolderInfo.AppDataFolder, "Definitions", "Custom");
 
                 indexerList = ReadDefinitionsFromDisk(indexerList, customDefinitionFolder);
+                indexerList = indexerList.Select(UpdateDanishBytesMetaDefinition).ToList();
             }
             catch (Exception ex)
             {
@@ -281,7 +285,57 @@ namespace NzbDrone.Core.IndexerVersions
                 });
             }
 
+            if (string.Equals(definition.Id, DANISHBYTES_API_DEFINITION, StringComparison.OrdinalIgnoreCase))
+            {
+                definition.Links = UpdateDanishBytesLinks(definition.Links);
+                UpdateDanishBytesHelpLinks(definition.Settings);
+            }
+
             return definition;
+        }
+
+        private CardigannMetaDefinition UpdateDanishBytesMetaDefinition(CardigannMetaDefinition definition)
+        {
+            if (definition == null)
+            {
+                return null;
+            }
+
+            if (!string.Equals(definition.Id, DANISHBYTES_API_DEFINITION, StringComparison.OrdinalIgnoreCase) &&
+                !string.Equals(definition.File, DANISHBYTES_API_DEFINITION, StringComparison.OrdinalIgnoreCase))
+            {
+                return definition;
+            }
+
+            definition.Links = UpdateDanishBytesLinks(definition.Links);
+            UpdateDanishBytesHelpLinks(definition.Settings);
+
+            return definition;
+        }
+
+        private List<string> UpdateDanishBytesLinks(List<string> links)
+        {
+            var updatedLinks = (links ?? new List<string>())
+                .Where(link => !string.Equals(link, NORDICBYTES_URL, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
+            updatedLinks.Insert(0, NORDICBYTES_URL);
+
+            return updatedLinks;
+        }
+
+        private void UpdateDanishBytesHelpLinks(List<SettingsField> settings)
+        {
+            if (settings == null)
+            {
+                return;
+            }
+
+            foreach (var setting in settings.Where(s => !string.IsNullOrWhiteSpace(s.Default) && (s.Name == "info_apikey" || s.Name == "info_rsskey")))
+            {
+                setting.Default = setting.Default.Replace(DANISHBYTES_URL, NORDICBYTES_URL, StringComparison.OrdinalIgnoreCase);
+                setting.Default = setting.Default.Replace("DanishBytes", "NordicBytes", StringComparison.OrdinalIgnoreCase);
+            }
         }
 
         public void Handle(ApplicationStartedEvent message)


### PR DESCRIPTION
Ensure danishbytes-api includes the new nordicbytes.org base URL and updates API/RSS help links to the renamed tracker. This keeps existing definitions functional while reflecting the current site name and domain.

#### Database Migration
NO

#### Description
This PR updates the DanishBytes API definition handling to reflect the tracker rename to NordicBytes.  
It ensures danishbytes-api includes https://nordicbytes.org/ as a base URL option and updates the "About your API key" / "About your RSS key" helper links and label text to NordicBytes while keeping existing definition compatibility.

#### Screenshot (if UI related)
N/A (no UI changes)
#### Todos
- [ ] Tests (not run in this environment: dotnet unavailable)
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json) (not needed)
- [ ] Wiki Updates (https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR
None yet