### PR TITLE
Feature: Implement a user controlled rate limit.

### DIFF
--- a/src/NzbDrone.Core/Indexers/HttpIndexerBase.cs
+++ b/src/NzbDrone.Core/Indexers/HttpIndexerBase.cs
@@ -43,7 +43,7 @@ namespace NzbDrone.Core.Indexers
                     { Exception: HttpException { Response.HasHttpServerError: true } } => PredicateResult.True(),
                     _ => PredicateResult.False()
                 },
-                Delay = RateLimit,
+                Delay = GetResolvedRateLimit(),
                 MaxRetryAttempts = 2,
                 BackoffType = DelayBackoffType.Exponential,
                 UseJitter = true,
@@ -80,6 +80,31 @@ namespace NzbDrone.Core.Indexers
         public override IndexerCapabilities Capabilities { get; protected set; }
         public virtual int PageSize => 0;
         public virtual TimeSpan RateLimit => TimeSpan.FromSeconds(2);
+
+        private TimeSpan GetResolvedRateLimit(TimeSpan? requestDelay = null)
+        {
+            var systemDelay = requestDelay ?? TimeSpan.Zero;
+
+            if (systemDelay < RateLimit)
+            {
+                systemDelay = RateLimit;
+            }
+
+            if (Settings?.BaseSettings?.RequestDelay is null or < 2 or > 60)
+            {
+                return systemDelay;
+            }
+
+            var userDelay = TimeSpan.FromSeconds(Settings.BaseSettings.RequestDelay.Value);
+
+            if (userDelay > systemDelay)
+            {
+                _logger.Trace("Using user defined request delay of {0} seconds for indexer {1}", userDelay.TotalSeconds, Definition.Name);
+                return userDelay;
+            }
+
+            return systemDelay;
+        }
 
         public abstract IIndexerRequestGenerator GetRequestGenerator();
         public abstract IParseIndexerResponse GetParser();
@@ -236,11 +261,7 @@ namespace NzbDrone.Core.Indexers
                 return new IndexerDownloadResponse(Encoding.UTF8.GetBytes(request.Url.FullUri));
             }
 
-            if (request.RateLimit < RateLimit)
-            {
-                request.RateLimit = RateLimit;
-            }
-
+            request.RateLimit = GetResolvedRateLimit(request.RateLimit);
             request.AllowAutoRedirect = false;
 
             byte[] fileData;
@@ -636,10 +657,7 @@ namespace NzbDrone.Core.Indexers
         {
             _logger.Debug("Downloading Feed " + request.HttpRequest.ToString(false));
 
-            if (request.HttpRequest.RateLimit < RateLimit)
-            {
-                request.HttpRequest.RateLimit = RateLimit;
-            }
+            request.HttpRequest.RateLimit = GetResolvedRateLimit(request.HttpRequest.RateLimit);
 
             if (_configService.LogIndexerResponse)
             {
@@ -716,11 +734,7 @@ namespace NzbDrone.Core.Indexers
                 request.RequestTimeout = TimeSpan.FromSeconds(15);
             }
 
-            if (request.RateLimit < RateLimit)
-            {
-                request.RateLimit = RateLimit;
-            }
-
+            request.RateLimit = GetResolvedRateLimit(request.RateLimit);
             var response = await _httpClient.ExecuteProxiedAsync(request, Definition);
 
             _eventAggregator.PublishEvent(new IndexerAuthEvent(Definition.Id, !response.HasHttpError, response.ElapsedTime));

--- a/src/NzbDrone.Core/Indexers/IndexerBaseSettings.cs
+++ b/src/NzbDrone.Core/Indexers/IndexerBaseSettings.cs
@@ -16,6 +16,10 @@ namespace NzbDrone.Core.Indexers
                 .GreaterThan(0)
                 .When(c => c.GrabLimit.HasValue)
                 .WithMessage("Should be greater than zero");
+
+            RuleFor(c => c.RequestDelay)
+                .InclusiveBetween(2, 60)
+                .When(c => c.RequestDelay.HasValue);
         }
     }
 
@@ -29,6 +33,9 @@ namespace NzbDrone.Core.Indexers
 
         [FieldDefinition(3, Type = FieldType.Select, Label = "IndexerSettingsLimitsUnit", SelectOptions = typeof(IndexerLimitsUnit), HelpText = "IndexerSettingsLimitsUnitHelpText", Advanced = true)]
         public int LimitsUnit { get; set; } = (int)IndexerLimitsUnit.Day;
+
+        [FieldDefinition(4, Type = FieldType.Number, Label = "IndexerSettingsRequestDelay", HelpText = "IndexerSettingsRequestDelayHelpText", Advanced = true)]
+        public double? RequestDelay { get; set; }
     }
 
     public enum IndexerLimitsUnit

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -428,6 +428,8 @@
   "IndexerSettingsPreferMagnetUrlHelpText": "When enabled, this indexer will prefer the use of magnet URLs for grabs with fallback to torrent links",
   "IndexerSettingsQueryLimit": "Query Limit",
   "IndexerSettingsQueryLimitHelpText": "The number of max queries as specified by the respective unit that {appName} will allow to the site",
+  "IndexerSettingsRequestDelay": "Minimum Request Delay",
+  "IndexerSettingsRequestDelayHelpText": "Minimum delay in seconds between requests for this indexer. The rate limit can only be increased by this setting. Setting a lower value than the default delay will be ignored.",
   "IndexerSettingsRssKey": "RSS Key",
   "IndexerSettingsSeedRatio": "Seed Ratio",
   "IndexerSettingsSeedRatioHelpText": "The ratio a torrent should reach before stopping, empty uses the download client's default. Ratio should be at least 1.0 and follow the indexers rules",


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This pr adds the functionality for the user to change the rate limit for each indexer individually.

##### Behavior

Currently (before the pr) Prowlarr seems to have had a hard-coded lower limit of 2 seconds or the rate limit of the provider if its higher. I implemented this in a way that the user **cannot** set a rate limit lower than the hard-coded limit of 2 seconds, but they **can** set a limit lower that that of the indexer.

As an example lets look at 1337x which currently has a rate limit of 3s:
- The user would be able to set a rate limit of 2 seconds
- But the user cannot set a rate limit lower than 2 seconds

<s>

I implemented it like this because in issue #2635 it was said:

> (...) That said, I'm not against a solution to allow user defined the rate limits per indexer as long they are not lower than our limits.
>
> — @mynameisbogdan

I don't fully understand yet why this would be important. Personally I think that we could allow people to set any rate limit - even 0.

Because even when the rate limit is 0 the requests will happen sequentially, so we will never overwhelm an indexer. And if some indexer doesn't allow a certain cadence of requests I don't see why it makes sense to restrict **ALL** indexers to this 2 second minimum interval. I think that its the users responsibility to choose an adequate rate limit.

I would be glad if someone could comment on why we should not allow lower rate limits than the default - otherwise I would suggest to allow any rate limit.

</s>

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR
* Fixes #2635