### PR TITLE
Fixed: (Anidub) Search by longest term word for DLE search compatibility

### DIFF
--- a/src/NzbDrone.Core.Test/IndexerTests/AnidubTests/AnidubRequestGeneratorFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/AnidubTests/AnidubRequestGeneratorFixture.cs
@@ -1,0 +1,41 @@
+using System.Linq;
+using System.Text;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.Indexers.Definitions;
+using NzbDrone.Core.Indexers.Settings;
+using NzbDrone.Core.IndexerSearch.Definitions;
+
+namespace NzbDrone.Core.Test.IndexerTests.AnidubTests
+{
+    [TestFixture]
+    public class AnidubRequestGeneratorFixture
+    {
+        private AnidubRequestGenerator _generator;
+
+        [SetUp]
+        public void Setup()
+        {
+            _generator = new AnidubRequestGenerator(new UserPassTorrentBaseSettings { BaseUrl = "https://tr.anidub.com/" });
+        }
+
+        [TestCase("Sousou no Frieren", "story=Frieren")]
+        [TestCase("Spy x Family", "story=Family")]
+        [TestCase("Sousou no Frieren S02", "story=Frieren")]
+        [TestCase("Dandadan", "story=Dandadan")]
+        [TestCase("Frieren S01", "story=Frieren")]
+        public void should_search_by_longest_word_of_term(string term, string expectedStoryParameter)
+        {
+            var requests = _generator.GetSearchRequests(new BasicSearchCriteria { SearchTerm = term })
+                .GetAllTiers()
+                .SelectMany(tier => tier)
+                .ToList();
+
+            requests.Should().HaveCount(1);
+
+            var body = Encoding.UTF8.GetString(requests.Single().HttpRequest.ContentData);
+
+            body.Should().Contain(expectedStoryParameter);
+        }
+    }
+}

--- a/src/NzbDrone.Core/Indexers/Definitions/Anidub.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Anidub.cs
@@ -142,6 +142,20 @@ namespace NzbDrone.Core.Indexers.Definitions
             _settings = settings;
         }
 
+        private static string GetSearchTerm(string term)
+        {
+            // Remove season and episode info from search term cause it breaks search
+            var searchTerm = Regex.Replace(term, @"(?:[SsEe]?\d{1,4}){1,2}$", "").TrimEnd();
+
+            // The site's DLE full-text search is unreliable for multi-word phrases:
+            // e.g. "Sousou no Frieren" and "Sousou Frieren" both return zero results
+            // while "Sousou" and "Frieren" each match. Search by the longest word
+            // and let the apps match the full release title.
+            var words = searchTerm.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+
+            return words.Length > 1 ? words.OrderByDescending(w => w.Length).First() : searchTerm;
+        }
+
         private IEnumerable<IndexerRequest> GetPagedRequests(string term)
         {
             string requestUrl;
@@ -168,9 +182,7 @@ namespace NzbDrone.Core.Indexers.Definitions
                     { "search_start", "1" },
                     { "full_search", "1" },
                     { "result_from", "1" },
-
-                    // Remove season and episode info from search term cause it breaks search
-                    { "story", Regex.Replace(term, @"(?:[SsEe]?\d{1,4}){1,2}$", "").TrimEnd() },
+                    { "story", GetSearchTerm(term) },
                     { "titleonly", "3" },
                     { "searchuser", "" },
                     { "replyless", "0" },


### PR DESCRIPTION
#### Database Migration

NO

#### Description

The Anidub site's DLE full-text search is unreliable for multi-word phrases. Measured against the live tracker (via the indexer's own search form, `titleonly=3`):

| Query | Results |
|---|---|
| `Frieren` | 2 |
| `Sousou` | 2 |
| `Sousou Frieren` | **0** |
| `Sousou no Frieren` | **0** |
| `Spy x Family` | 7 |
| `Family` | 7 (includes all Spy x Family entries) |

Sonarr/Radarr always send full series titles ("Sousou no Frieren", "Frieren Beyond Journeys End", …), so app-driven searches frequently return nothing even though the releases exist and match. Reduce the query to its longest word (after the existing SxxEyy stripping) and let the apps do the title matching — single-word queries are reliable and the apps' parsing/matching already filters false positives.

Covered by `AnidubRequestGeneratorFixture`.

Related: #2698 (Anidub title parsing, PR #2699 — independent fixes, both needed for Anidub to be usable with the apps).

#### Todos

- [x] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] Wiki Updates

#### Issues Fixed or Closed by this PR

*
