### PR TITLE
fix: Cloudflare detection without requiring Server header

### DIFF
--- a/src/NzbDrone.Core/Http/CloudFlare/CloudFlareDetectionService.cs
+++ b/src/NzbDrone.Core/Http/CloudFlare/CloudFlareDetectionService.cs
@@ -20,12 +20,7 @@ namespace NzbDrone.Core.Http.CloudFlare
 
         public static bool IsCloudflareProtected(HttpResponse response)
         {
-            if (!response.Headers.Any(i => i.Key != null && i.Key.ToLower() == "server" && CloudflareServerNames.Contains(i.Value.ToLower())))
-            {
-                return false;
-            }
-
-            // detect CloudFlare and DDoS-GUARD
+            // detect CloudFlare and DDoS-GUARD via content analysis (most reliable, check first)
             if (response.StatusCode.Equals(HttpStatusCode.ServiceUnavailable) ||
                 response.StatusCode.Equals(HttpStatusCode.Forbidden))
             {
@@ -34,10 +29,31 @@ namespace NzbDrone.Core.Http.CloudFlare
                     responseHtml.Contains("<title>Access denied</title>") ||
                     responseHtml.Contains("<title>Attention Required! | Cloudflare</title>") ||
                     responseHtml.Trim().Equals("error code: 1020") ||
-                    responseHtml.Contains("<title>DDOS-GUARD</title>", StringComparison.OrdinalIgnoreCase))
+                    responseHtml.Contains("<title>DDOS-GUARD</title>", StringComparison.OrdinalIgnoreCase) ||
+                    responseHtml.Contains("cdn-cgi"))
                 {
                     return true;
                 }
+            }
+
+            // detect CloudFlare redirect challenges (HTTP 302 with cdn-cgi URLs or content)
+            if (response.StatusCode.Equals(HttpStatusCode.Redirect) ||
+                response.StatusCode.Equals(HttpStatusCode.Found) ||
+                response.StatusCode.Equals(HttpStatusCode.Moved) ||
+                response.StatusCode.Equals(HttpStatusCode.RedirectMethod))
+            {
+                var location = response.Headers["Location"] ?? string.Empty;
+                var content = response.Content ?? string.Empty;
+                if (location.Contains("cdn-cgi") || content.Contains("cdn-cgi"))
+                {
+                    return true;
+                }
+            }
+
+            // detect CloudFlare and DDoS-GUARD via Server header
+            if (response.Headers.Any(i => i.Key != null && i.Key.ToLower() == "server" && CloudflareServerNames.Contains(i.Value.ToLower())))
+            {
+                return true;
             }
 
             // detect Custom CloudFlare for EbookParadijs, Film-Paleis, MuziekFabriek and Puur-Hollands


### PR DESCRIPTION
## Problem

The `IsCloudflareProtected` method in `CloudFlareDetectionService` required a `Server: cloudflare` (or `cloudflare-nginx`, `ddos-guard`) response header **before** it would check the response content for Cloudflare/DDoS-Guard patterns. 

Many Cloudflare-protected sites do **not** include this header, causing the early return at line 23-26 to skip all content analysis and return `false` — preventing FlareSolverr from being activated. The request then fails with a direct HTTP error (403, 302 redirect to cdn-cgi challenge), and the indexer gets disabled.

## Affected Indexers

- **TorrentGalaxyClone**: Returns HTTP 302 redirect to `cdn-cgi/content?id=...` (Cloudflare redirect challenge) — `Server` header missing
- **kickasstorrents.to**: Returns HTTP 403 with Cloudflare HTML body — `Server` header missing on many mirrors
- **EZTV** (and potentially others): Same 403 pattern, same missing `Server` header

FlareSolverr itself can successfully bypass these sites when called directly (tested manually).

## Root Cause

```csharp
// OLD CODE - checks Server header FIRST, returns false immediately if missing
if (!response.Headers.Any(i => i.Key != null && 
    i.Key.ToLower() == "server" && 
    CloudflareServerNames.Contains(i.Value.ToLower())))
{
    return false;  // ← Never reaches content analysis below
}
```

## Fix

1. **Content analysis moved first** — Status code + HTML title/body patterns are checked regardless of `Server` header presence
2. **`cdn-cgi` detection in 403/503 bodies** — Additional pattern match for Cloudflare responses without standard titles
3. **Redirect challenge detection** — New handler for HTTP 301/302/303/307 responses with `cdn-cgi` in the `Location` header or response body (TorrentGalaxyClone case)
4. **Server header kept as additional signal** — Not removed, just no longer a gate that blocks content analysis