### PR TITLE
New: Use Happy Eyeballs for HTTP socket address selection

### DIFF
--- a/src/NzbDrone.Common.Test/Http/HappyEyeballsFixture.cs
+++ b/src/NzbDrone.Common.Test/Http/HappyEyeballsFixture.cs
@@ -1,0 +1,223 @@
+using System;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using NzbDrone.Common.Http.HappyEyeballs;
+using NzbDrone.Test.Common;
+
+namespace NzbDrone.Common.Test.Http
+{
+    [TestFixture]
+    public class HappyEyeballsFixture : TestBase
+    {
+        private static IPAddress ipv6Address1 = IPAddress.Parse("2001:db8::1");
+        private static IPAddress ipv6Address2 = IPAddress.Parse("2001:db8::2");
+        private static IPAddress ipv4Address1 = IPAddress.Parse("192.0.2.1");
+        private static IPAddress ipv4Address2 = IPAddress.Parse("192.0.2.2");
+
+        private Mock<Func<IPAddress, CancellationToken, Task<IDisposable>>> _connectSocketMock;
+        private Mock<Func<CancellationToken, Task>> _taskDelayMock;
+        private HappyEyeballs<IDisposable> _happyEyeballs;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _connectSocketMock = new Mock<Func<IPAddress, CancellationToken, Task<IDisposable>>>(MockBehavior.Strict);
+            _taskDelayMock = new Mock<Func<CancellationToken, Task>>(MockBehavior.Strict);
+            _happyEyeballs = new HappyEyeballs<IDisposable>(_connectSocketMock.Object, _taskDelayMock.Object);
+        }
+
+        [Test]
+        public void should_throw_exception_when_no_ips_resolved()
+        {
+            var addresses = Array.Empty<IPAddress>();
+            var cancellationToken = CancellationToken.None;
+
+            Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
+                await _happyEyeballs.Connect(addresses, cancellationToken));
+        }
+
+        [Test]
+        public async Task should_connect_successfully_when_valid_addresses_are_provided()
+        {
+            var addresses = new[]
+            {
+                ipv4Address1,
+                ipv6Address1,
+            };
+
+            var cancellationToken = CancellationToken.None;
+
+            var sequence = new MockSequence();
+            _connectSocketMock.InSequence(sequence)
+                .Setup(x => x(ipv6Address1, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Mock.Of<IDisposable>(MockBehavior.Strict));
+            _taskDelayMock.InSequence(sequence)
+                .Setup(x => x(It.IsAny<CancellationToken>()))
+                .Returns(TaskFromCancellationToken);
+
+            var result = await _happyEyeballs.Connect(addresses, cancellationToken);
+
+            result.Should().NotBeNull();
+
+            _connectSocketMock.Verify(x => x(It.IsAny<IPAddress>(), It.IsAny<CancellationToken>()), Times.Once);
+            _taskDelayMock.Verify(x => x(It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Test]
+        public void should_throw_aggregateexception_when_no_addresses_successfully_connect()
+        {
+            var addresses = new[]
+            {
+                ipv4Address1,
+                ipv4Address2,
+                ipv6Address1,
+                ipv6Address2,
+            };
+
+            var cancellationToken = CancellationToken.None;
+
+            var sequence = new MockSequence();
+            _connectSocketMock.InSequence(sequence)
+                .Setup(x => x(ipv6Address1, It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new Exception());
+            _taskDelayMock.InSequence(sequence)
+                .Setup(x => x(It.IsAny<CancellationToken>()))
+                .Returns(TaskFromCancellationToken);
+            _connectSocketMock.InSequence(sequence)
+                .Setup(x => x(ipv4Address1, It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new Exception());
+            _taskDelayMock.InSequence(sequence)
+                .Setup(x => x(It.IsAny<CancellationToken>()))
+                .Returns(TaskFromCancellationToken);
+            _connectSocketMock.InSequence(sequence)
+                .Setup(x => x(ipv6Address2, It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new Exception());
+            _taskDelayMock.InSequence(sequence)
+                .Setup(x => x(It.IsAny<CancellationToken>()))
+                .Returns(TaskFromCancellationToken);
+            _connectSocketMock.InSequence(sequence)
+                .Setup(x => x(ipv4Address2, It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new Exception());
+
+            var ex = Assert.ThrowsAsync<AggregateException>(async () =>
+                await _happyEyeballs.Connect(addresses, cancellationToken));
+
+            ex.InnerExceptions.Should().HaveCount(4);
+
+            _connectSocketMock.Verify(x => x(It.IsAny<IPAddress>(), It.IsAny<CancellationToken>()), Times.Exactly(4));
+            _taskDelayMock.Verify(x => x(It.IsAny<CancellationToken>()), Times.Exactly(3));
+        }
+
+        [Test]
+        public void should_throw_operationcanceledexception_when_canceled()
+        {
+            var addresses = new[]
+            {
+                ipv6Address1,
+            };
+
+            using var cancellationTokenSource = new CancellationTokenSource();
+            var cancellationToken = cancellationTokenSource.Token;
+
+            _connectSocketMock
+                .Setup(x => x(It.IsAny<IPAddress>(), It.IsAny<CancellationToken>()))
+                .Callback((IPAddress _, CancellationToken _) => cancellationTokenSource.Cancel())
+                .ThrowsAsync(new Exception());
+
+            var ex = Assert.ThrowsAsync<OperationCanceledException>(async () =>
+                await _happyEyeballs.Connect(addresses, cancellationToken));
+
+            ex.CancellationToken.IsCancellationRequested.Should().BeTrue();
+
+            _connectSocketMock.Verify(x => x(It.IsAny<IPAddress>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Test]
+        public async Task should_connect_to_ipv4_when_ipv6_connection_fails()
+        {
+            var addresses = new[]
+            {
+                ipv4Address1,
+                ipv6Address1,
+            };
+
+            var cancellationToken = CancellationToken.None;
+
+            var sequence = new MockSequence();
+            _connectSocketMock.InSequence(sequence)
+                .Setup(x => x(ipv6Address1, It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new Exception());
+            _taskDelayMock.InSequence(sequence)
+                .Setup(x => x(It.IsAny<CancellationToken>()))
+                .Returns(TaskFromCancellationToken);
+            _connectSocketMock.InSequence(sequence)
+                .Setup(x => x(ipv4Address1, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Mock.Of<IDisposable>(MockBehavior.Strict));
+
+            var result = await _happyEyeballs.Connect(addresses, cancellationToken);
+
+            result.Should().NotBeNull();
+
+            _connectSocketMock.Verify(x => x(It.IsAny<IPAddress>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
+            _taskDelayMock.Verify(x => x(It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Test]
+        public async Task should_dispose_multiple_successful_connections()
+        {
+            var addresses = new[]
+            {
+                ipv4Address1,
+                ipv6Address1,
+                ipv6Address2,
+            };
+
+            var cancellationToken = CancellationToken.None;
+
+            var disposableMock = new Mock<IDisposable>(MockBehavior.Strict);
+            disposableMock.Setup(x => x.Dispose());
+
+            var sequence = new MockSequence();
+            _connectSocketMock.InSequence(sequence)
+                .Setup(x => x(ipv6Address1, It.IsAny<CancellationToken>()))
+                .Returns((IPAddress _, CancellationToken cancel) => ReturnAfterCancellation(cancel, disposableMock.Object));
+            _taskDelayMock.InSequence(sequence)
+                .Setup(x => x(It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+            _connectSocketMock.InSequence(sequence)
+                .Setup(x => x(ipv4Address1, It.IsAny<CancellationToken>()))
+                .Returns((IPAddress _, CancellationToken cancel) => ReturnAfterCancellation(cancel, disposableMock.Object));
+            _taskDelayMock.InSequence(sequence)
+                .Setup(x => x(It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+            _connectSocketMock.InSequence(sequence)
+                .Setup(x => x(ipv6Address2, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Mock.Of<IDisposable>(MockBehavior.Strict));
+
+            var result = await _happyEyeballs.Connect(addresses, cancellationToken);
+
+            result.Should().NotBeNull();
+
+            _connectSocketMock.Verify(x => x(It.IsAny<IPAddress>(), It.IsAny<CancellationToken>()), Times.Exactly(3));
+            _taskDelayMock.Verify(x => x(It.IsAny<CancellationToken>()), Times.Exactly(2));
+            disposableMock.Verify(x => x.Dispose(), Times.Exactly(2));
+        }
+
+        private static async Task<IDisposable> ReturnAfterCancellation(CancellationToken cancellationToken, IDisposable socket)
+        {
+            await TaskFromCancellationToken(cancellationToken).ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
+            return socket;
+        }
+
+        private static Task TaskFromCancellationToken(CancellationToken cancellationToken)
+        {
+            var tcs = new TaskCompletionSource();
+            cancellationToken.Register(() => tcs.TrySetCanceled());
+            return tcs.Task;
+        }
+    }
+}

--- a/src/NzbDrone.Common/Extensions/DnsEndPointExtensions.cs
+++ b/src/NzbDrone.Common/Extensions/DnsEndPointExtensions.cs
@@ -1,0 +1,9 @@
+using System.Net;
+
+namespace NzbDrone.Common.Extensions
+{
+    public static class DnsEndPointExtensions
+    {
+        public static string HostPort(this DnsEndPoint endPoint) => $"{endPoint.Host}:{endPoint.Port}";
+    }
+}

--- a/src/NzbDrone.Common/Http/Dispatchers/ManagedHttpDispatcher.cs
+++ b/src/NzbDrone.Common/Http/Dispatchers/ManagedHttpDispatcher.cs
@@ -1,10 +1,7 @@
 using System;
 using System.Diagnostics;
-using System.IO;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Net.NetworkInformation;
 using System.Net.Security;
 using System.Net.Sockets;
 using System.Text;
@@ -13,6 +10,7 @@ using System.Threading.Tasks;
 using NLog;
 using NzbDrone.Common.Cache;
 using NzbDrone.Common.Extensions;
+using NzbDrone.Common.Http.HappyEyeballs;
 using NzbDrone.Common.Http.Proxy;
 
 namespace NzbDrone.Common.Http.Dispatchers
@@ -21,18 +19,13 @@ namespace NzbDrone.Common.Http.Dispatchers
     {
         private const string NO_PROXY_KEY = "no-proxy";
 
-        private const int connection_establish_timeout = 2000;
-        private static bool useIPv6 = Socket.OSSupportsIPv6;
-        private static bool hasResolvedIPv6Availability;
-
         private readonly IHttpProxySettingsProvider _proxySettingsProvider;
         private readonly ICreateManagedWebProxy _createManagedWebProxy;
         private readonly ICertificateValidationService _certificateValidationService;
         private readonly IUserAgentBuilder _userAgentBuilder;
         private readonly ICached<System.Net.Http.HttpClient> _httpClientCache;
         private readonly ICached<CredentialCache> _credentialCache;
-
-        private readonly Logger _logger;
+        private readonly HttpHappyEyeballs _httpHappyEyeballs;
 
         public ManagedHttpDispatcher(IHttpProxySettingsProvider proxySettingsProvider,
             ICreateManagedWebProxy createManagedWebProxy,
@@ -49,7 +42,7 @@ namespace NzbDrone.Common.Http.Dispatchers
             _httpClientCache = cacheManager.GetCache<System.Net.Http.HttpClient>(typeof(ManagedHttpDispatcher));
             _credentialCache = cacheManager.GetCache<CredentialCache>(typeof(ManagedHttpDispatcher), "credentialcache");
 
-            _logger = logger;
+            _httpHappyEyeballs = new HttpHappyEyeballs(logger);
         }
 
         public async Task<HttpResponse> GetResponseAsync(HttpRequest request, CookieContainer cookies)
@@ -190,7 +183,7 @@ namespace NzbDrone.Common.Http.Dispatchers
                 Credentials = GetCredentialCache(),
                 PreAuthenticate = true,
                 MaxConnectionsPerServer = 12,
-                ConnectCallback = onConnect,
+                ConnectCallback = Socket.OSSupportsIPv6 ? _httpHappyEyeballs.OnConnect : null,
                 PooledConnectionLifetime = TimeSpan.FromMinutes(10),
                 SslOptions = new SslClientAuthenticationOptions
                 {
@@ -281,88 +274,6 @@ namespace NzbDrone.Common.Http.Dispatchers
         private CredentialCache GetCredentialCache()
         {
             return _credentialCache.Get("credentialCache", () => new CredentialCache());
-        }
-
-        private bool HasRoutableIPv4Address()
-        {
-            // Get all IPv4 addresses from all interfaces and return true if there are any with non-loopback addresses
-            try
-            {
-                var networkInterfaces = NetworkInterface.GetAllNetworkInterfaces();
-
-                return networkInterfaces.Any(ni =>
-                    ni.OperationalStatus == OperationalStatus.Up &&
-                    ni.GetIPProperties().UnicastAddresses.Any(ip =>
-                        ip.Address.AddressFamily == AddressFamily.InterNetwork &&
-                        !IPAddress.IsLoopback(ip.Address)));
-            }
-            catch (Exception e)
-            {
-                _logger.Debug(e, "Caught exception while GetAllNetworkInterfaces assuming IPv4 connectivity: {0}", e.Message);
-                return true;
-            }
-        }
-
-        private async ValueTask<Stream> onConnect(SocketsHttpConnectionContext context, CancellationToken cancellationToken)
-        {
-            // Until .NET supports an implementation of Happy Eyeballs (https://tools.ietf.org/html/rfc8305#section-2), let's make IPv4 fallback work in a simple way.
-            // This issue is being tracked at https://github.com/dotnet/runtime/issues/26177 and expected to be fixed in .NET 6.
-            if (useIPv6)
-            {
-                try
-                {
-                    var localToken = cancellationToken;
-
-                    if (!hasResolvedIPv6Availability)
-                    {
-                        // to make things move fast, use a very low timeout for the initial ipv6 attempt.
-                        var quickFailCts = new CancellationTokenSource(connection_establish_timeout);
-                        var linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, quickFailCts.Token);
-
-                        localToken = linkedTokenSource.Token;
-                    }
-
-                    return await attemptConnection(AddressFamily.InterNetworkV6, context, localToken);
-                }
-                catch
-                {
-                    // Do not retry IPv6 if a routable IPv4 address is available, otherwise continue to attempt IPv6 connections.
-                    var routableIPv4 = HasRoutableIPv4Address();
-                    _logger.Info("IPv4 is available: {0}, IPv6 will be {1}", routableIPv4, routableIPv4 ? "disabled" : "left enabled");
-                    useIPv6 = !routableIPv4;
-                }
-                finally
-                {
-                    hasResolvedIPv6Availability = true;
-                }
-            }
-
-            // fallback to IPv4.
-            return await attemptConnection(AddressFamily.InterNetwork, context, cancellationToken);
-        }
-
-        private static async ValueTask<Stream> attemptConnection(AddressFamily addressFamily, SocketsHttpConnectionContext context, CancellationToken cancellationToken)
-        {
-            // The following socket constructor will create a dual-mode socket on systems where IPV6 is available.
-            var socket = new Socket(addressFamily, SocketType.Stream, ProtocolType.Tcp)
-            {
-                // Turn off Nagle's algorithm since it degrades performance in most HttpClient scenarios.
-                NoDelay = true
-            };
-
-            try
-            {
-                await socket.ConnectAsync(context.DnsEndPoint, cancellationToken).ConfigureAwait(false);
-
-                // The stream should take the ownership of the underlying socket,
-                // closing it when it's disposed.
-                return new NetworkStream(socket, ownsSocket: true);
-            }
-            catch
-            {
-                socket.Dispose();
-                throw;
-            }
         }
     }
 }

--- a/src/NzbDrone.Common/Http/HappyEyeballs/HappyEyeballs.cs
+++ b/src/NzbDrone.Common/Http/HappyEyeballs/HappyEyeballs.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NzbDrone.Common.Http.HappyEyeballs;
+
+/*
+Until .NET implements Happy Eyeballs natively, use third-party implementation from
+https://slugcat.systems/post/24-06-16-ipv6-is-hard-happy-eyeballs-dotnet-httpclient/#the-implementation
+This issue is being tracked at https://github.com/dotnet/runtime/issues/26177.
+
+Below is a slightly modified Happy Eyeballs implementation from the post above.
+We've factored out HTTP-specific implementation into HttpHappyEyeballs class to
+make testing easier.
+*/
+
+public class HappyEyeballs<TSocket>
+    where TSocket : IDisposable
+{
+    private readonly Func<IPAddress, CancellationToken, Task<TSocket>> _connectSocket;
+    private readonly Func<CancellationToken, Task> _taskDelay;
+
+    public HappyEyeballs(
+        Func<IPAddress, CancellationToken, Task<TSocket>> connectSocket,
+        Func<CancellationToken, Task> taskDelay)
+    {
+        _connectSocket = connectSocket;
+        _taskDelay = taskDelay;
+    }
+
+    public async ValueTask<TSocket> Connect(
+        IPAddress[] addresses,
+        CancellationToken cancellationToken)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(addresses.Length);
+
+        var ips = SortInterleaved(addresses);
+
+        return await ParallelTask(
+            ips.Length,
+            (i, cancel) => _connectSocket(ips[i], cancel),
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private IPAddress[] SortInterleaved(IPAddress[] addresses)
+    {
+        // Interleave returned addresses so that they are IPv6 -> IPv4 -> IPv6 -> IPv4.
+        // Assuming we have multiple addresses of the same type that is.
+        // As described in the RFC.
+        var ipv6 = addresses.Where(x => x.AddressFamily == AddressFamily.InterNetworkV6).ToArray();
+        var ipv4 = addresses.Where(x => x.AddressFamily == AddressFamily.InterNetwork).ToArray();
+
+        var commonLength = Math.Min(ipv6.Length, ipv4.Length);
+
+        var result = new IPAddress[addresses.Length];
+
+        for (var i = 0; i < commonLength; i++)
+        {
+            result[i * 2] = ipv6[i];
+            result[1 + (i * 2)] = ipv4[i];
+        }
+
+        if (ipv4.Length > ipv6.Length)
+        {
+            ipv4.AsSpan(commonLength).CopyTo(result.AsSpan(commonLength * 2));
+        }
+        else if (ipv6.Length > ipv4.Length)
+        {
+            ipv6.AsSpan(commonLength).CopyTo(result.AsSpan(commonLength * 2));
+        }
+
+        return result;
+    }
+
+    private async Task<TSocket> ParallelTask(
+        int totalTasks,
+        Func<int, CancellationToken, Task<TSocket>> taskBuilder,
+        CancellationToken cancellationToken)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(totalTasks);
+
+        using var successCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+        var taskIndex = 0;
+        var tasks = new List<Task<TSocket>>();
+        var innerExceptions = new List<Exception>();
+
+        // The general loop here is as follows:
+        // 1. Add a new task for the next IP to try.
+        // 2. Wait until any task completes OR the delay happens.
+        // If an error occurs, we stop checking that task and continue checking the next.
+        // Every iteration we add another task, until we're full on them.
+        // We keep looping until we have SUCCESS, or we run out of attempt tasks entirely.
+        Task<TSocket> successTask = null;
+
+        while (taskIndex < totalTasks || tasks.Count > 0)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                break;
+            }
+
+            if (taskIndex < totalTasks)
+            {
+                tasks.Add(taskBuilder(taskIndex, successCts.Token));
+                taskIndex++;
+            }
+
+            var whenAnyDone = Task.WhenAny(tasks);
+            Task<TSocket> completedTask;
+
+            if (taskIndex < totalTasks)
+            {
+                using var delayCts = CancellationTokenSource.CreateLinkedTokenSource(successCts.Token);
+
+                // If we have another one to queue, wait for a timeout instead of *just* waiting for a connection task.
+                var timeoutTask = _taskDelay(delayCts.Token);
+                var whenAnyOrTimeout = await Task.WhenAny(whenAnyDone, timeoutTask).ConfigureAwait(false);
+
+                if (whenAnyOrTimeout != whenAnyDone)
+                {
+                    continue;
+                }
+
+                // Ensure that we dispose the internal timer associated with Task.Delay.
+                await delayCts.CancelAsync().ConfigureAwait(false);
+                await timeoutTask.ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
+
+                completedTask = whenAnyDone.Result;
+            }
+            else
+            {
+                completedTask = await whenAnyDone.ConfigureAwait(false);
+            }
+
+            tasks.Remove(completedTask);
+
+            if (completedTask.IsCompletedSuccessfully)
+            {
+                successTask = completedTask;
+                break;
+            }
+            else if (completedTask.IsFaulted)
+            {
+                innerExceptions.AddRange(completedTask.Exception!.InnerExceptions);
+            }
+        }
+
+        // Cancel and wait for all pending tasks.
+        await successCts.CancelAsync().ConfigureAwait(false);
+        await Task.WhenAll(tasks.Cast<Task>()).ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
+
+        // Make sure that we don't get multiple sockets completing at once.
+        //
+        // Also for cancellation, e.g. if delay task completes before
+        // socket connection in the task loop, and we receive cancellation
+        // at the same time (thus stopping the loop). In this case, prefer
+        // throwing an exception instead of returning a successful task.
+        foreach (var task in tasks)
+        {
+            if (task.IsCompletedSuccessfully)
+            {
+                task.Result.Dispose();
+            }
+        }
+
+        if (successTask == null)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            throw new AggregateException(innerExceptions);
+        }
+
+        return successTask.Result;
+    }
+}

--- a/src/NzbDrone.Common/Http/HappyEyeballs/HttpHappyEyeballs.cs
+++ b/src/NzbDrone.Common/Http/HappyEyeballs/HttpHappyEyeballs.cs
@@ -1,0 +1,93 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using NLog;
+using NzbDrone.Common.Extensions;
+
+namespace NzbDrone.Common.Http.HappyEyeballs;
+
+public class HttpHappyEyeballs
+{
+    private const int ConnectionAttemptDelay = 250;
+
+    private readonly Logger _logger;
+
+    public HttpHappyEyeballs(Logger logger)
+    {
+        _logger = logger;
+    }
+
+    public async ValueTask<Stream> OnConnect(
+        SocketsHttpConnectionContext context,
+        CancellationToken cancellationToken)
+    {
+        var endPoint = context.DnsEndPoint;
+        var ipHostEntry = await Dns.GetHostEntryAsync(endPoint.Host, endPoint.AddressFamily, cancellationToken).ConfigureAwait(false);
+        var resolvedAddresses = ipHostEntry.AddressList;
+
+        if (resolvedAddresses.Length == 0)
+        {
+            throw new WebException(
+                $"The remote name {endPoint.Host} could not be resolved",
+                WebExceptionStatus.NameResolutionFailure);
+        }
+
+        var happyEyeballs = CreateHappyEyeballs(endPoint);
+        var socket = await happyEyeballs.Connect(resolvedAddresses, cancellationToken).ConfigureAwait(false);
+        _logger.Trace("Successfully connected {0} to address: {1}", endPoint.HostPort(), socket.RemoteEndPoint);
+
+        return new NetworkStream(socket, ownsSocket: true);
+    }
+
+    private HappyEyeballs<Socket> CreateHappyEyeballs(DnsEndPoint endPoint)
+    {
+        return new HappyEyeballs<Socket>(
+            (ipAddress, cancel) => ConnectSocket(ipAddress, endPoint, cancel),
+            cancel => TaskDelay(endPoint, cancel));
+    }
+
+    private async Task TaskDelay(DnsEndPoint endPoint, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var timeSpan = TimeSpan.FromMilliseconds(ConnectionAttemptDelay);
+        _logger.Trace("Waiting on {0} connection attempt delay for {1}", endPoint.HostPort(), timeSpan);
+
+        await Task.Delay(timeSpan, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<Socket> ConnectSocket(
+        IPAddress ipAddress,
+        DnsEndPoint endPoint,
+        CancellationToken cancellationToken)
+    {
+        var remoteEP = new IPEndPoint(ipAddress, endPoint.Port);
+
+        // The following socket constructor will create a dual-mode socket on
+        // systems where IPv6 is available.
+        var socket = new Socket(SocketType.Stream, ProtocolType.Tcp)
+        {
+            // Turn off Nagle's algorithm since it degrades performance in most
+            // HttpClient scenarios.
+            NoDelay = true
+        };
+
+        _logger.Trace("Trying Happy Eyeballs connection to {0} for host {1}", ipAddress, endPoint.HostPort());
+
+        try
+        {
+            await socket.ConnectAsync(remoteEP, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception e)
+        {
+            socket.Dispose();
+            _logger.Trace(e, "Happy Eyeballs connection to {0} for host {1} failed", ipAddress, endPoint.HostPort());
+            throw;
+        }
+
+        return socket;
+    }
+}


### PR DESCRIPTION
## Summary

- Port of [Sonarr#8153](https://github.com/Sonarr/Sonarr/pull/8153) (merged 2026-01-27 to `v5-develop`) — fixes the same bug here.
- Closes #2157.

## Problem

`src/NzbDrone.Common/Http/Dispatchers/ManagedHttpDispatcher.cs` currently does

```csharp
useIPv6 = !routableIPv4;
```

per request, with the comment

> Do not retry IPv6 if a routable IPv4 address is available, otherwise continue to attempt IPv6 connections.

A single failure on any IPv6 attempt — for example an IPv4-only indexer that never had AAAA in the first place — flips a static field and disables IPv6 process-wide for every other indexer. Hosts that are IPv6-only (BYRBT and similar CN academic trackers, FlareSolverr in some setups) become permanently unreachable until the process restarts.

## Fix

Replace the static-flag approach with a Happy Eyeballs (RFC 8305) implementation: race interleaved IPv6/IPv4 connection attempts in parallel, take the first success, fail only if every address fails. Exact port of Sonarr's code with namespaces adjusted to Prowlarr.

## Difference from Sonarr's diff

Sonarr's `DnsEndPointExtensions.cs` uses **C# 14** `extension(DnsEndPoint)` member syntax. Prowlarr is on **C# 12 / .NET 8**, so the extension is rewritten as a classic `static string HostPort(this DnsEndPoint endPoint)` and the three call sites in `HttpHappyEyeballs.cs` go from `endPoint.HostPort` to `endPoint.HostPort()`. Functionally identical. Everything else is byte-identical to Sonarr's PR.

## Verification

- `dotnet build src/Prowlarr.sln -c Debug` → 0 warnings, 0 errors (.NET 8.0.420)
- `dotnet test src/NzbDrone.Common.Test --filter HappyEyeballs` → 6/6 pass

## Files

- New: `src/NzbDrone.Common/Http/HappyEyeballs/HappyEyeballs.cs`
- New: `src/NzbDrone.Common/Http/HappyEyeballs/HttpHappyEyeballs.cs`
- New: `src/NzbDrone.Common/Extensions/DnsEndPointExtensions.cs`
- New: `src/NzbDrone.Common.Test/Http/HappyEyeballsFixture.cs`
- Modified: `src/NzbDrone.Common/Http/Dispatchers/ManagedHttpDispatcher.cs` — drops `routableIPv4` static-state probe and the unused `_logger`/`useIPv6`/`hasResolvedIPv6Availability` fields, plugs in `Socket.OSSupportsIPv6 ? _httpHappyEyeballs.OnConnect : null` as the `ConnectCallback`.