### PR TITLE
Rename Settings/Indexers to Settings/Indexer Proxies

### DIFF
--- a/frontend/src/Components/Page/Sidebar/PageSidebar.js
+++ b/frontend/src/Components/Page/Sidebar/PageSidebar.js
@@ -49,7 +49,7 @@ const links = [
     to: '/settings',
     children: [
       {
-        title: () => translate('Indexers'),
+        title: () => translate('IndexerProxies'),
         to: '/settings/indexers'
       },
       {

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -445,6 +445,7 @@
   "IndexerVipExpiredHealthCheckMessage": "Indexer VIP benefits have expired: {indexerNames}",
   "IndexerVipExpiringHealthCheckMessage": "Indexer VIP benefits expiring soon: {indexerNames}",
   "Indexers": "Indexers",
+  "IndexerProxies": "Indexer Proxies",
   "Info": "Info",
   "InfoUrl": "Info URL",
   "InitialFailure": "Initial Failure",


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Renames the Indexer Proxies sidebar title from "Indexers" to "Indexer Proxies". Time after time this original naming has caused issues for users, and renaming this makes it clearer what that Settings page is for. 

#### Screenshot (if UI related)
<img width="661" height="412" alt="image" src="https://github.com/user-attachments/assets/3636e8e7-e783-4833-9b8c-690187cbb41c" />

#### Todos
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)