### PR TITLE
refactor: use DateTime.UnixEpoch for Unix timestamp calculations

### DIFF
--- a/src/NzbDrone.Common/Disk/DiskProviderBase.cs
+++ b/src/NzbDrone.Common/Disk/DiskProviderBase.cs
@@ -350,9 +350,9 @@ namespace NzbDrone.Common.Disk
         {
             Ensure.That(path, () => path).IsValidPath(PathValidationType.CurrentOs);
 
-            if (dateTime.Before(DateTimeExtensions.Epoch))
+            if (dateTime.Before(DateTime.UnixEpoch))
             {
-                dateTime = DateTimeExtensions.Epoch;
+                dateTime = DateTime.UnixEpoch;
             }
 
             Directory.SetLastWriteTimeUtc(path, dateTime);
@@ -362,9 +362,9 @@ namespace NzbDrone.Common.Disk
         {
             Ensure.That(path, () => path).IsValidPath(PathValidationType.CurrentOs);
 
-            if (dateTime.Before(DateTimeExtensions.Epoch))
+            if (dateTime.Before(DateTime.UnixEpoch))
             {
-                dateTime = DateTimeExtensions.Epoch;
+                dateTime = DateTime.UnixEpoch;
             }
 
             File.SetLastWriteTime(path, dateTime);

--- a/src/NzbDrone.Common/Extensions/DateTimeExtensions.cs
+++ b/src/NzbDrone.Common/Extensions/DateTimeExtensions.cs
@@ -63,6 +63,5 @@ namespace NzbDrone.Common.Extensions
             return new DateTime(date.Year, date.Month, date.Day, 0, 0, 0, 0);
         }
 
-        public static DateTime Epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
     }
 }

--- a/src/NzbDrone.Common/OAuth/OAuthTools.cs
+++ b/src/NzbDrone.Common/OAuth/OAuthTools.cs
@@ -99,7 +99,7 @@ namespace NzbDrone.Common.OAuth
 
         private static long ToUnixTime(DateTime dateTime)
         {
-            var timeSpan = dateTime - new DateTime(1970, 1, 1);
+            var timeSpan = dateTime - DateTime.UnixEpoch;
             var timestamp = (long)timeSpan.TotalSeconds;
 
             return timestamp;

--- a/src/NzbDrone.Core/Indexers/Definitions/BroadcastheNet/BroadcastheNetParser.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/BroadcastheNet/BroadcastheNetParser.cs
@@ -95,7 +95,7 @@ namespace NzbDrone.Core.Indexers.BroadcastheNet
                     Grabs = torrent.Snatched,
                     Seeders = torrent.Seeders,
                     Peers = torrent.Leechers + torrent.Seeders,
-                    PublishDate = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc).ToUniversalTime().AddSeconds(torrent.Time),
+                    PublishDate = DateTime.UnixEpoch.AddSeconds(torrent.Time),
                     Origin = torrent.Origin,
                     Source = torrent.Source,
                     Container = torrent.Container,

--- a/src/NzbDrone.Core/Indexers/Definitions/Cardigann/CardigannRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Cardigann/CardigannRequestGenerator.cs
@@ -444,7 +444,7 @@ namespace NzbDrone.Core.Indexers.Definitions.Cardigann
                 var enctype = form.GetAttribute("enctype");
                 if (enctype == "multipart/form-data")
                 {
-                    var boundary = "---------------------------" + DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1)).TotalSeconds.ToString().Replace(".", "");
+                    var boundary = "---------------------------" + (DateTime.UtcNow - DateTime.UnixEpoch).TotalSeconds.ToString().Replace(".", "");
                     var bodyParts = new List<string>();
 
                     foreach (var pair in pairs)

--- a/src/NzbDrone.Core/Indexers/Definitions/NzbIndex.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/NzbIndex.cs
@@ -1138,8 +1138,6 @@ namespace NzbDrone.Core.Indexers.Definitions
 
             foreach (var row in jsonContent.Value<JArray>("results"))
             {
-                var dateTime = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
-
                 var id = row.Value<string>("id");
                 var details = _settings.BaseUrl + "collection/" + id;
 
@@ -1157,7 +1155,7 @@ namespace NzbDrone.Core.Indexers.Definitions
                     DownloadUrl = _settings.BaseUrl + "download/" + id,
                     Title = parsedTitle.Groups["title"].Value,
                     Categories = row.Value<JArray>("group_ids").SelectMany(g => _categories.MapTrackerCatToNewznab(g.Value<string>())).Distinct().ToList(),
-                    PublishDate = dateTime.AddMilliseconds(row.Value<long>("posted")).ToLocalTime(),
+                    PublishDate = DateTime.UnixEpoch.AddMilliseconds(row.Value<long>("posted")).ToLocalTime(),
                     Size = row.Value<long>("size"),
                     Files = row.Value<int>("file_count")
                 };

--- a/src/NzbDrone.Core/Indexers/Definitions/TorrentSyndikat.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/TorrentSyndikat.cs
@@ -226,8 +226,6 @@ namespace NzbDrone.Core.Indexers.Definitions
 
             foreach (var row in jsonContent.Value<JArray>("rows"))
             {
-                var dateTime = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
-
                 var id = row.Value<string>("id");
                 var details = _settings.BaseUrl + "details.php?id=" + id;
                 var seeders = row.Value<int>("seeders");
@@ -243,7 +241,7 @@ namespace NzbDrone.Core.Indexers.Definitions
                     DownloadUrl = _settings.BaseUrl + "download.php?id=" + id + "&apikey=" + _settings.ApiKey,
                     Title = row.Value<string>("name"),
                     Categories = _categories.MapTrackerCatToNewznab(row.Value<int>("category").ToString()),
-                    PublishDate = dateTime.AddSeconds(row.Value<long>("added")).ToLocalTime(),
+                    PublishDate = DateTime.UnixEpoch.AddSeconds(row.Value<long>("added")).ToLocalTime(),
                     Size = row.Value<long>("size"),
                     Files = row.Value<int>("numfiles"),
                     Seeders = seeders,

--- a/src/NzbDrone.Core/Indexers/Definitions/TorrentsCSV.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/TorrentsCSV.cs
@@ -160,7 +160,7 @@ namespace NzbDrone.Core.Indexers.Definitions
                 var seeders = torrent.Seeders ?? 0;
                 var leechers = torrent.Leechers ?? 0;
                 var grabs = torrent.Completed ?? 0;
-                var publishDate = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc).AddSeconds(torrent.Created);
+                var publishDate = DateTime.UnixEpoch.AddSeconds(torrent.Created);
 
                 var release = new TorrentInfo
                 {

--- a/src/NzbDrone.Core/Parser/DateTimeUtil.cs
+++ b/src/NzbDrone.Core/Parser/DateTimeUtil.cs
@@ -27,17 +27,13 @@ namespace NzbDrone.Core.Parser
 
         public static DateTime UnixTimestampToDateTime(double unixTime)
         {
-            var unixStart = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
             var unixTimeStampInTicks = (long)(unixTime * TimeSpan.TicksPerSecond);
-            return new DateTime(unixStart.Ticks + unixTimeStampInTicks);
+            return new DateTime(DateTime.UnixEpoch.Ticks + unixTimeStampInTicks, DateTimeKind.Utc);
         }
 
         public static double DateTimeToUnixTimestamp(DateTime dt)
         {
-            var date = dt.ToUniversalTime();
-            var ticks = date.Ticks - new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc).Ticks;
-            var ts = ticks / TimeSpan.TicksPerSecond;
-            return ts;
+            return (double)new DateTimeOffset(dt.ToUniversalTime()).ToUnixTimeSeconds();
         }
 
         // ex: "2 hours 1 day"


### PR DESCRIPTION
Replace manual `new DateTime(1970, 1, 1, ...)` epoch constants with `DateTime.UnixEpoch` and `DateTimeOffset` built-in methods available since .NET 5.

**Changes:**
- `OAuthTools.cs`: replace hardcoded epoch with `DateTime.UnixEpoch`
- `DateTimeUtil.cs`: simplify both conversion methods; also fixes missing `DateTimeKind.Utc` on the return value of `UnixTimestampToDateTime`
- `DateTimeExtensions.cs`: remove redundant `Epoch` field in favor of `DateTime.UnixEpoch`
- `DiskProviderBase.cs`: replace `DateTimeExtensions.Epoch` with `DateTime.UnixEpoch` directly
- `BroadcastheNetParser.cs`, `TorrentsCSV.cs`, `TorrentSyndikat.cs`, `NzbIndex.cs`: inline `DateTime.UnixEpoch` replacing local epoch variables
- `CardigannRequestGenerator.cs`: replace hardcoded epoch in boundary string generation