### PR TITLE
Fixed: Apply FlareSolverr user agent to tagged indexers

### DIFF
--- a/src/NzbDrone.Core.Test/IndexerProxyTests/FlareSolverr/FlareSolverrFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerProxyTests/FlareSolverr/FlareSolverrFixture.cs
@@ -1,0 +1,187 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using FluentAssertions;
+using Moq;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using NzbDrone.Common.Cache;
+using NzbDrone.Common.Cloud;
+using NzbDrone.Common.Http;
+using NzbDrone.Common.Http.Proxy;
+using NzbDrone.Core.IndexerProxies;
+using NzbDrone.Core.IndexerProxies.FlareSolverr;
+using NzbDrone.Core.Localization;
+using NzbDrone.Core.Test.Framework;
+
+namespace NzbDrone.Core.Test.IndexerProxyTests.FlareSolverr
+{
+    [TestFixture]
+    public class FlareSolverrFixture : CoreTest<IndexerProxies.FlareSolverr.FlareSolverr>
+    {
+        private const string ProtectedUrl = "https://example.com/api/results";
+        private const string SolverUserAgent = "solver-agent";
+
+        private Cached<string> _cache;
+
+        [SetUp]
+        public void Setup()
+        {
+            _cache = new Cached<string>();
+            Mocker.SetConstant<IProwlarrCloudRequestBuilder>(new ProwlarrCloudRequestBuilder());
+
+            Mocker.GetMock<ICacheManager>()
+                .Setup(v => v.GetCache<string>(typeof(string), "UserAgent"))
+                .Returns(_cache);
+
+            Mocker.GetMock<IHttpProxySettingsProvider>()
+                .Setup(v => v.GetProxySettings())
+                .Returns((HttpProxySettings)null);
+
+            Mocker.GetMock<ILocalizationService>()
+                .Setup(v => v.GetLocalizedString(It.IsAny<string>(), It.IsAny<Dictionary<string, object>>()))
+                .Returns<string, Dictionary<string, object>>((phrase, _) => phrase);
+
+            Subject.Definition = new IndexerProxyDefinition
+            {
+                Settings = new FlareSolverrSettings
+                {
+                    Host = "http://localhost:8191",
+                    RequestTimeout = 60
+                }
+            };
+        }
+
+        [Test]
+        public void should_apply_solver_user_agent_after_successful_proxy_test()
+        {
+            GivenSolverResponse();
+
+            var validationResult = Subject.Test();
+            var request = Subject.PreRequest(new HttpRequest("https://another.example/api/results"));
+
+            validationResult.IsValid.Should().BeTrue();
+            request.Headers.UserAgent.Should().Be(SolverUserAgent);
+        }
+
+        [Test]
+        public void should_preserve_explicit_user_agent()
+        {
+            GivenSolverResponse();
+            Subject.Test().IsValid.Should().BeTrue();
+            var request = new HttpRequest(ProtectedUrl);
+            request.Headers.UserAgent = "custom-agent";
+
+            Subject.PreRequest(request);
+
+            request.Headers.UserAgent.Should().Be("custom-agent");
+        }
+
+        [Test]
+        public void should_fall_back_to_user_agent_cached_for_indexer_host()
+        {
+            _cache.Set("example.com", "host-agent");
+            var request = new HttpRequest(ProtectedUrl);
+
+            Subject.PreRequest(request);
+
+            request.Headers.UserAgent.Should().Be("host-agent");
+        }
+
+        [Test]
+        public void should_scope_cached_user_agent_to_solver_host()
+        {
+            GivenSolverResponse();
+            Subject.Test().IsValid.Should().BeTrue();
+            ((FlareSolverrSettings)Subject.Definition.Settings).Host = "http://another-solver:8191";
+            var request = new HttpRequest("https://another.example/api/results");
+
+            Subject.PreRequest(request);
+
+            request.Headers.UserAgent.Should().BeNull();
+        }
+
+        [Test]
+        public void should_not_cache_user_agent_from_failed_proxy_test()
+        {
+            GivenSolverResponse(status: "error", userAgent: null, message: "Unable to solve request");
+
+            var validationResult = Subject.Test();
+            var request = Subject.PreRequest(new HttpRequest("https://another.example/api/results"));
+
+            validationResult.IsValid.Should().BeFalse();
+            request.Headers.UserAgent.Should().BeNull();
+        }
+
+        [Test]
+        public void should_refresh_solver_user_agent_after_solving_a_challenge()
+        {
+            GivenSolverResponse(userAgent: "old-solver-agent");
+            Subject.Test().IsValid.Should().BeTrue();
+            var originalResponse = CloudflareResponse(new HttpRequest(ProtectedUrl));
+            var finalResponse = CloudflareResponse(originalResponse.Request);
+            Mocker.GetMock<IHttpClient>()
+                .SetupSequence(v => v.Execute(It.IsAny<HttpRequest>()))
+                .Returns(SolverResponse())
+                .Returns(finalResponse);
+
+            var response = Subject.PostResponse(originalResponse);
+            var otherRequest = Subject.PreRequest(new HttpRequest("https://another.example/api/results"));
+
+            response.Should().BeSameAs(finalResponse);
+            otherRequest.Headers.UserAgent.Should().Be(SolverUserAgent);
+        }
+
+        private void GivenSolverResponse(string status = "ok", string userAgent = SolverUserAgent, string message = "Success")
+        {
+            Mocker.GetMock<IHttpClient>()
+                .Setup(v => v.Execute(It.IsAny<HttpRequest>()))
+                .Returns(SolverResponse(status, userAgent, message));
+        }
+
+        private static HttpResponse CloudflareResponse(HttpRequest request)
+        {
+            return new HttpResponse(
+                request,
+                new HttpHeader
+                {
+                    { "Server", "cloudflare" },
+                    { "Content-Type", "text/html" }
+                },
+                new CookieCollection(),
+                "<html><head><title>Just a moment...</title></head></html>",
+                statusCode: HttpStatusCode.Forbidden);
+        }
+
+        private static HttpResponse SolverResponse(string status = "ok", string userAgent = SolverUserAgent, string message = "Success")
+        {
+            object solution = null;
+
+            if (userAgent != null)
+            {
+                solution = new
+                {
+                    url = ProtectedUrl,
+                    status = 200,
+                    headers = new Dictionary<string, string>(),
+                    response = "<html>solver response</html>",
+                    cookies = Array.Empty<object>(),
+                    userAgent
+                };
+            }
+
+            var content = JsonConvert.SerializeObject(new
+            {
+                status,
+                message,
+                solution
+            });
+
+            return new HttpResponse(
+                new HttpRequest("http://localhost:8191/v1"),
+                new HttpHeader { ContentType = "application/json" },
+                new CookieCollection(),
+                content);
+        }
+    }
+}

--- a/src/NzbDrone.Core/IndexerProxies/FlareSolverr/FlareSolverr.cs
+++ b/src/NzbDrone.Core/IndexerProxies/FlareSolverr/FlareSolverr.cs
@@ -58,7 +58,7 @@ namespace NzbDrone.Core.IndexerProxies.FlareSolverr
 
             if (flaresolverrResponse.StatusCode != HttpStatusCode.OK && flaresolverrResponse.StatusCode != HttpStatusCode.InternalServerError)
             {
-                throw new FlareSolverrException("HTTP StatusCode not 200 or 500. Status is :" + response.StatusCode);
+                throw new FlareSolverrException("HTTP StatusCode not 200 or 500. Status is :" + flaresolverrResponse.StatusCode);
             }
 
             var result = JsonConvert.DeserializeObject<FlareSolverrResponse>(flaresolverrResponse.Content);
@@ -71,7 +71,32 @@ namespace NzbDrone.Core.IndexerProxies.FlareSolverr
 
             InjectCookies(newRequest, result);
 
-            //Request again with User-Agent and Cookies from Flaresolverr
+            // Use FlareSolverr's response body directly when available.
+            // A second HTTP request with the extracted cookies would get rejected
+            // because cf_clearance is validated against the TLS fingerprint of the
+            // client that solved the challenge (FlareSolverr's headless browser),
+            // which differs from .NET HttpClient's fingerprint.
+            if (result.Solution.Response.IsNotNullOrWhiteSpace())
+            {
+                var headers = new HttpHeader();
+
+                // Preserve the Content-Type from FlareSolverr's solution so downstream
+                // parsers (e.g. JSON indexers) interpret the body correctly.
+                if (result.Solution.Headers?.ContentType.IsNotNullOrWhiteSpace() == true)
+                {
+                    headers.ContentType = result.Solution.Headers.ContentType;
+                }
+
+                return new HttpResponse(
+                    response.Request,
+                    headers,
+                    response.Cookies,
+                    result.Solution.Response,
+                    response.ElapsedTime,
+                    HttpStatusCode.OK);
+            }
+
+            // Fallback: if FlareSolverr returned no body, retry with cookies (original behavior)
             var finalResponse = _httpClient.Execute(newRequest);
 
             return finalResponse;

--- a/src/NzbDrone.Core/IndexerProxies/FlareSolverr/FlareSolverr.cs
+++ b/src/NzbDrone.Core/IndexerProxies/FlareSolverr/FlareSolverr.cs
@@ -38,9 +38,19 @@ namespace NzbDrone.Core.IndexerProxies.FlareSolverr
             request.SuppressHttpError = true;
 
             //Inject UA if not present
-            if (_cache.Find(request.Url.Host).IsNotNullOrWhiteSpace() && request.Headers.UserAgent.IsNullOrWhiteSpace())
+            if (request.Headers.UserAgent.IsNullOrWhiteSpace())
             {
-                request.Headers.UserAgent = _cache.Find(request.Url.Host);
+                var userAgent = _cache.Find(GetSolverUserAgentCacheKey());
+
+                if (userAgent.IsNullOrWhiteSpace())
+                {
+                    userAgent = _cache.Find(request.Url.Host);
+                }
+
+                if (userAgent.IsNotNullOrWhiteSpace())
+                {
+                    request.Headers.UserAgent = userAgent;
+                }
             }
 
             return request;
@@ -58,20 +68,29 @@ namespace NzbDrone.Core.IndexerProxies.FlareSolverr
 
             if (flaresolverrResponse.StatusCode != HttpStatusCode.OK && flaresolverrResponse.StatusCode != HttpStatusCode.InternalServerError)
             {
-                throw new FlareSolverrException("HTTP StatusCode not 200 or 500. Status is :" + response.StatusCode);
+                throw new FlareSolverrException("HTTP StatusCode not 200 or 500. Status is :" + flaresolverrResponse.StatusCode);
             }
 
             var result = JsonConvert.DeserializeObject<FlareSolverrResponse>(flaresolverrResponse.Content);
+
+            if (result?.Solution == null ||
+                result.Solution.UserAgent.IsNullOrWhiteSpace() ||
+                !string.Equals(result.Status, "ok", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new FlareSolverrException(result?.Message.IsNotNullOrWhiteSpace() == true
+                    ? result.Message
+                    : "FlareSolverr returned an invalid response");
+            }
 
             var newRequest = response.Request;
 
             //Cache the user-agent so we can inject it in next request to avoid re-solve
             _cache.Set(response.Request.Url.Host, result.Solution.UserAgent);
+            _cache.Set(GetSolverUserAgentCacheKey(), result.Solution.UserAgent);
             newRequest.Headers.UserAgent = result.Solution.UserAgent;
 
             InjectCookies(newRequest, result);
 
-            //Request again with User-Agent and Cookies from Flaresolverr
             var finalResponse = _httpClient.Execute(newRequest);
 
             return finalResponse;
@@ -193,8 +212,21 @@ namespace NzbDrone.Core.IndexerProxies.FlareSolverr
                     _logger.Error("Proxy validation failed: {0}", response.StatusCode);
                     failures.Add(new NzbDroneValidationFailure("Host", _localizationService.GetLocalizedString("ProxyValidationBadRequest", new Dictionary<string, object> { { "statusCode", response.StatusCode } })));
                 }
+                else
+                {
+                    var result = JsonConvert.DeserializeObject<FlareSolverrResponse>(response.Content);
 
-                var result = JsonConvert.DeserializeObject<FlareSolverrResponse>(response.Content);
+                    if (result?.Solution == null ||
+                        result.Solution.UserAgent.IsNullOrWhiteSpace() ||
+                        !string.Equals(result.Status, "ok", StringComparison.OrdinalIgnoreCase))
+                    {
+                        throw new FlareSolverrException(result?.Message.IsNotNullOrWhiteSpace() == true
+                            ? result.Message
+                            : "FlareSolverr returned an invalid response");
+                    }
+
+                    _cache.Set(GetSolverUserAgentCacheKey(), result.Solution.UserAgent);
+                }
             }
             catch (Exception ex)
             {
@@ -203,6 +235,11 @@ namespace NzbDrone.Core.IndexerProxies.FlareSolverr
             }
 
             return new ValidationResult(failures);
+        }
+
+        private string GetSolverUserAgentCacheKey()
+        {
+            return $"FlareSolverr:{Settings.Host.TrimEnd('/')}";
         }
 
         private Uri GetProxyUri(HttpProxySettings proxySettings)


### PR DESCRIPTION
Fixes #2561

## What this changes

Prowlarr's existing FlareSolverr/Byparr proxy test already makes a browser request and receives the solver's `solution.userAgent`. This change caches that user-agent per configured solver and applies it to indexer requests routed through that tagged proxy.

The cached user-agent is refreshed whenever:

- the proxy test succeeds, including the existing startup check
- FlareSolverr/Byparr later solves a challenge successfully

An explicitly configured request user-agent still takes precedence. The existing per-indexer-host user-agent cache remains as a fallback.

## Why

In the reported failure, Cloudflare challenged Prowlarr's user-agent while the solver's browser could fetch the same endpoint. Applying the solver user-agent before the initial indexer request can avoid that mismatch without sending every request through the browser.

This revision removes the response-body fallback from the earlier version of the PR. The normal flow remains unchanged: make the request directly, invoke FlareSolverr/Byparr only if Cloudflare protection is detected, then retry with the returned cookies and user-agent. This keeps the existing cookie-reuse behavior and does not add special handling for public, private, or semi-private response bodies.

The cache key includes the configured solver URL so separate solver instances do not share user-agents. Invalid solver responses or responses without a user-agent are not cached.

## Tests

- 6 FlareSolverr-specific tests passed
- 508 remaining Core tests passed; 6 existing tests skipped
- The external update-download test was excluded because `download.sonarr.tv:80` was unreachable from the isolated test container
- `git diff --check` passed
