### PR TITLE
Fixed: (Anidub) Make release titles parseable by Sonarr and Radarr

### DIFF
--- a/src/NzbDrone.Core.Test/IndexerTests/AnidubTests/AnidubTitleParserFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/AnidubTests/AnidubTitleParserFixture.cs
@@ -1,0 +1,77 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.Indexers;
+using NzbDrone.Core.Indexers.Definitions;
+
+namespace NzbDrone.Core.Test.IndexerTests.AnidubTests
+{
+    [TestFixture]
+    public class AnidubTitleParserFixture
+    {
+        private static readonly ICollection<IndexerCategory> AnimeTvCategories = new List<IndexerCategory> { NewznabStandardCategory.TVAnime };
+        private static readonly ICollection<IndexerCategory> MovieCategories = new List<IndexerCategory> { NewznabStandardCategory.Movies };
+        private static readonly ICollection<IndexerCategory> AudioCategories = new List<IndexerCategory> { NewznabStandardCategory.Audio };
+
+        private readonly AnidubTitleParser _titleParser = new();
+
+        [TestCase("Провожающая в последний путь Фрирен / Sousou no Frieren [28 из 28]", "Sousou no Frieren S1")]
+        [TestCase("Провожающая в последний путь Фрирен ТВ-2 / Sousou no Frieren TV-2 [10 из 24]", "Sousou no Frieren S2E01-10 of 24")]
+        [TestCase("Дандадан / Dandadan [12 из 12]", "Dandadan S1")]
+        [TestCase("Дандадан TV-2 / Dandadan ТВ-2 [12 из 12]", "Dandadan S2")]
+        [TestCase("Владыка ТВ-4 / Overlord TV-IV [13 из 13]", "Overlord S4")]
+        [TestCase("Блич / Bleach [151-366 из 366]", "Bleach E151-366 of 366")]
+        [TestCase("Ванпанчмен ТВ-1 / One-Punch Man TV-1 [12 из 12] + Specials [6 из 6]", "One-Punch Man S1")]
+        [TestCase("Ми-ми-ми-мишка ТВ-2 / Kuma Kuma Kuma Bear Punch! [12 из 12]", "Kuma Kuma Kuma Bear Punch! S2")]
+        [TestCase("Гинтама / Gintama ТВ-1 [81 из 201]", "Gintama S1E01-81 of 201")]
+        [TestCase("Гинтама ТВ-4 / Gintama TV-4 [51 из 51 + SP]", "Gintama S4")]
+        [TestCase("Истории чудовищ / Bakemonogatari [12 из 12 + 3 SP]", "Bakemonogatari S1")]
+        [TestCase("Боруто: Новое околение / Boruto: Naruto Next Generations [293 из ххх]", "Boruto: Naruto Next Generations S1E01-293")]
+        [TestCase("Волейбол!!  ТВ-4/ Haikyuu!! To the Top 2nd Cour [12 из 13]", "Haikyuu!! To the Top 2nd Cour S4E01-12 of 13")]
+        [TestCase("Повесть о Стране Цветных Облаков TV-1 / Saiunkoku Monogatari TV-1 [01 из 39]", "Saiunkoku Monogatari S1E01 of 39")]
+        [TestCase("Семья шпиона ТВ-1 Часть 2 / Spy x Family TV-1 Part 2 [13 из 13]", "Spy x Family Part 2 S1")]
+        [TestCase("Блич: Тысячелетняя кровавая война - Конфликт ТВ-2 / Bleach: Sennen Kessen-hen - Soukoku-tan TV-2 [14 из 14]", "Bleach: Sennen Kessen-hen - Soukoku-tan S2")]
+        [TestCase("Блич / Bleach", "Bleach")]
+        [TestCase("Наруто (спэшлы) / Naruto Specials [02 из 02]", "Naruto Specials S1")]
+        [TestCase("Хиган / Sweat Punch Series 4 Higan OVA [01 из 01]", "Sweat Punch Series 4 Higan OVA S1")]
+        public void should_parse_anime_tv_titles_with_strip_cyrillic(string title, string expected)
+        {
+            _titleParser.Parse(title, AnimeTvCategories, stripCyrillicLetters: true).Should().Be(expected);
+        }
+
+        [TestCase("Провожающая в последний путь Фрирен / Sousou no Frieren [28 из 28]", "Провожающая в последний путь Фрирен / Sousou no Frieren S1")]
+        [TestCase("Дандадан TV-2 / Dandadan ТВ-2 [12 из 12]", "Дандадан / Dandadan S2")]
+        public void should_keep_cyrillic_title_part_when_strip_disabled(string title, string expected)
+        {
+            _titleParser.Parse(title, AnimeTvCategories, stripCyrillicLetters: false).Should().Be(expected);
+        }
+
+        [TestCase("Наруто: Кровавая тюрьма / Gekijouban Naruto: Blood Prison", "Gekijouban Naruto: Blood Prison")]
+        [TestCase("Наруто: Ураганные Хроники - Узы / Gekijouban Naruto Shippuuden: Kizuna [Movie]", "Gekijouban Naruto Shippuuden: Kizuna")]
+        public void should_parse_movie_titles_with_strip_cyrillic(string title, string expected)
+        {
+            _titleParser.Parse(title, MovieCategories, stripCyrillicLetters: true).Should().Be(expected);
+        }
+
+        [Test]
+        public void should_add_russian_language_token_when_enabled()
+        {
+            _titleParser.Parse("Провожающая в последний путь Фрирен / Sousou no Frieren [28 из 28]", AnimeTvCategories, stripCyrillicLetters: true, addRussianToTitle: true)
+                .Should().Be("Sousou no Frieren S1 RUS");
+        }
+
+        [Test]
+        public void should_not_duplicate_russian_language_token()
+        {
+            _titleParser.Parse("Test Title RUS", AnimeTvCategories, stripCyrillicLetters: false, addRussianToTitle: true)
+                .Should().Be("Test Title RUS");
+        }
+
+        [Test]
+        public void should_not_touch_markers_for_non_tv_categories()
+        {
+            _titleParser.Parse("Волейбол!! / Haikyuu!! [OST]", AudioCategories, stripCyrillicLetters: true)
+                .Should().Be("Haikyuu!! [OST]");
+        }
+    }
+}

--- a/src/NzbDrone.Core/Indexers/Definitions/Anidub.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Anidub.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using AngleSharp.Html.Parser;
 using NLog;
 using NzbDrone.Common.Http;
+using NzbDrone.Core.Annotations;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Indexers.Exceptions;
 using NzbDrone.Core.Indexers.Settings;
@@ -22,7 +23,7 @@ using NzbDrone.Core.ThingiProvider;
 
 namespace NzbDrone.Core.Indexers.Definitions
 {
-    public class Anidub : TorrentIndexerBase<UserPassTorrentBaseSettings>
+    public class Anidub : TorrentIndexerBase<AnidubSettings>
     {
         public override string Name => "Anidub";
         public override string[] IndexerUrls => new[] { "https://tr.anidub.com/" };
@@ -246,11 +247,12 @@ namespace NzbDrone.Core.Indexers.Definitions
     public class AnidubParser : IParseIndexerResponse
     {
         private readonly ProviderDefinition _definition;
-        private readonly UserPassTorrentBaseSettings _settings;
+        private readonly AnidubSettings _settings;
         private readonly IndexerCapabilitiesCategories _categories;
         private readonly TimeSpan _rateLimit;
         private readonly IIndexerHttpClient _httpClient;
         private readonly Logger _logger;
+        private readonly AnidubTitleParser _titleParser = new();
 
         private static Dictionary<string, string> CategoriesMap => new()
         {
@@ -272,7 +274,7 @@ namespace NzbDrone.Core.Indexers.Definitions
             { "/anons_ongoing", "12" }
         };
 
-        public AnidubParser(ProviderDefinition definition, UserPassTorrentBaseSettings settings, IndexerCapabilitiesCategories categories, TimeSpan rateLimit, IIndexerHttpClient httpClient, Logger logger)
+        public AnidubParser(ProviderDefinition definition, AnidubSettings settings, IndexerCapabilitiesCategories categories, TimeSpan rateLimit, IIndexerHttpClient httpClient, Logger logger)
         {
             _definition = definition;
             _settings = settings;
@@ -282,10 +284,10 @@ namespace NzbDrone.Core.Indexers.Definitions
             _logger = logger;
         }
 
-        private static string GetTitle(AngleSharp.Html.Dom.IHtmlDocument content, AngleSharp.Dom.IElement tabNode)
+        private string GetTitle(AngleSharp.Html.Dom.IHtmlDocument content, AngleSharp.Dom.IElement tabNode, ICollection<IndexerCategory> categories)
         {
             var domTitle = content.QuerySelector("#news-title");
-            var baseTitle = domTitle.TextContent.Trim();
+            var baseTitle = _titleParser.Parse(domTitle.TextContent.Trim(), categories, _settings.StripCyrillicLetters, _settings.AddRussianToTitle);
             var quality = GetQuality(tabNode.ParentElement);
 
             if (!string.IsNullOrWhiteSpace(quality))
@@ -438,11 +440,13 @@ namespace NzbDrone.Core.Indexers.Definitions
             var parser = new HtmlParser();
             using var dom = parser.ParseDocument(indexerResponse.Content);
 
+            var categories = ParseCategories(indexerResponse.Request.Url.Path);
+
             foreach (var t in dom.QuerySelectorAll("#tabs .torrent_c > div"))
             {
                 var release = new TorrentInfo
                 {
-                    Title = GetTitle(dom, t),
+                    Title = GetTitle(dom, t, categories),
                     InfoUrl = indexerResponse.Request.Url.FullUri,
                     DownloadVolumeFactor = 0,
                     UploadVolumeFactor = 1,
@@ -451,7 +455,7 @@ namespace NzbDrone.Core.Indexers.Definitions
                     Seeders = GetReleaseSeeders(t),
                     Peers = GetReleaseSeeders(t) + GetReleaseLeechers(t),
                     Grabs = GetReleaseGrabs(t),
-                    Categories = ParseCategories(indexerResponse.Request.Url.Path),
+                    Categories = categories,
                     PublishDate = GetDateFromShowPage(dom),
                     DownloadUrl = GetReleaseLink(t),
                     Size = GetReleaseSize(t),
@@ -502,5 +506,205 @@ namespace NzbDrone.Core.Indexers.Definitions
         }
 
         public Action<IDictionary<string, string>, DateTime?> CookiesUpdater { get; set; }
+    }
+
+    public class AnidubTitleParser
+    {
+        // Season markers: "ТВ-2", "TV-2", "TV 3" and roman numerals ("TV-IV")
+        private static readonly Regex SeasonMarkerRegex = new(@"\b(?:ТВ|TV)[-\s]?(\d{1,3}|[IVXLC]+)\b", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        // Specials appended after the main batch: "+ Specials [6 из 6]", "+ SP"
+        private static readonly Regex SpecialsSuffixRegex = new(@"\s*\+\s*(?:Specials?|SP)\s*(?:\[[^\]]*\])?", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        // Batch episode counter: "[28 из 28]", "[10 из 24]", "[151-366 из 366]", "[293 из ххх]", "[51 из 51 + SP]"
+        private static readonly Regex BatchBracketRegex = new(@"\s*\[(\d+)(?:-(\d+))?\s+из\s+(\d+|[xх]+|\?+)(?:\s*\+\s*\d*\s*SP)?\]", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        private static readonly Regex MovieBracketRegex = new(@"\s*\[Movie\]", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        private static readonly Regex SeasonTokenRegex = new(@"\bS\d+", RegexOptions.Compiled);
+
+        private static readonly Regex TitlePartSplitRegex = new(@"\s*/\s*", RegexOptions.Compiled);
+
+        private static readonly Regex StripCyrillicRegex = new(@"(\([\p{IsCyrillic}\W]+\))|(^[\p{IsCyrillic}\W\d]+\/ )|([\p{IsCyrillic} \-]+,+)|([\p{IsCyrillic}]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        public string Parse(string title, ICollection<IndexerCategory> categories, bool stripCyrillicLetters = false, bool addRussianToTitle = false)
+        {
+            categories ??= Array.Empty<IndexerCategory>();
+
+            // https://www.fileformat.info/info/unicode/category/Pd/list.htm
+            title = Regex.Replace(title, @"\p{Pd}", "-", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+            if (IsAnyTvCategory(categories))
+            {
+                title = SpecialsSuffixRegex.Replace(title, string.Empty);
+
+                // Both the season marker and the batch counter are removed here
+                // and re-appended below in a canonical Sonarr-parseable form.
+                var seasonNumber = 1;
+                var seasonMatch = SeasonMarkerRegex.Match(title);
+                var hasExplicitMarkers = seasonMatch.Success;
+
+                if (seasonMatch.Success)
+                {
+                    seasonNumber = ParseSeasonNumber(seasonMatch.Groups[1].Value);
+                    title = SeasonMarkerRegex.Replace(title, string.Empty);
+                }
+
+                var episodes = string.Empty;
+                var isCrossSeasonRange = false;
+
+                var batchMatch = BatchBracketRegex.Match(title);
+                if (batchMatch.Success)
+                {
+                    hasExplicitMarkers = true;
+
+                    var from = batchMatch.Groups[1].Value;
+                    var to = batchMatch.Groups[2].Value;
+                    var total = batchMatch.Groups[3].Value;
+                    var totalSuffix = total.All(char.IsDigit) ? $" of {total}" : string.Empty;
+
+                    if (!string.IsNullOrEmpty(to))
+                    {
+                        // Explicit ranges ("151-366 из 366") may span seasons in absolute numbering, keep them season-less
+                        episodes = $"E{from}-{to}{totalSuffix}";
+                        isCrossSeasonRange = true;
+                    }
+                    else if (from == total)
+                    {
+                        // Complete batch is a full season pack
+                        episodes = string.Empty;
+                    }
+                    else if (int.TryParse(from, out var fromNumber) && fromNumber == 1)
+                    {
+                        episodes = $"E01{totalSuffix}";
+                    }
+                    else
+                    {
+                        // Anidub batches are cumulative and always start from the first episode
+                        episodes = $"E01-{from}{totalSuffix}";
+                    }
+
+                    title = BatchBracketRegex.Replace(title, string.Empty);
+                }
+
+                if (stripCyrillicLetters)
+                {
+                    title = SelectForeignTitleParts(title);
+                }
+
+                if (hasExplicitMarkers)
+                {
+                    var suffix = isCrossSeasonRange || SeasonTokenRegex.IsMatch(title) ? episodes : $"S{seasonNumber}{episodes}";
+
+                    if (!string.IsNullOrWhiteSpace(suffix))
+                    {
+                        title = $"{title.TrimEnd()} {suffix}";
+                    }
+                }
+            }
+            else
+            {
+                title = MovieBracketRegex.Replace(title, string.Empty);
+
+                if (stripCyrillicLetters)
+                {
+                    title = SelectForeignTitleParts(title);
+                }
+            }
+
+            if (addRussianToTitle && (IsAnyTvCategory(categories) || IsAnyMovieCategory(categories)) && !Regex.IsMatch(title, @"\bRUS\b", RegexOptions.IgnoreCase))
+            {
+                title += " RUS";
+            }
+
+            title = Regex.Replace(title, @"[\[\(]\s*[\)\]]", string.Empty, RegexOptions.Compiled);
+            title = title.Trim(' ', ',', '-', '_', '|', '/', '\\', ':', ';');
+
+            // replace multiple spaces with a single space
+            title = Regex.Replace(title, @"\s+", " ");
+
+            return title.Trim();
+        }
+
+        private static string SelectForeignTitleParts(string title)
+        {
+            // Anidub titles are "<russian title> / <romaji title> [batch]", keep the romaji part(s)
+            var parts = TitlePartSplitRegex.Split(title);
+
+            if (parts.Length > 1)
+            {
+                var foreignParts = parts.Where(part => !IsMostlyCyrillic(part)).ToList();
+
+                if (foreignParts.Count > 0 && foreignParts.Count < parts.Length)
+                {
+                    return string.Join(" / ", foreignParts);
+                }
+            }
+
+            return StripCyrillicRegex.Replace(title, string.Empty).Trim(' ', '-');
+        }
+
+        private static bool IsMostlyCyrillic(string part)
+        {
+            var cyrillicLetters = part.Count(c => c is >= 'А' and <= 'я');
+            var latinLetters = part.Count(c => c is (>= 'A' and <= 'Z') or (>= 'a' and <= 'z'));
+
+            return cyrillicLetters > latinLetters;
+        }
+
+        private static int ParseSeasonNumber(string value)
+        {
+            if (int.TryParse(value, out var number))
+            {
+                return number;
+            }
+
+            // Roman numerals (e.g. "Overlord TV-IV")
+            var result = 0;
+            var previous = 0;
+
+            foreach (var letter in value.ToUpperInvariant().Reverse())
+            {
+                var current = letter switch
+                {
+                    'I' => 1,
+                    'V' => 5,
+                    'X' => 10,
+                    'L' => 50,
+                    'C' => 100,
+                    _ => 0
+                };
+
+                result += current < previous ? -current : current;
+                previous = current;
+            }
+
+            return result;
+        }
+
+        private static bool IsAnyTvCategory(ICollection<IndexerCategory> categories)
+        {
+            return categories.Contains(NewznabStandardCategory.TV) || NewznabStandardCategory.TV.SubCategories.Any(subCategory => categories.Contains(subCategory));
+        }
+
+        private static bool IsAnyMovieCategory(ICollection<IndexerCategory> categories)
+        {
+            return categories.Contains(NewznabStandardCategory.Movies) || NewznabStandardCategory.Movies.SubCategories.Any(subCategory => categories.Contains(subCategory));
+        }
+    }
+
+    public class AnidubSettings : UserPassTorrentBaseSettings
+    {
+        public AnidubSettings()
+        {
+            StripCyrillicLetters = false;
+            AddRussianToTitle = false;
+        }
+
+        [FieldDefinition(4, Label = "Strip Cyrillic Letters", HelpText = "Strip the Cyrillic title part from release names to improve parsing by Sonarr and Radarr", Type = FieldType.Checkbox)]
+        public bool StripCyrillicLetters { get; set; }
+
+        [FieldDefinition(5, Label = "Add RUS to titles", HelpText = "Add RUS to end of all titles to improve language detection by Sonarr and Radarr. Will cause English-only results to be misidentified.", Type = FieldType.Checkbox)]
+        public bool AddRussianToTitle { get; set; }
     }
 }


### PR DESCRIPTION

#### Database Migration

NO

#### Description

The native Anidub indexer returned the raw Russian page title with only a quality suffix, which Sonarr rejects as "Unknown Series" — the indexer was effectively unusable with the apps. This PR adds an `AnidubTitleParser` (modelled on `TolokaTitleParser`/`RuTrackerTitleParser`) that converts the tracker's own markers into canonical scene form, plus the same opt-in settings the sibling Cyrillic trackers already have.

Marker conversion (always on, TV categories only):

| Tracker title (real examples) | Result (with Strip Cyrillic Letters) |
|---|---|
| `Провожающая в последний путь Фрирен / Sousou no Frieren [28 из 28]` | `Sousou no Frieren S1` |
| `Провожающая в последний путь Фрирен ТВ-2 / Sousou no Frieren TV-2 [10 из 24]` | `Sousou no Frieren S2E01-10 of 24` |
| `Владыка ТВ-4 / Overlord TV-IV [13 из 13]` | `Overlord S4` |
| `Блич / Bleach [151-366 из 366]` | `Bleach E151-366 of 366` |
| `Ванпанчмен ТВ-1 / One-Punch Man TV-1 [12 из 12] + Specials [6 из 6]` | `One-Punch Man S1` |
| `Боруто: Новое околение / Boruto: Naruto Next Generations [293 из ххх]` | `Boruto: Naruto Next Generations S1E01-293` |

- `ТВ-N` / `TV-N` / roman-numeral `TV-IV` season markers → `SN`
- complete batches `[28 из 28]` → season pack
- partial batches `[10 из 24]` → `E01-10 of 24` (Anidub batches are cumulative from episode 1)
- explicit ranges `[151-366 из 366]` are kept season-less (they may span seasons in absolute numbering)
- `+ Specials [6 из 6]` / `[51 из 51 + SP]` suffixes are dropped

New `AnidubSettings` (both default off for back-compat):
- **Strip Cyrillic Letters** — keeps the romaji part of `<russian> / <romaji>` titles (per-part Cyrillic/Latin dominance, with the shared strip regex as fallback), like Toloka/RuTracker/PornoLab
- **Add RUS to titles** — same as RuTracker (#1434)

Covered by `AnidubTitleParserFixture` — 26 test cases built from real tracker output across format variants (markers on either side of the slash, missing whitespace around `/`, unknown totals `ххх`, OVA/movies/OST categories).

#### Todos

- [x] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] Wiki Updates

#### Issues Fixed or Closed by this PR

* Fixes #2698
