### PR TITLE
Fixed: (Toloka) Relocate stranded season tokens after Cyrillic stripping

### DIFF
--- a/src/NzbDrone.Core.Test/IndexerTests/TolokaTests/TolokaTitleParserFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/TolokaTests/TolokaTitleParserFixture.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.Indexers;
+using NzbDrone.Core.Indexers.Definitions;
+
+namespace NzbDrone.Core.Test.IndexerTests.TolokaTests
+{
+    [TestFixture]
+    public class TolokaTitleParserFixture
+    {
+        private static readonly ICollection<IndexerCategory> TvCategories = new List<IndexerCategory> { NewznabStandardCategory.TVAnime };
+
+        private readonly TolokaTitleParser _titleParser = new();
+
+        // The Cyrillic title part can leave a stranded "<token> (S..) / " prefix after stripping when it
+        // contains characters the strip regex keeps: an apostrophe ("Сім'я") or a digit ("Володар 2").
+        [TestCase("Сім'я шпигуна (Сезон 1) / Spy x Family (2022) WEB-DL 1080p H.265 Ukr/Jap | sub Ukr", "Spy x Family (2022) WEB-DL 1080p H.265 Ukr/Jap | sub Ukr (S1)")]
+        [TestCase("Володар 2 (Сезон 2) / Overlord II (2018) WEBRip 1080p H.265 Ukr/Jap | Sub Ukr", "Overlord II (2018) WEBRip 1080p H.265 Ukr/Jap | Sub Ukr (S2)")]
+        [TestCase("Берсерк / Berserk (2016) WEB-DL 1080p Ukr/Jap", "Berserk (2016) WEB-DL 1080p Ukr/Jap")]
+        public void should_relocate_stranded_season_token_after_stripping(string title, string expected)
+        {
+            _titleParser.Parse(title, TvCategories, stripCyrillicLetters: true)
+                .Should().Be(expected);
+        }
+    }
+}

--- a/src/NzbDrone.Core/Indexers/Definitions/Toloka.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Toloka.cs
@@ -462,6 +462,8 @@ namespace NzbDrone.Core.Indexers.Definitions
 
         private readonly Regex _stripCyrillicRegex = new(@"(\([\p{IsCyrillic}\W]+\))|(^[\p{IsCyrillic}\W\d]+\/ )|([\p{IsCyrillic} \-]+,+)|([\p{IsCyrillic}]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
+        private readonly Regex _strandedTokenRegex = new(@"^[^a-zA-Z\[\(]*(\((?:S|E)[^)]+\))\s*/\s*", RegexOptions.Compiled);
+
         public string Parse(string title, ICollection<IndexerCategory> categories, bool stripCyrillicLetters = true)
         {
             // https://www.fileformat.info/info/unicode/category/Pd/list.htm
@@ -491,6 +493,15 @@ namespace NzbDrone.Core.Indexers.Definitions
             if (stripCyrillicLetters)
             {
                 title = _stripCyrillicRegex.Replace(title, string.Empty).Trim(' ', '-');
+
+                // When the stripped Cyrillic title contained converted season/episode tokens
+                // they are left stranded before the foreign title (e.g. "' (S1) / Spy x Family ...",
+                // "0 (S2E01-23 of 23) / Steins;Gate 0 ..."), relocate them to the end of the release title.
+                var strandedMatch = _strandedTokenRegex.Match(title);
+                if (strandedMatch.Success)
+                {
+                    title = $"{_strandedTokenRegex.Replace(title, string.Empty)} {strandedMatch.Groups[1].Value}".Trim();
+                }
             }
 
             title = Regex.Replace(title, @"\b-Rip\b", "Rip", RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -506,7 +517,7 @@ namespace NzbDrone.Core.Indexers.Definitions
 
             title = Regex.Replace(title, @"[\[\(]\s*[\)\]]", "", RegexOptions.Compiled);
 
-            title = title.Trim(' ', '&', ',', '.', '!', '?', '+', '-', '_', '|', '/', '\\', ':', ';', 'ʼ', '`');
+            title = title.Trim(' ', '&', ',', '.', '!', '?', '+', '-', '_', '|', '/', '\\', ':', ';', '\'', 'ʼ', '`');
 
             // replace multiple spaces with a single space
             title = Regex.Replace(title, @"\s+", " ");
@@ -521,7 +532,7 @@ namespace NzbDrone.Core.Indexers.Definitions
 
         private static string MoveFirstTagsToEndOfReleaseTitle(string input)
         {
-            var output = input.Trim(' ', '&', ',', '.', '!', '?', '+', '-', '_', '|', '/', '\\', ':', ';', 'ʼ', '`');
+            var output = input.Trim(' ', '&', ',', '.', '!', '?', '+', '-', '_', '|', '/', '\\', ':', ';', '\'', 'ʼ', '`');
             foreach (var findTagsRegex in FindTagsInTitlesRegexList)
             {
                 var expectedIndex = 0;


### PR DESCRIPTION

#### Database Migration

NO

#### Description

Follow-up to #2471 / #2317, same bug class. When the Cyrillic title part contains characters the strip regex does not remove — the ASCII apostrophe in words like `Сім'я`, digits that belong to the Ukrainian title (`Володар 2`, `Брама Штайнера 0`) — the converted season/episode token is left stranded in front of the foreign title, and `MoveFirstTagsToEndOfReleaseTitle` cannot recover it. Real titles currently produced with "Strip Cyrillic Letters" enabled:

| Current output | With this PR |
|---|---|
| `' (S1) / Spy x Family (2022) WEB-DL 1080p H.265 Ukr/Jap \| sub Ukr` | `Spy x Family (2022) WEB-DL 1080p H.265 Ukr/Jap \| sub Ukr (S1)` |
| `0 (S2E01-23 of 23 + OVA) / Steins;Gate 0 (2018) HDTV 1080p Ukr/Jap \| sub Ukr` | `Steins;Gate 0 (2018) HDTV 1080p Ukr/Jap \| sub Ukr (S2E01-23 of 23 + OVA)` |
| `2 (S2) / Overlord II (2018) WEBRip 1080p H.265 Ukr/Jap \| Sub Ukr` | `Overlord II (2018) WEBRip 1080p H.265 Ukr/Jap \| Sub Ukr (S2)` |

Sonarr cannot match the current form (the stranded token plus `/` corrupts the parsed series title).

Changes:
- relocate a stranded leading `(S…)`/`(E…)` token (followed by `/`) to the end of the release title after stripping
- trim the ASCII apostrophe `'` (U+0027) alongside the modifier-letter apostrophe `ʼ` (U+02BC) added in #2471

Covered by `TolokaTitleParserFixture` with titles taken from live Toloka output.

#### Todos

- [x] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] Wiki Updates

#### Issues Fixed or Closed by this PR

*
