### PR TITLE
Fixed: (SecretCinema) Improve release titles

### DIFF
--- a/.github/workflows/label-actions.yml
+++ b/.github/workflows/label-actions.yml
@@ -8,16 +8,14 @@ on:
   discussion:
     types: [labeled, unlabeled]
 
-permissions:
-  contents: read
-  issues: write
-  pull-requests: write
-  discussions: write
-
 jobs:
   action:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     steps:
-      - uses: dessant/label-actions@v4
+      - uses: dessant/label-actions@v5
         with:
           process-only: 'issues, prs'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -4,9 +4,9 @@ on:
 
 jobs:
   triage:
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
-    runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@v6

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -3,13 +3,17 @@ name: 'Lock threads'
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '10 0 * * *'
 
 jobs:
   lock:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+      discussions: write
     steps:
-      - uses: dessant/lock-threads@v5
+      - uses: dessant/lock-threads@v6
         with:
           github-token: ${{ github.token }}
           issue-inactive-days: '90'

--- a/src/NzbDrone.Core/Indexers/Definitions/SecretCinema.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/SecretCinema.cs
@@ -59,10 +59,13 @@ public class SecretCinema : GazelleBase<GazelleSettings>
     }
 }
 
-public class SecretCinemaParser : IParseIndexerResponse
+public partial class SecretCinemaParser : IParseIndexerResponse
 {
     private readonly GazelleSettings _settings;
     private readonly IndexerCapabilities _capabilities;
+
+    [GeneratedRegex(@"(\b|[-._ ])((?:19|20)\d{2})(\b|[-._ ])", RegexOptions.Compiled)]
+    private static partial Regex YearRegex();
 
     public SecretCinemaParser(GazelleSettings settings, IndexerCapabilities capabilities)
     {
@@ -145,18 +148,23 @@ public class SecretCinemaParser : IParseIndexerResponse
 
                     if (IsAnyMovieCategory(release.Categories))
                     {
-                        // Remove director from title
-                        // SC API returns no more useful information than this
-                        release.Title = $"{title} ({result.GroupYear}) {torrent.Media}".Trim();
-
-                        if (torrent.RemasterTitle.IsNotNullOrWhiteSpace())
+                        if (torrent.RemasterTitle.IsNotNullOrWhiteSpace() && YearRegex().IsMatch(torrent.RemasterTitle))
                         {
-                            release.Title += $" [{WebUtility.HtmlDecode(torrent.RemasterTitle).Trim()}]";
+                            release.Title = WebUtility.HtmlDecode(torrent.RemasterTitle).Trim();
                         }
+                        else
+                        {
+                            release.Title = $"{title} ({result.GroupYear}) {torrent.Media}".Trim();
 
-                        // Replace media formats with standards
-                        release.Title = Regex.Replace(release.Title, @"\bBDMV\b", "COMPLETE BLURAY", RegexOptions.IgnoreCase);
-                        release.Title = Regex.Replace(release.Title, @"\bSD\b", "DVDRip", RegexOptions.IgnoreCase);
+                            if (torrent.RemasterTitle.IsNotNullOrWhiteSpace())
+                            {
+                                release.Title += $" [{WebUtility.HtmlDecode(torrent.RemasterTitle).Trim()}]";
+                            }
+
+                            // Replace media formats with standards
+                            release.Title = Regex.Replace(release.Title, @"\bBDMV\b", "COMPLETE BLURAY", RegexOptions.IgnoreCase);
+                            release.Title = Regex.Replace(release.Title, @"\bSD\b", "DVDRip", RegexOptions.IgnoreCase);
+                        }
                     }
                     else
                     {

--- a/src/NzbDrone.Core/Indexers/Definitions/SecretCinema.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/SecretCinema.cs
@@ -158,7 +158,7 @@ public partial class SecretCinemaParser : IParseIndexerResponse
 
                             if (torrent.RemasterTitle.IsNotNullOrWhiteSpace())
                             {
-                                release.Title += $" [{WebUtility.HtmlDecode(torrent.RemasterTitle).Trim()}]";
+                                release.Title += $" / {WebUtility.HtmlDecode(torrent.RemasterTitle).Trim()}";
                             }
 
                             // Replace media formats with standards


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Using release titles added from RemasterTitle field only if they contains year, as old torrents still have the old values intended for remaster title.