### PR TITLE
Fix minage, minsize, and maxsize Newznab request parameters

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/Newznab/NewznabRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Newznab/NewznabRequestGenerator.cs
@@ -275,7 +275,7 @@ namespace NzbDrone.Core.Indexers.Newznab
 
             if (searchCriteria.MinAge.HasValue)
             {
-                parameters.Set("minage", searchCriteria.MaxAge.ToString());
+                parameters.Set("minage", searchCriteria.MinAge.ToString());
             }
 
             if (searchCriteria.MaxAge.HasValue)
@@ -285,12 +285,12 @@ namespace NzbDrone.Core.Indexers.Newznab
 
             if (searchCriteria.MinSize.HasValue)
             {
-                parameters.Set("minsize", searchCriteria.MaxAge.ToString());
+                parameters.Set("minsize", searchCriteria.MinSize.ToString());
             }
 
             if (searchCriteria.MaxSize.HasValue)
             {
-                parameters.Set("maxsize", searchCriteria.MaxAge.ToString());
+                parameters.Set("maxsize", searchCriteria.MaxSize.ToString());
             }
 
             if (parameters.Count > 0)


### PR DESCRIPTION
## What does this PR do?

Fixes three copy-paste bugs in `NewznabRequestGenerator.cs` where `minage`, `minsize`, and `maxsize` query parameters were all incorrectly sourced from `searchCriteria.MaxAge` instead of their respective fields.

**Before:**
```csharp
parameters.Set("minage", searchCriteria.MaxAge.ToString());   // wrong
parameters.Set("minsize", searchCriteria.MaxAge.ToString());  // wrong
parameters.Set("maxsize", searchCriteria.MaxAge.ToString());  // wrong
```

**After:**
```csharp
parameters.Set("minage", searchCriteria.MinAge.ToString());
parameters.Set("minsize", searchCriteria.MinSize.ToString());
parameters.Set("maxsize", searchCriteria.MaxSize.ToString());
```

## What kind of change is this?

Bug fix

## Checklist

- [x] All existing tests pass
- [x] No new tests needed (pure copy-paste fix)

Closes #2668

🤖 Generated with [Claude Code](https://claude.com/claude-code)