### PR TITLE
Fixed: (RuTracker) Word boundary in RUS token duplicate check

### DIFF
--- a/src/NzbDrone.Core.Test/IndexerTests/RuTrackerTests/RuTrackerTitleParserFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/RuTrackerTests/RuTrackerTitleParserFixture.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.Indexers;
+using NzbDrone.Core.Indexers.Definitions;
+
+namespace NzbDrone.Core.Test.IndexerTests.RuTrackerTests
+{
+    [TestFixture]
+    public class RuTrackerTitleParserFixture
+    {
+        private static readonly ICollection<IndexerCategory> TvCategories = new List<IndexerCategory> { NewznabStandardCategory.TVHD };
+
+        private readonly RuTrackerTitleParser _titleParser = new();
+
+        [TestCase("Series Title (2019) WEB-DL 1080p", "Series Title (2019) WEB-DL 1080p RUS")]
+        [TestCase("Series Title (2019) WEB-DL 1080p RUS", "Series Title (2019) WEB-DL 1080p RUS")]
+        public void should_add_rus_to_title_without_duplicating(string title, string expected)
+        {
+            _titleParser.Parse(title, TvCategories, stripCyrillicLetters: false, addRussianToTitle: true)
+                .Should().Be(expected);
+        }
+    }
+}

--- a/src/NzbDrone.Core/Indexers/Definitions/RuTracker.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/RuTracker.cs
@@ -1769,7 +1769,7 @@ namespace NzbDrone.Core.Indexers.Definitions
             }
 
             // language fix: all rutracker releases contains russian track
-            if (addRussianToTitle && (IsAnyTvCategory(categories) || IsAnyMovieCategory(categories)) && !Regex.Match(title, "\bRUS\b", RegexOptions.IgnoreCase).Success)
+            if (addRussianToTitle && (IsAnyTvCategory(categories) || IsAnyMovieCategory(categories)) && !Regex.Match(title, @"\bRUS\b", RegexOptions.IgnoreCase).Success)
             {
                 title += " RUS";
             }


### PR DESCRIPTION

#### Database Migration

NO

#### Description

The "Add RUS to titles" option (#1434) guards against appending a duplicate token with:

```csharp
!Regex.Match(title, "\bRUS\b", RegexOptions.IgnoreCase).Success
```

In a non-verbatim C# string `\b` is the backspace character (U+0008), not a regex word boundary, so the pattern can never match and ` RUS` is appended even when the title already contains `RUS` (e.g. releases that already carry a `RUS` language tag end up as `... RUS RUS`). One-character fix to a verbatim string literal, plus a regression test.

#### Todos

- [x] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] Wiki Updates

#### Issues Fixed or Closed by this PR

*
