### PR TITLE
Fixed: Don't send limit=0 to Newznab indexers

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/Headphones/HeadphonesRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Headphones/HeadphonesRequestGenerator.cs
@@ -120,12 +120,12 @@ namespace NzbDrone.Core.Indexers.Headphones
                 baseUrl += "&apikey=" + Settings.ApiKey;
             }
 
-            if (searchCriteria.Limit.HasValue)
+            if (searchCriteria.Limit.HasValue && searchCriteria.Limit.Value > 0)
             {
                 parameters.Add("limit", searchCriteria.Limit.ToString());
             }
 
-            if (searchCriteria.Offset.HasValue)
+            if (searchCriteria.Offset.HasValue && searchCriteria.Offset.Value > 0)
             {
                 parameters.Add("offset", searchCriteria.Offset.ToString());
             }

--- a/src/NzbDrone.Core/Indexers/Definitions/Headphones/HeadphonesRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Headphones/HeadphonesRequestGenerator.cs
@@ -120,7 +120,7 @@ namespace NzbDrone.Core.Indexers.Headphones
                 baseUrl += "&apikey=" + Settings.ApiKey;
             }
 
-            if (searchCriteria.Limit.HasValue && searchCriteria.Limit.Value > 0)
+            if (searchCriteria.Limit is > 0)
             {
                 parameters.Add("limit", searchCriteria.Limit.ToString());
             }

--- a/src/NzbDrone.Core/Indexers/Definitions/Headphones/HeadphonesRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Headphones/HeadphonesRequestGenerator.cs
@@ -125,7 +125,7 @@ namespace NzbDrone.Core.Indexers.Headphones
                 parameters.Add("limit", searchCriteria.Limit.ToString());
             }
 
-            if (searchCriteria.Offset is > 0)
+            if (searchCriteria.Offset.HasValue)
             {
                 parameters.Add("offset", searchCriteria.Offset.ToString());
             }

--- a/src/NzbDrone.Core/Indexers/Definitions/Headphones/HeadphonesRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Headphones/HeadphonesRequestGenerator.cs
@@ -125,7 +125,7 @@ namespace NzbDrone.Core.Indexers.Headphones
                 parameters.Add("limit", searchCriteria.Limit.ToString());
             }
 
-            if (searchCriteria.Offset.HasValue && searchCriteria.Offset.Value > 0)
+            if (searchCriteria.Offset is > 0)
             {
                 parameters.Add("offset", searchCriteria.Offset.ToString());
             }

--- a/src/NzbDrone.Core/Indexers/Definitions/Newznab/NewznabRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Newznab/NewznabRequestGenerator.cs
@@ -263,12 +263,12 @@ namespace NzbDrone.Core.Indexers.Newznab
                 searchUrl += "&apikey=" + Settings.ApiKey;
             }
 
-            if (searchCriteria.Limit.HasValue)
+            if (searchCriteria.Limit.HasValue && searchCriteria.Limit.Value > 0)
             {
                 parameters.Set("limit", searchCriteria.Limit.ToString());
             }
 
-            if (searchCriteria.Offset.HasValue)
+            if (searchCriteria.Offset.HasValue && searchCriteria.Offset.Value > 0)
             {
                 parameters.Set("offset", searchCriteria.Offset.ToString());
             }

--- a/src/NzbDrone.Core/Indexers/Definitions/Newznab/NewznabRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Newznab/NewznabRequestGenerator.cs
@@ -268,7 +268,7 @@ namespace NzbDrone.Core.Indexers.Newznab
                 parameters.Set("limit", searchCriteria.Limit.ToString());
             }
 
-            if (searchCriteria.Offset.HasValue && searchCriteria.Offset.Value > 0)
+            if (searchCriteria.Offset is > 0)
             {
                 parameters.Set("offset", searchCriteria.Offset.ToString());
             }

--- a/src/NzbDrone.Core/Indexers/Definitions/Newznab/NewznabRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Newznab/NewznabRequestGenerator.cs
@@ -268,7 +268,7 @@ namespace NzbDrone.Core.Indexers.Newznab
                 parameters.Set("limit", searchCriteria.Limit.ToString());
             }
 
-            if (searchCriteria.Offset is > 0)
+            if (searchCriteria.Offset.HasValue)
             {
                 parameters.Set("offset", searchCriteria.Offset.ToString());
             }

--- a/src/NzbDrone.Core/Indexers/Definitions/Newznab/NewznabRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Newznab/NewznabRequestGenerator.cs
@@ -263,7 +263,7 @@ namespace NzbDrone.Core.Indexers.Newznab
                 searchUrl += "&apikey=" + Settings.ApiKey;
             }
 
-            if (searchCriteria.Limit.HasValue && searchCriteria.Limit.Value > 0)
+            if (searchCriteria.Limit is > 0)
             {
                 parameters.Set("limit", searchCriteria.Limit.ToString());
             }

--- a/src/Prowlarr.Api.V1/Search/SearchResource.cs
+++ b/src/Prowlarr.Api.V1/Search/SearchResource.cs
@@ -14,7 +14,7 @@ namespace Prowlarr.Api.V1.Search
         public string Type { get; set; }
         public List<int> IndexerIds { get; set; }
         public List<int> Categories { get; set; }
-        public int Limit { get; set; }
-        public int Offset { get; set; }
+        public int? Limit { get; set; }
+        public int? Offset { get; set; }
     }
 }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
When searching via the internal API (`/api/v1/search`), `SearchResource.Limit` defaults to `0` because it's a non-nullable `int`. This gets passed through to the Newznab request generator, which emits `&limit=0` in the query URL.

Indexers that follow the Newznab spec honor `limit=0` literally and return zero results. Confirmed affected indexers include DrunkenSlug and NZBGeek -- both return 0 items with `limit=0` despite having thousands of matches:

limit=0: 0 results
GET /api?t=search&q=batman&limit=0  → <newznab:response total="0"/>

limit omitted: works
GET /api?t=search&q=batman          → <newznab:response total="16413"/>

Changes `Limit` and `Offset` on `SearchResource` to `int?` so they default to `null` when omitted, matching `NewznabRequest`. The Newznab and Headphones request generators now skip emitting these params when the value is 0.

Other implementations (AvistazRequestGenerator, AnimeZ) already handle this via `GetValueOrDefault(PageSize)`.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR