### PR TITLE
Fixed: (Anidub) Read quality and torrent id from the correct nodes

### DIFF
--- a/src/NzbDrone.Core.Test/Files/Indexers/Anidub/frieren-detail.html
+++ b/src/NzbDrone.Core.Test/Files/Indexers/Anidub/frieren-detail.html
@@ -1,0 +1,712 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<title>Провожающая в последний путь Фрирен / Sousou no Frieren [28 из 28] &raquo; AniDUB Tracker Скачать аниме бесплатно на торрент трекер Анидаб</title>
+<meta name="description" content="Король демонов повержен. Миссия отряда поддержки героя наконец-то завершена, участники похода радостно расходятся по домам. Их щедро наградили, и теперь можно беззаботно доживать свой век ря" />
+<meta name="keywords" content="время, героя, Фрирен, смерти, своих, друзей, понимает, старения, свидетелем, наказание, Девушка, становится, превращается, отряде, путешествие, новое, чтобы, найти, ответ, отправляется" />
+<meta name="generator" content="DataLife Engine (http://dle-news.ru)" />
+<meta property="og:site_name" content="AniDUB Tracker Скачать аниме бесплатно на торрент трекер Анидаб" />
+<meta property="og:type" content="article" />
+<meta property="og:title" content="Провожающая в последний путь Фрирен / Sousou no Frieren [28 из 28]" />
+<meta property="og:url" content="https://tr.anidub.com/anime_tv/anime_ongoing/11775-provozhayuschaya-v-posledniy-put-friren-sousou-no-frieren-04-iz-xx.html" />
+<link rel="search" type="application/opensearchdescription+xml" href="https://tr.anidub.com/engine/opensearch.php" title="AniDUB Tracker Скачать аниме бесплатно на торрент трекер Анидаб" />
+<link rel="alternate" type="application/rss+xml" title="AniDUB Tracker Скачать аниме бесплатно на торрент трекер Анидаб" href="https://tr.anidub.com/rss.xml" />
+<script type="text/javascript" src="/engine/classes/js/jquery.js"></script>
+<script type="text/javascript" src="/engine/classes/js/jquery-ui.min.js"></script>
+<script type="text/javascript" src="/engine/classes/js/dle_js.js"></script>
+<script type="text/javascript" src="/engine/classes/masha/masha.js"></script>
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="openstat-verification" content="b5c63e3c0ac502c2cd2d07d20e10e0b8df065ca4" />
+    <link rel="shortcut icon" href="/templates/Anidub/images/favicon.ico">
+    <link rel="stylesheet" href="/templates/Anidub/style/jquery.formstyler.css" type="text/css">
+    <link rel="stylesheet" href="/templates/Anidub/style/style.css?v2310201402" type="text/css">
+	<link rel="stylesheet" href="/templates/Anidub/style/engine.css" type="text/css">
+    <!--[if lt IE 9]>
+    <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
+    <![endif]-->
+    <script type="text/javascript" src="/templates/Anidub/js/plugins.min.js"></script>
+    <script type="text/javascript" src="/templates/Anidub/js/showbizpro.min.js"></script>
+    <script type="text/javascript" src="/templates/Anidub/js/formstyler.min.js"></script>
+    <script type="text/javascript" src="/templates/Anidub/js/scripts.js"></script>
+    <link rel="stylesheet" type="text/css" href="/templates/Anidub/tracker/style/torrent.css" />
+    <script type="text/javascript" src="/templates/Anidub/tracker/js/functions.js"></script>
+    <script type="text/javascript" src="/templates/Anidub/js/jquery.plugin.min.js"></script> 
+    <script type="text/javascript" src="/templates/Anidub/js/jquery.countdown.min.js"></script>
+    <script type="text/javascript" src="/templates/Anidub/js/jquery.countdown-ru.js"></script>
+    <script type="text/javascript" src="/templates/Anidub/js/jquery.jgfeed-min.js"></script>
+    <script type="text/javascript" src="/templates/Anidub/js/isInViewport.min.js"></script>
+</head>
+<body>
+<div id="loading-layer" style="display:none">Загрузка. Пожалуйста, подождите...</div>
+<script type="text/javascript">
+<!--
+var dle_root       = '/';
+var dle_admin      = '';
+var dle_login_hash = '';
+var dle_group      = 5;
+var dle_skin       = 'Anidub';
+var dle_wysiwyg    = '0';
+var quick_wysiwyg  = '0';
+var dle_act_lang   = ["Да", "Нет", "Ввод", "Отмена", "Сохранить", "Удалить"];
+var menu_short     = 'Быстрое редактирование';
+var menu_full      = 'Полное редактирование';
+var menu_profile   = 'Профиль';
+var menu_send      = 'Сообщение';
+var menu_uedit     = 'Админцентр';
+var dle_info       = 'Информация';
+var dle_confirm    = 'Подтверждение';
+var dle_prompt     = 'Ввод информации';
+var dle_req_field  = 'Заполните все необходимые поля';
+var dle_del_agree  = 'Вы действительно хотите удалить? Данное действие невозможно будет отменить';
+var dle_spam_agree = 'Вы действительно хотите отметить пользователя как спамера? Это приведет к удалению всех его комментариев';
+var dle_complaint  = 'Укажите текст вашей жалобы для администрации:';
+var dle_big_text   = 'Выделен слишком большой участок текста.';
+var dle_orfo_title = 'Укажите комментарий для администрации к найденной ошибке на странице';
+var dle_p_send     = 'Отправить';
+var dle_p_send_ok  = 'Уведомление успешно отправлено';
+var dle_save_ok    = 'Изменения успешно сохранены. Обновить страницу?';
+var dle_del_news   = 'Удалить статью';
+var allow_dle_delete_news   = false;
+var dle_search_delay   = false;
+var dle_search_value   = '';
+$(function(){
+	FastSearch();
+});
+//-->
+</script>
+<header>
+    <div id="header_h">
+        <div class="wrap">
+			<ul id="h_flow" class="lcol">
+                <li><a href="/"><span>Главная</span></a></li>
+                    <li class="h_this"><a href="/anime_tv/"><span>АНИМЕ</span></a>
+                    <ul>
+                        <div>
+                        <li><a href="/anime_tv/anime_ongoing/">Онгоинги</a></li>
+                        <li><a href="/anime_tv/shonen/">100+</a></li>
+                        <li><a href="/anime_tv/full/">Законченные</a></li>
+                        <li><a href="/anime_ova/">OVA</a></li>
+                        <li><a href="/anime_movie/">Фильмы</a></li>
+                        </div>
+                    </ul>
+                </li>
+                <li><a href="https://news.anidub.life"><span title="Аниме Новости">Новости</span></a></li>
+                <li><a href="https://anidub.world" target="_blank"><span title="Аниме">АниДаб Онлайн</span></a></li>
+                <li><a href="/dorama/"><span>ДОРАМЫ</span></a></li>
+                <li><a href="/manga/"><span>МАНГА</span></a></li>
+                <li><a href="http://forum.anidub.com"><span title="Аниме Форум">Форум</span></a></li>
+
+                
+            </ul>
+            <div class="header_search rcol">
+                <form action="" name="searchform" method="post">
+					<input type="hidden" name="do" value="search" />
+					<input type="hidden" name="subaction" value="search" />
+                    <input id="story" name="story" placeholder="Введите текст для поиска..." type="text" maxlength="60">
+                    <input value="Поиск" type="submit">
+                </form>
+            </div>
+        </div>
+    </div>
+    <div id="header_c">
+        <div class="wrap">
+        <div class="logo fade"><a href="/" title="AniDub.com - Торрент трекер">AniDub.com - Торрент трекер</a></div>
+            <div class="login rcol">
+                
+
+<div class="is_login">
+                    <div class="lcol">
+                        <form method="post" action="">
+                            <input type="text" name="login_name" id="login_name" />
+                            <div class="clr"></div>
+                            <input type="password" name="login_password" id="login_password" />
+                            <button class="fbutton" onclick="submit();" type="submit" title="Войти">Войти</button>
+							<input name="login" type="hidden" id="login" value="submit" />
+                        </form>
+                    </div>
+                    <div class="rcol">
+                        <a href="https://tr.anidub.com/index.php?do=register">Регистрация</a><br>
+                        <a href="https://tr.anidub.com/index.php?do=lostpassword">Забыли пароль?</a>
+                        <label for="login_not_save">Чужой компьютер</label><input type="checkbox" name="login_not_save" id="login_not_save" value="1"/>
+                    </div>
+                </div>
+
+            </div>
+        </div>
+    </div>
+    <div id="header_b">
+        <div class="wrap">
+            <div class="social">
+                <a href="https://tr.anidub.com/rss.xml" target="_blank" class="fade"></a>
+                <a href="https://www.facebook.com/Anidub" target="_blank" class="fade"></a>
+                <a href="https://vk.com/anidub" target="_blank" class="fade"></a>
+            </div>
+        </div>
+        <!--advert-->
+    </div>
+</header>
+
+<div id="content" class="wrap">
+<aside class="lcol">
+	<div class="block">
+        <div class="block_h">Навигация <span>по сайту</span></div>
+        <div class="block_c">
+            <ul class="navi_c">
+                <li><div><a href="/">Главная страница</a></div></li>
+                <li class="sublink"><div><a href="javascript:;"><span>Аниме ТВ</span></a></div></li>
+                <li class="submenu">
+                    <ul class="submenu">
+                        <li><a href="/anime_tv/anime_ongoing/">Онгоинги</a></li>
+                        <li><a href="/anime_tv/shonen/">100+</a></li>
+                        <li><a href="/anime_tv/full/">Законченные</a></li>
+                    </ul>
+                </li>
+                <li><div><a href="/anime_ova/">Аниме OVA</a></div></li>
+                <li><div><a href="/anime_movie/">Аниме фильмы</a></div></li>
+                <li><div><a href="/dorama/">Дорамы</a></div></li>
+                <li><div><a href="/manga/">Манга</a></div></li>
+				<li><div><a href="/ost/">OST</a></div></li>
+            </ul>
+            <ul class="black">
+				<li><a href="https://tr.anidub.com/rules.html">Правила трекера</a></li>
+                <li><a href="http://forum.anidub.com/forum/112-%D1%82%D1%80%D0%B5%D0%BA%D0%B5%D1%80-anidubcom/" taaget="_blank">Форум трекера</a></li>
+                <li><a href="https://anidub.world" taaget="_blank">АниДаб онлайн</a></li>
+                <li><a href="https://news.anidub.life/" taaget="_blank">Новости Аниме</a></li>
+                <li><a href="https://vk.com/anidub" taaget="_blank">Мы вконтакте</a></li>
+                <li><a href="https://t.me/anidubofficial" taaget="_blank">Наш Telegram</a></li>
+            </ul>
+            <div class="clr"></div>
+        </div>
+    </div>
+    <div class="banner">
+        
+    </div>
+	<div class="block">
+		<div class="block_h">Наши <span>стримы</span></div>
+        	<div class="block_c friends">
+            		<ul>
+                		<li><a href="http://forum.anidub.com/forum/193-%D1%81%D1%82%D1%80%D0%B8%D0%BC-%D0%B0%D0%BD%D0%BE%D0%BD%D1%81%D1%8B/" target="_blank"><b>Анонсы стримов</b></a></li>
+	            	</ul>
+			<div class="counters">
+                		<!--<span class="fade" style="opacity: 1;"><a rel="nofollow" target="_blank" href="http://goodgame.ru/channel/FooBoo/"><img title="Стрим FooBoo" alt="Стрим FooBoo" src="http://ipic.lv/i1/138ad881/9bb9187b8ba1333.jpg"></a></span>-->
+		                <!--span class="fade" style="opacity: 1;"><a rel="nofollow" target="_blank" href="http://goodgame.ru/channel/Holly_Forve/"><img title="Стрим Holly" alt="Стрим Holly" src="http://ipic.lv/i1/fa45eb38/13e6513662e6b79.jpg"></a></span-->
+        		        <!--<span class="fade" style="opacity: 1;"><a rel="nofollow" target="_blank" href="https://www.twitch.tv/jamclub"><img title="Стрим Jama" alt="Стрим Jama" src="http://ipic.lv/i1/97684bd4/602d86a36bcc699.jpg"></a></span>-->
+        		        <!--span class="fade" style="opacity: 1;"><a rel="nofollow" target="_blank" href="http://goodgame.ru/channel/sadzurami/"><img title="Стрим Zadzurami" alt="Стрим Sadzurami" src="http://ipic.lv/i3/b9301225/452d1f48b182882.jpg"></a></span-->
+	        	</div>
+        	</div>
+    	</div>
+    <div class="vk_block">
+        <script type="text/javascript" src="//vk.com/js/api/openapi.js?101"></script>
+
+<!-- VK Widget -->
+<div id="vk_groups"></div>
+<script type="text/javascript">
+VK.Widgets.Group("vk_groups", {mode: 0, width: "240", height: "400", color1: 'FFFFFF', color2: '3b5167', color3: 'e84c3d'}, 4493128);
+</script>
+    </div>
+    <div class="block">
+        <div class="block_h">Случайный <span>релиз</span></div>
+        <div class="block_c">
+			<div class="rand">
+    <span class="title">
+        <span class="rcol">
+            <sup>рейтинг</sup>
+            <sub>4,3 из 5</sub>
+        </span>
+        <a href="https://tr.anidub.com/anime_ova/anime_ona/8918-perekrestok-cross-road.html"><span class="lcols">Перепутье / Cross Road</span></a>
+    </span>
+    
+     <span class="image">
+        <a href="https://tr.anidub.com/anime_ova/anime_ona/8918-perekrestok-cross-road.html">
+            <img src="https://static3.statics.life/online/poster/48214eff23.jpg" alt="Перепутье / Cross Road" />
+        </a>
+         <span class="inf">
+             <b>35639</b>
+             <b><a href="https://tr.anidub.com/anime_ova/anime_ona/8918-perekrestok-cross-road.html#comment">3</a></b>
+             <b>Sheenegarmi</b>
+         </span>
+     </span>
+     
+<a href="https://tr.anidub.com/anime_ova/anime_ona/8918-perekrestok-cross-road.html" class="load">rand</a>
+</div>
+
+            <div class="clr"></div>
+        </div>
+    </div>
+    <div class="block">
+        <div class="block_h">Наши <span>друзья</span></div>
+        <div class="block_c friends">
+            <ul>
+                <!-- <li><a href="#"><b>habrahabr.ru</b> - IT сообщество</a></li>-->
+            </ul>
+            <div class="counters">
+                <span class="fade"><a href="http://amvnews.ru/" target="_blank" rel="nofollow"><img src="https://tr.anidub.com/uploads/banners/amvnews.gif" width="88" height="31" alt="Музыкальные аниме клипы" border="0"></a></span>
+                <span class="fade"> <a href="http://animeonline.su/" target="_blank" rel="nofollow"><img src="https://tr.anidub.com/uploads/banners/animeonline.gif" width="88" height="31" border="0" alt="АнимеОнЛайн.СУ"></a></span>
+                <span class="fade"> <a href="http://nice-media.ru/" target="_blank" rel="nofollow"><img src="https://tr.anidub.com/uploads/banners/nice-media.gif" alt="Nice-Media.ru - перевод и озвучание"></a></span>
+            </div>
+        </div>
+    </div>
+    <div class="banner">
+        
+    </div>
+
+</aside>
+<aside class="rcol">
+	<div class="12">
+        <!-- <div class="block_h">AniDub <span>радио</span></div>
+        <div class="block_c padd">
+            {text}
+            <div class="clr"></div>
+        </div>-->
+            <div class="banner">
+        
+    </div>
+    </div>
+
+	<!-- top20 slider -->
+    <div class="block">
+        <div class="block_h sl_btn">Топ 20 <span>аниме</span>
+            <a href="#" class="prev">prev</a>
+            <a href="#" class="next">next</a>
+        </div>
+        <div class="block_c">
+            <ul class="topnews">
+				<li><a href="https://tr.anidub.com/anime_movie/10763-van-pis-zolotoe-serdce-one-piece-heart-of-gold-movie.html">Ван-Пис: Золотое сердце / One Piece - Heart of Gold <b>(3)</b></a></li><li><a href="https://tr.anidub.com/anime_movie/11429-onepices14.html">Ван-Пис: Паническое бегство / One Piece Stampede <b>(1)</b></a></li><li><a href="https://tr.anidub.com/anime_movie/709-one-piece-movie-1-van-pis-film-pervyy-.html">Ван-Пис (Фильм первый) / One Piece: The Great Gold Pirate <b>(3)</b></a></li><li><a href="https://tr.anidub.com/anime_movie/10445-van-pis-3d2y-perezhit-smert-eysa-obeschanie-luffi-svoim-nakama-one-piece-3d2y-ace-no-shi-wo-koete-luffy-nakama-tono-chikai.html">Ван-Пис 3D2Y: Пережить смерть Эйса! Обещание Луффи своим товарищам / One Piece 3D2Y: Ace no shi wo Koete! Luffy Nakama Tono Chikai <b>(5)</b></a></li><li><a href="https://tr.anidub.com/anime_movie/9340-istoriya-lyubvi-tamako-tamako-love-story.html">История любви Тамако / Tamako Love Story <b>(39)</b></a></li><li><a href="https://tr.anidub.com/anime_movie/751-one-piece-movie-2-van-pis-film-vtoroy-.html">Ван-Пис: Фильм второй / One Piece: Clockwork Island Adventure <b>(6)</b></a></li><li><a href="https://tr.anidub.com/anime_movie/8842-van-pis-film-zet-one-piece-film-z.html">Ван Пис Фильм Зет / One Piece Film Z <b>(18)</b></a></li><li><a href="https://tr.anidub.com/anime_movie/6991-one-piece-movie-3-ova-van-pis-film-tretiy-ova-2002-bdrip720p.html">Ван-Пис: Фильм третий / One Piece Movie 3 <b>(7)</b></a></li><li><a href="https://tr.anidub.com/anime_ova/anime_ona/8507-nebesa-astronomicheskiy-klub-starshey-shkoly-ebusagava-ebiten-kouritsu-ebi-sugawa-koukou-tenmonbu-01-iz-10.html">Небеса: Астрономический Клуб Старшей Школы Ебусагава / Ebiten: Kouritsu Ebi Sugawa Koukou Tenmonbu [10 из 10] <b>(7)</b></a></li><li><a href="https://tr.anidub.com/anime_tv/7917-rycari-zodiaka-tv-2-saint-seiya-omega-01-18-iz-26-2012-hdtv.html">Рыцари Зодиака ТВ-2 / Saint Seiya Omega [22 из 51] <b>(2)</b></a></li>
+            </ul>
+            <div class="clr"></div>
+        </div>
+    </div>
+	<!-- top20 slider -->
+	
+
+    <div class="block">
+        <div class="block_h">Последнее <span>из блога</span></div>
+        <div class="block_c">
+            <ul class="topnews_2" id="blog">
+            </ul>
+                <script type="text/javascript">
+                $(function(){
+                    var b="";
+                    function a(d){
+                        var c = "";
+                        if(d == "episodes"){
+                            c = "http://anidub.com/feed/?cat=28";
+                        }
+                        
+                        if(d == "news"){
+                            c = "http://anidub.com/feed/?cat=27";
+                        }
+
+                        $.jGFeed(c,function(e){
+                            if(!e){
+                                return false
+                            }
+                            if(d == "episodes"){
+                                for(var g=0;g<10;g++){
+                                    var h=e.entries[g];
+                                    var f='<li>'+h.categories[0]+': <a href="'+h.link+'" target="_blank">'+h.title+"</a></li>";
+                                    $("ul#blog").append(f);
+                                }
+                            }
+                            if(d == "news"){
+                                for(var g=0;g<5;g++){
+                                    var h=e.entries[g];
+                                    var f='<li><a href="'+h.link+'" target="_blank"><img src="'+h.mediaGroups[0]['contents'][0]['url']+'"/><span>'+h.title+"</span></a></li>";
+                                    $("ul#blognews").append(f);
+                                }
+                            }
+                        },10);
+                    }
+                    a("episodes");
+                    a("news");
+                });
+                </script>
+            <div class="clr"></div>
+        </div>
+    </div>
+    <div class="block">
+        <div class="block_h">Новости <span>аниме и манги</span></div>
+        <div class="block_c">
+            <ul class="topnews_3" id="blognews">
+				
+            </ul>
+            <div class="clr"></div>
+        </div>
+    </div>
+    <div class="banner">
+        
+    </div>
+</aside>
+<section>
+    <div class="speedbar">
+        <span id="dle-speedbar"><span itemscope itemtype="http://data-vocabulary.org/Breadcrumb"><a href="https://tr.anidub.com/" itemprop="url"><span itemprop="title">AniDUB Tracker</span></a></span> &raquo; <span itemscope itemtype="http://data-vocabulary.org/Breadcrumb"><a href="https://tr.anidub.com/anime_tv/" itemprop="url"><span itemprop="title">Аниме TV</span></a></span> &raquo; <span itemscope itemtype="http://data-vocabulary.org/Breadcrumb"><a href="https://tr.anidub.com/anime_tv/anime_ongoing/" itemprop="url"><span itemprop="title">Аниме Ongoing</span></a></span> &raquo; Провожающая в последний путь Фрирен / Sousou no Frieren [28 из 28]</span>
+    </div>
+	
+	<div id='dle-content'><article class="story full">
+        <div class="story_h">
+            <div class="lcol">
+                <h1><span id="news-title">Провожающая в последний путь Фрирен / Sousou no Frieren [28 из 28]</span></h1>
+                
+                <div class="lcol">
+                    Категория: <a href="https://tr.anidub.com/anime_tv/">Аниме TV</a> &raquo; <a href="https://tr.anidub.com/anime_tv/anime_ongoing/">Аниме Ongoing</a>
+                </div>
+                
+            </div>
+            <div class="rcol">
+                <sup>рейтинг <b>4.6 из 5</b></sup>
+                <div id='ratig-layer-11775'><div class="rating">
+		<ul class="unit-rating">
+		<li class="current-rating" style="width:100%;">100</li>
+		<li><a href="#" title="Плохо" class="r1-unit" onclick="doRate('1', '11775'); return false;">1</a></li>
+		<li><a href="#" title="Приемлемо" class="r2-unit" onclick="doRate('2', '11775'); return false;">2</a></li>
+		<li><a href="#" title="Средне" class="r3-unit" onclick="doRate('3', '11775'); return false;">3</a></li>
+		<li><a href="#" title="Хорошо" class="r4-unit" onclick="doRate('4', '11775'); return false;">4</a></li>
+		<li><a href="#" title="Отлично" class="r5-unit" onclick="doRate('5', '11775'); return false;">5</a></li>
+		</ul>
+</div></div>
+            </div>
+        </div>
+        <ul class="story_inf">
+            <li><b>Добавил:</b> <a onclick="ShowProfile('Diezikiil', 'https://tr.anidub.com/user/Diezikiil/', '0'); return false;" href="https://tr.anidub.com/user/Diezikiil/">Diezikiil</a></li>
+            <li><b>Дата:</b> 24-03-2024, 00:54</li>
+            <li><b>Просмотры:</b> 1294636</li>
+            <li><b>Отзывы:</b> 6</li>
+        </ul>
+        <div class="story_c">
+            <div class="poster_bg ignore-select">
+                <span class="poster"><img src="https://static2.statics.life/tracker/poster/ba468231ef.jpg" alt=""></span>
+                <div class="clr"></div>
+                
+                
+            </div>
+<div class="xfinfodata">
+<b>Год: </b><span><a href="https://tr.anidub.com/xfsearch/2023/">2023</a></span><br>
+<b>Жанр: </b><span itemprop="genre"><a href="https://tr.anidub.com/xfsearch/%D0%94%D1%80%D0%B0%D0%BC%D0%B0/">Драма</a>, <a href="https://tr.anidub.com/xfsearch/%D0%9F%D1%80%D0%B8%D0%BA%D0%BB%D1%8E%D1%87%D0%B5%D0%BD%D0%B8%D1%8F/">Приключения</a>, <a href="https://tr.anidub.com/xfsearch/%D0%A1%D1%91%D0%BD%D0%B5%D0%BD/">Сёнен</a>, <a href="https://tr.anidub.com/xfsearch/%D0%A4%D1%8D%D0%BD%D1%82%D0%B5%D0%B7%D0%B8/">Фэнтези</a></span><br>
+<b>Страна: </b><span>Япония</span><br>
+<b>Количество серий: </b><span>17</span><br>
+
+
+
+<b itemprop="director" itemscope itemtype="http://schema.org/Person">Режиссер: </b><span itemprop="name"><a href="https://tr.anidub.com/xfsearch/%D0%9A%D1%8D%D0%B9%D0%B8%D1%82%D0%B8%D1%80%D0%BE+%D0%A1%D0%B0%D0%B9%D1%82%D0%BE/">Кэйитиро Сайто</a></span><br>
+
+
+<b>Озвучивание: </b><span><a href="https://tr.anidub.com/xfsearch/%D0%9A%D0%BE%D0%BC%D0%B0%D0%BD%D0%B4%D0%B0+AniDUB/">Команда AniDUB</a>, <a href="https://tr.anidub.com/xfsearch/Odissey/">Odissey</a>, <a href="https://tr.anidub.com/xfsearch/Lilla/">Lilla</a>, <a href="https://tr.anidub.com/xfsearch/Muroi/">Muroi</a></span><br>
+
+<b>Тайминг и работа со звуком: </b><span><a href="https://tr.anidub.com/xfsearch/Kroz/">Kroz</a></span><br>
+<div class="video_info"><b>Студия:</b> <a href="/xfsearch/Madhouse Studios/"><img src="/uploads/company/Madhouse Studios.jpg" title="" alt="Madhouse Studios" style="vertical-align: middle;" /></a></div>
+</div><br>
+            <b>Описание:</b> 
+            Король демонов повержен. Миссия отряда поддержки героя наконец-то завершена, участники похода радостно расходятся по домам. Их щедро наградили, и теперь можно беззаботно доживать свой век рядом с близкими. Грустно только красотке Фрирен, ведь она эльф. Дар долголетия превращается в наказание. Девушка становится свидетелем старения и смерти всех своих друзей. Фрирен понимает, что время, проведенное в отряде героя, – лучшие годы ее жизни. И это время безвозвратно ушло. Но так ли это? Эльфийка отправляется в новое путешествие, чтобы найти ответ.<br/>
+            <div style="text-align:center;"><!--sizestart:4--><span style="font-size:14pt;"><!--/sizestart-->Исправлена 25 серия<!--sizeend--></span><!--/sizeend--></div><br /><!--dle_spoiler Техданные: --><div class="title_spoiler"><a href="javascript:ShowOrHide('sp4fe92d7a63b472689153da61d4b85635')"><img id="image-sp4fe92d7a63b472689153da61d4b85635" style="vertical-align: middle;border: none;" alt="" src="/templates/Anidub/dleimages/spoiler-plus.gif" /></a>&nbsp;<a href="javascript:ShowOrHide('sp4fe92d7a63b472689153da61d4b85635')"><!--spoiler_title-->Техданные:<!--spoiler_title_end--></a></div><div id="sp4fe92d7a63b472689153da61d4b85635" class="text_spoiler" style="display:none;"><!--spoiler_text--><!--colorstart:green--><span style="color:green"><!--/colorstart--><br />Общее<br />Полное имя                               : D:\AniDub\Sousou.no.Frieren.s01e24.HD1080p.WEBRip.Rus.AniDub.com.mp4<br />Формат                                   : MPEG-4<br />Профиль формата                          : Base Media<br />Идентификатор кодека                     : isom (isom/iso2/avc1/mp41)<br />Размер файла                             : 401 Мбайт<br />Продолжительность                        : 25 м. 7 с.<br />Общий поток                              : 2 234 Кбит/сек<br />Программа кодирования                    : Voukoder (DaVinci Resolve)<br /><br />Видео<br />Идентификатор                            : 1<br />Формат                                   : AVC<br />Формат/Информация                        : Advanced Video Codec<br />Профиль формата                          : High@L4<br />Настройки формата                        : CABAC / 4 Ref Frames<br />Параметр CABAC формата                   : Да<br />Параметр RefFrames формата               : 4 кадра<br />Идентификатор кодека                     : avc1<br />Идентификатор кодека/Информация          : Advanced Video Coding<br />Продолжительность                        : 25 м. 7 с.<br />Битрейт                                  : 2 099 Кбит/сек<br />Ширина                                   : 1 920 пикселей<br />Высота                                   : 1 080 пикселей<br />Соотношение сторон                       : 16:9<br />Режим частоты кадров                     : Постоянный<br />Частота кадров                           : 23,976 (24000/1001) кадра/сек<br />Цветовое пространство                    : YUV<br />Субдискретизация насыщенности            : 4:2:0<br />Битовая глубина                          : 8 бит<br />Тип развёртки                            : Прогрессивная<br />Бит/(Пиксели*Кадры)                      : 0.042<br />Размер потока                            : 377 Мбайт (94%)<br />Библиотека кодирования                   : x264 core 164<br />Настройки программы                      : cabac=1 / ref=3 / deblock=1:0:0 / analyse=0x3:0x113 / me=hex / subme=7 / psy=1 / psy_rd=1.00:0.00 / mixed_ref=1 / me_range=16 / chroma_me=1 / trellis=1 / 8x8dct=1 / cqm=0 / deadzone=21,11 / fast_pskip=1 / chroma_qp_offset=-2 / threads=24 / lookahead_threads=4 / sliced_threads=0 / nr=0 / decimate=1 / interlaced=0 / bluray_compat=0 / constrained_intra=0 / bframes=3 / b_pyramid=2 / b_adapt=1 / b_bias=0 / direct=1 / weightb=1 / open_gop=0 / weightp=2 / keyint=250 / keyint_min=23 / scenecut=40 / intra_refresh=0 / rc_lookahead=40 / rc=crf / mbtree=1 / crf=23.0 / qcomp=0.60 / qpmin=0 / qpmax=69 / qpstep=4 / ip_ratio=1.40 / aq=1:1.00<br />Цветовой диапазон                        : Limited<br />Основные цвета                           : BT.709<br />Характеристики трансфера                 : BT.709<br />Коэффициенты матрицы                     : BT.709<br />Codec configuration box                  : avcC<br /><br />Аудио<br />Идентификатор                            : 2<br />Формат                                   : AAC LC<br />Формат/Информация                        : Advanced Audio Codec Low Complexity<br />Идентификатор кодека                     : mp4a-40-2<br />Продолжительность                        : 25 м. 7 с.<br />Продолжительность оригинала              : 25 м. 7 с.<br />Вид битрейта                             : Постоянный<br />Битрейт                                  : 132 Кбит/сек<br />Каналы                                   : 2 канала<br />Channel layout                           : L R<br />Частота                                  : 48,0 КГц<br />Частота кадров                           : 46,875 кадров/сек (1024 SPF)<br />Метод сжатия                             : С потерями<br />Размер потока                            : 23,3 Мбайт (6%)<br />Размер потока оригинала                  : 23,3 Мбайт (6%)<br />Default                                  : Да<br />Alternate group                          : 1<br /><br />Прочее<br />Идентификатор                            : 3<br />Тип                                      : Time code<br />Формат                                   : QuickTime TC<br />Продолжительность                        : 25 м. 7 с.<br />Частота кадров                           : 23,976 (24000/1001) кадра/сек<br />Временной код первого кадра              : 00:00:00:00<br />Time code of last frame                  : 00:25:07:10<br />Временной код, чередующийся              : Да<br />Язык                                     : English<br />Default                                  : Нет<br /><br /><br /><!--spoiler_text_end--></div><!--/dle_spoiler--><!--colorend--></span><!--/colorend-->
+             <div class="clr"></div>
+		
+
+           
+        </div>
+        <div class="story_b clr">
+            <div class="lcol tags">
+                 
+            </div>
+            <div class="rcol soci">
+                <div class="share42init" data-url="https://tr.anidub.com/anime_tv/anime_ongoing/11775-provozhayuschaya-v-posledniy-put-friren-sousou-no-frieren-04-iz-xx.html" data-title="Торрент трекер"></div>
+                <script type="text/javascript" src="/templates/Anidub/js/share42.js"></script>
+            </div>
+        </div>
+    </article>
+	
+    <!-- torrent -->
+    <div id="tabs" class="ignore-select">
+        <div class="static_h">
+            <div class="lcol">Статистика <em>торрента</em></div>
+            <div class="rcol">
+                <span class="tabs_name lcol">Скачать в <b>формате</b></span>
+                <ul class="lcol">
+                    <li><a href="#tv1080" onclick="infoLoader(''); return false;">TV (1080p)</a></li>
+                </ul>
+            </div>
+        </div>
+        <div class="torrent">
+            <div class="torrent_c">
+		<div id="tv1080"><div id='torrent_38377_info'>                    <div class="torrent_h">
+                        <a href="/engine/download.php?id=38377" class=" "><span class="">Скачать торрент!</span></a> <a href="/engine/download.php?id=38377" class=" ">Провожающая в последний путь Фрирен / So...</a>
+                    </div>
+                    
+                    <div class="list down">
+                        Раздают: <span class="li_distribute_m">12</span> <span class="sep"></span> Качают: <span class="li_swing_m">1</span> <span class="sep"></span> Размер: <span class="red">14.46 GB</span> <span class="sep"></span> Скачали: <span class="li_download_m">1133</span>
+                    </div>
+                    <div class="list torrentname">
+                        <span>Имя файла:</span> <span class="red" title="&#091;AniDub&#093;_Sousou.no.Frieren.torrent">&#091;AniDub&#093;_Sousou.no.Frieren.torrent</span>
+                    </div>
+                    <div class="list">
+                        Последняя активность: <span class="red">11 июня 2026 03:06</span>
+                    </div>
+					
+			<div class="list">Управление:
+				<a href="#" onclick="tracker_refresh('38377', '11775', 'info'); return !1;">[обновить]</a>
+				
+				
+				
+				
+			</div>
+			
+                    <!--div class="list">
+                        <a href="#" class="file_list open" onclick="$('#tr_f_8').toggle();return false;"><img style="vertical-align: middle;border: none;" alt="" src="/templates/Anidub/dleimages/spoiler-minus.gif" />&nbsp;Список файлов <b>3</b></a>
+                    </div>
+                    <ul class="li_list_a1" id="tr_f_8" style="display: block;">
+			
+                    </ul-->
+                    
+</div>                
+            </div>
+		
+        </div>
+    </div>
+    <!-- /torrent -->
+	<div class="ads"></div>
+	
+    <div class="static_h">Похожие <em>торренты</em></div>
+    <div class="static_c nopad">
+        <div class="related">
+            <ul>
+                <li><a href="https://tr.anidub.com/anime_tv/anime_ongoing/11766-furi-kuri-granzh-flcl-grunge-01-iz-xx.html">Фури-кури: Гранж / FLCL: Grunge [03 из 03]</a></li><li><a href="https://tr.anidub.com/anime_tv/anime_ongoing/11712-na-samom-dele-ya-samyy-silnyy-jitsu-wa-ore-saikyou-deshita-01-iz-12.html">На самом деле, я самый сильный? / Jitsu wa Ore, Saikyou deshita? [12 из 12]</a></li><li><a href="https://tr.anidub.com/anime_tv/anime_ongoing/11607-reinkarnaciya-silneyshego-ommedzi-eti-monstry-slishkom-slaby-po-sravneniyu-s-moim-ekaem-saikyou-onmyouji-no-isekai-tenseiki-01-iz-12.html">Реинкарнация сильнейшего оммёдзи: Эти монстры слишком слабы по сравнению с  ...</a></li><li><a href="https://tr.anidub.com/anime_tv/full/10161-kak-sozdat-skuchnuyu-geroinyu-tv-2-saenai-heroine-no-sodatekata-tv-2-00-iz-12.html">Как создать скучную героиню ТВ-2 / Saenai Heroine no Sodatekata TV-2 [11 из ...</a></li><li><a href="https://tr.anidub.com/anime_tv/full/8737-istinno-geroyskiy-fayt-2-tv-2-senyuu-2-tv-201-iz-13.html">Истинно геройский файт. 2 / Senyuu. 2 [13 из 13 + SP]</a></li>
+            </ul>
+        </div>
+    </div>
+    <div class="static_h full">Отзывы <em>пользователей</em></div>
+	<!--dlenavigationcomments-->
+	<a name="comment"></a><form method="post" action="" name="dlemasscomments" id="dlemasscomments"><div id="dle-comments-list">
+
+<div id="dle-ajax-comments"></div>
+<div id='comment-id-129165'><div class="comment">
+            <div class="lcol">
+                <div class="avatar"><div><img src="/templates/Anidub/dleimages/noavatar.png" alt=""></div><span class="offline">off</span> 
+                </div>
+
+            </div>
+            <div class="rcols">
+                <ul class="ul_inf lcol">
+                    <li><b>Написал:</b> <a onclick="ShowProfile('%D0%9E%D1%82%D1%82%D0%B0%D1%80', 'https://tr.anidub.com/user/%D0%9E%D1%82%D1%82%D0%B0%D1%80/', '0'); return false;" href="https://tr.anidub.com/user/%D0%9E%D1%82%D1%82%D0%B0%D1%80/">Оттар</a></li>
+                    <li><b>Дата:</b> 13 апреля 2024 10:32</li>
+                </ul>
+                
+                <div class="comment_text clr">
+                    
+                    <div id='comm-id-129165'>1хбет?! Да, такого говноедства я не ожидал...</div>
+                    
+                    <div class="clr"></div>
+                </div>
+                <div class="clr"></div>
+                <span class="answ rcol"> </span>
+            </div>
+        </div></div><div id='comment-id-129082'><div class="comment">
+            <div class="lcol">
+                <div class="avatar"><div><img src="/templates/Anidub/dleimages/noavatar.png" alt=""></div><span class="offline">off</span> 
+                </div>
+
+            </div>
+            <div class="rcols">
+                <ul class="ul_inf lcol">
+                    <li><b>Написал:</b> <a onclick="ShowProfile('dimajack', 'https://tr.anidub.com/user/dimajack/', '0'); return false;" href="https://tr.anidub.com/user/dimajack/">dimajack</a></li>
+                    <li><b>Дата:</b> 2 марта 2024 19:10</li>
+                </ul>
+                
+                <div class="comment_text clr">
+                    
+                    <div id='comm-id-129082'>25 серия не открывается.<br />да и по весу файла ясно, что видимо не до конца залили.</div>
+                    
+                    <div class="clr"></div>
+                </div>
+                <div class="clr"></div>
+                <span class="answ rcol"> </span>
+            </div>
+        </div></div><div id='comment-id-128979'><div class="comment">
+            <div class="lcol">
+                <div class="avatar"><div><img src="/templates/Anidub/dleimages/noavatar.png" alt=""></div><span class="offline">off</span> 
+                </div>
+
+            </div>
+            <div class="rcols">
+                <ul class="ul_inf lcol">
+                    <li><b>Написал:</b> <a onclick="ShowProfile('XaNDeRFreeMaN', 'https://tr.anidub.com/user/XaNDeRFreeMaN/', '0'); return false;" href="https://tr.anidub.com/user/XaNDeRFreeMaN/">XaNDeRFreeMaN</a></li>
+                    <li><b>Дата:</b> 14 января 2024 13:37</li>
+                </ul>
+                
+                <div class="comment_text clr">
+                    
+                    <div id='comm-id-128979'>Добрый день, видимо накосячили с форматами, пришлось конвертером конвертировать в нормальный mp4, можете выкладывать как раньше с параметрами H264, 6000kbps и энкодером AAC пж?)))<br />Просто использую Plex и со старыми раздачами таких проблем нет, а в данной раздаче все не по плану идет)</div>
+                    
+                    <div class="clr"></div>
+                </div>
+                <div class="clr"></div>
+                <span class="answ rcol"> </span>
+            </div>
+        </div></div><div id='comment-id-128940'><div class="comment">
+            <div class="lcol">
+                <div class="avatar"><div><img src="/templates/Anidub/dleimages/noavatar.png" alt=""></div><span class="offline">off</span> 
+                </div>
+
+            </div>
+            <div class="rcols">
+                <ul class="ul_inf lcol">
+                    <li><b>Написал:</b> <a onclick="ShowProfile('The_DnK', 'https://tr.anidub.com/user/The_DnK/', '0'); return false;" href="https://tr.anidub.com/user/The_DnK/">The_DnK</a></li>
+                    <li><b>Дата:</b> 6 января 2024 06:25</li>
+                </ul>
+                
+                <div class="comment_text clr">
+                    
+                    <div id='comm-id-128940'>А кто уркал кнопку &quot;скачать торрент&quot;?</div>
+                    
+                    <div class="clr"></div>
+                </div>
+                <div class="clr"></div>
+                <span class="answ rcol"> </span>
+            </div>
+        </div></div><div id='comment-id-128782'><div class="comment">
+            <div class="lcol">
+                <div class="avatar"><div><img src="/templates/Anidub/dleimages/noavatar.png" alt=""></div><span class="offline">off</span> 
+                </div>
+
+            </div>
+            <div class="rcols">
+                <ul class="ul_inf lcol">
+                    <li><b>Написал:</b> <a onclick="ShowProfile('kostian76', 'https://tr.anidub.com/user/kostian76/', '0'); return false;" href="https://tr.anidub.com/user/kostian76/">kostian76</a></li>
+                    <li><b>Дата:</b> 7 октября 2023 19:06</li>
+                </ul>
+                
+                <div class="comment_text clr">
+                    
+                    <div id='comm-id-128782'>А почему сходу выложили 4 серии</div>
+                    
+                    <div class="clr"></div>
+                </div>
+                <div class="clr"></div>
+                <span class="answ rcol"> </span>
+            </div>
+        </div></div><div id='comment-id-128757'><div class="comment">
+            <div class="lcol">
+                <div class="avatar"><div><img src="https://tr.anidub.com/uploads/fotos/foto_137058.jpg" alt=""></div><span class="offline">off</span> 
+                </div>
+
+            </div>
+            <div class="rcols">
+                <ul class="ul_inf lcol">
+                    <li><b>Написал:</b> <a onclick="ShowProfile('Lookings', 'https://tr.anidub.com/user/Lookings/', '0'); return false;" href="https://tr.anidub.com/user/Lookings/">Lookings</a></li>
+                    <li><b>Дата:</b> 1 октября 2023 03:22</li>
+                </ul>
+                
+                <div class="comment_text clr">
+                    
+                    <div id='comm-id-128757'>По моему шикарное аниме. Напоминает &quot;Мастер муши&quot;. Но требует понимания, и некоторого погружения. Много символичного, и есть &quot;английский&quot; юмор в японском понимании мироздания. В общем буду не только смотреть, но и пересматривать этот бриллиант. Не знаю как-кому, а мне очень понравилось не только построение видео ряда, но и гениальная озвучка. За умение положить простыми штрихами текст на сюжет так, что кажется что так и должно быть, и иначе не было, и быть иначе не может и не должно - за всё это обожаю озвучку анидаба.</div>
+                    
+                    <div class="clr"></div>
+                </div>
+                <div class="clr"></div>
+                <span class="answ rcol"> </span>
+            </div>
+        </div></div></div></form>
+
+	<!--dlenavigationcomments-->
+    <div class="berror">
+        <div class="berror_c">
+            <b>Ошибка!</b><br>
+            Уважаемый посетитель, Вы зашли на сайт как незарегистрированный пользователь.<br>
+            Мы рекомендуем Вам <a href="#">зарегистрироваться</a> либо войти на сайт под своим именем.
+        </div>
+    </div>
+    <!--dleaddcomments-->
+<div class="berror">
+        <div class="berror_c">
+            <b>Информация</b><br />
+	Посетители, находящиеся в группе <b>Гости</b>, не могут оставлять комментарии к данной публикации.
+        </div>
+    </div></div>
+    <div class="clr"></div>
+</section>
+    <div class="clr"></div>
+</div>
+<footer>
+    <div class="footer_h wrap">
+        <nav>
+            <a href="/" class="fade">Главная</a>
+            <a href="https://news.anidub.life/" target="_blank" class="fade">Блог</a>
+            <a href="http://forum.anidub.com/forum/112-%D1%82%D1%80%D0%B5%D0%BA%D0%B5%D1%80-anidubcom/" target="_blank" class="fade">Форум</a>
+            <a href="/index.php?do=feedback" class="fade">Контакты</a>
+            <a href="/manga/" class="fade">Манга</a>
+            <a href="/dorama/" class="fade">Дорамы</a>
+            <a href="https://anidub.world" target="_blank" class="fade">АниДаб онлайн</a>
+        </nav>
+        <a href="#top" class="fade top" title="Подняться наверх">наверх</a>
+    </div>
+    <div class="footer_b wrap">
+        <div class="logo fade"><a href="/" title="AniDub.com - Торрент трекер">AniDub.com - Торрент трекер</a></div>
+        <div class="footer_text lcol">
+            <p><a href="/">Ani<span>Dub</span>.com</a> Copyright © 2009-2025, All rights reserved</p>
+            <p><span><a href="/for-rights-holders.html" style="color: red;font-weight: bold;font-size: 14px;margin-left: 5px;">Для правообладателей</a></span></p>
+            Файлы для обмена предоставлены пользователями сайта.<br>
+            Администрация не несёт ответственности за их содержание.
+        </div>
+        <div class="footer_count rcol">
+            <span class="fade">
+				<!--Openstat-->
+				<span id="openstat1119433"></span>
+				<script type="text/javascript">
+				var openstat = { counter: 1119433, image: 5081, color: "458efc", next: openstat };
+				(function(d, t, p) {
+				var j = d.createElement(t); j.async = true; j.type = "text/javascript";
+				j.src = ("https:" == p ? "https:" : "http:") + "//openstat.net/cnt.js";
+				var s = d.getElementsByTagName(t)[0]; s.parentNode.insertBefore(j, s);
+				})(document, "script", document.location.protocol);
+				</script>
+				<!--/Openstat-->
+			</span>
+
+			<span class="fade">
+			<!--LiveInternet counter--><script type="text/javascript"><!--
+				document.write("<a href='https://www.liveinternet.ru/click' "+
+				"target=_blank><img src='//counter.yadro.ru/hit?t11.6;r"+
+				escape(document.referrer)+((typeof(screen)=="undefined")?"":
+				";s"+screen.width+"*"+screen.height+"*"+(screen.colorDepth?
+				screen.colorDepth:screen.pixelDepth))+";u"+escape(document.URL)+
+				";h"+escape(document.title.substring(0,80))+";"+Math.random()+
+				"' alt='' title='LiveInternet: показано число просмотров за 24"+
+				" часа, посетителей за 24 часа и за сегодня' "+
+				"border='0' width='88' height='31'><\/a>")
+				//--></script><!--/LiveInternet-->
+			</span>
+        </div>
+        <div class="dcorearts fade"><a href="http://dcorearts.com/" target="_blank" title="DCOReARTs.COM - Студия web - дизайна и графики">DCOReARTs.COM - Студия web - дизайна и графики</a></div>
+    </div>
+</footer>
+                        <!-- Yandex.Metrika counter -->
+                    <script src="//mc.yandex.ru/metrika/watch.js" type="text/javascript"></script>
+                    <script type="text/javascript">
+                    try { var yaCounter1315615 = new Ya.Metrika({id:1315615,
+                              webvisor:true,
+                              clickmap:true,
+                              trackLinks:true,
+                              accurateTrackBounce:true,
+                              ut:"noindex"});
+                    } catch(e) { }
+                    </script>
+                    <noscript><div><img src="//mc.yandex.ru/watch/1315615?ut=noindex" style="position:absolute; left:-9999px;" alt="" /></div></noscript>
+                    <!-- /Yandex.Metrika counter -->
+
+
+
+
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-16411581-2"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'UA-16411581-2');
+</script>
+
+
+
+</body>
+</html>
+<!-- DataLife Engine Copyright SoftNews Media Group (http://dle-news.ru) -->

--- a/src/NzbDrone.Core.Test/IndexerTests/AnidubTests/AnidubParserFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/AnidubTests/AnidubParserFixture.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Linq;
+using System.Net;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using NzbDrone.Common.Http;
+using NzbDrone.Core.Indexers;
+using NzbDrone.Core.Indexers.Definitions;
+using NzbDrone.Core.Indexers.Settings;
+using NzbDrone.Core.Parser.Model;
+using NzbDrone.Core.Test.Framework;
+
+namespace NzbDrone.Core.Test.IndexerTests.AnidubTests
+{
+    [TestFixture]
+    public class AnidubParserFixture : CoreTest<Anidub>
+    {
+        private const string SearchPageHtml = @"<html><body><div class=""searchitem"">
+            <h3><a href=""https://tr.anidub.com/anime_tv/anime_ongoing/11775-provozhayuschaya-v-posledniy-put-friren-sousou-no-frieren-04-iz-xx.html"">Провожающая в последний путь Фрирен / Sousou no Frieren [28 из 28]</a></h3>
+            </div></body></html>";
+
+        private AnidubParser _parser;
+
+        [SetUp]
+        public void Setup()
+        {
+            var settings = new UserPassTorrentBaseSettings { BaseUrl = "https://tr.anidub.com/" };
+
+            var categories = new IndexerCapabilitiesCategories();
+            categories.AddCategoryMapping(2, NewznabStandardCategory.TVAnime, "Аниме TV");
+            categories.AddCategoryMapping(10, NewznabStandardCategory.TVAnime, "Аниме TV / Аниме Ongoing");
+
+            var detailPage = ReadAllText(@"Files/Indexers/Anidub/frieren-detail.html");
+
+            Mocker.GetMock<IIndexerHttpClient>()
+                .Setup(o => o.ExecuteProxied(It.IsAny<HttpRequest>(), It.IsAny<NzbDrone.Core.ThingiProvider.ProviderDefinition>()))
+                .Returns<HttpRequest, NzbDrone.Core.ThingiProvider.ProviderDefinition>((r, d) => new HttpResponse(r, new HttpHeader(), new CookieCollection(), detailPage));
+
+            _parser = new AnidubParser(new IndexerDefinition { Name = "Anidub" }, settings, categories, TimeSpan.Zero, Mocker.GetMock<IIndexerHttpClient>().Object, NLog.LogManager.GetLogger("test"));
+        }
+
+        [Test]
+        public void should_parse_quality_and_torrent_id_from_release_page()
+        {
+            var searchRequest = new IndexerRequest("https://tr.anidub.com/index.php?do=search", HttpAccept.Html);
+            var searchResponse = new IndexerResponse(searchRequest, new HttpResponse(searchRequest.HttpRequest, new HttpHeader(), new CookieCollection(), SearchPageHtml));
+
+            var releases = _parser.ParseResponse(searchResponse);
+
+            releases.Should().HaveCount(1);
+
+            var release = releases.Single() as TorrentInfo;
+
+            release.Title.Should().Be("Провожающая в последний путь Фрирен / Sousou no Frieren [28 из 28] [HDTV 1080p]");
+            release.DownloadUrl.Should().Be("https://tr.anidub.com/engine/download.php?id=38377");
+            release.Resolution.Should().Be("HDTV 1080p");
+            release.Seeders.Should().Be(12);
+        }
+    }
+}

--- a/src/NzbDrone.Core/Indexers/Definitions/Anidub.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Anidub.cs
@@ -286,7 +286,7 @@ namespace NzbDrone.Core.Indexers.Definitions
         {
             var domTitle = content.QuerySelector("#news-title");
             var baseTitle = domTitle.TextContent.Trim();
-            var quality = GetQuality(tabNode.ParentElement);
+            var quality = GetQuality(tabNode);
 
             if (!string.IsNullOrWhiteSpace(quality))
             {
@@ -298,8 +298,9 @@ namespace NzbDrone.Core.Indexers.Definitions
 
         private static string GetQuality(AngleSharp.Dom.IElement releaseNode)
         {
-            // For some releases there's no block with quality
-            if (string.IsNullOrWhiteSpace(releaseNode.Id))
+            // For some releases there's no block with quality, and single-quality
+            // releases place the torrent info node directly under the tab container
+            if (string.IsNullOrWhiteSpace(releaseNode.Id) || releaseNode.Id.StartsWith("torrent_"))
             {
                 return null;
             }
@@ -414,12 +415,25 @@ namespace NzbDrone.Core.Indexers.Definitions
 
         private static string GetTorrentId(AngleSharp.Dom.IElement tabNode)
         {
-            var nodeId = tabNode.Id;
+            // Quality tabs ("tv1080", "bd720", ...) wrap the torrent info node,
+            // single-quality releases place it directly under the tab container
+            var infoNode = GetTorrentInfoNode(tabNode);
+            var nodeId = infoNode.Id ?? string.Empty;
 
             // Format is "torrent_{id}_info"
             return nodeId
                 .Replace("torrent_", string.Empty)
                 .Replace("_info", string.Empty);
+        }
+
+        private static AngleSharp.Dom.IElement GetTorrentInfoNode(AngleSharp.Dom.IElement tabNode)
+        {
+            if (tabNode.Id?.StartsWith("torrent_") == true)
+            {
+                return tabNode;
+            }
+
+            return tabNode.QuerySelector("div[id^='torrent_'][id$='_info']") ?? tabNode;
         }
 
         private ICollection<IndexerCategory> ParseCategories(string uriPath)


### PR DESCRIPTION
#### Database Migration

NO

#### Description

The Anidub release page nests the torrent info node inside a per-quality tab:

```html
<div id="tabs"><div class="torrent_c">
  <div id="tv1080">                 <!-- quality tab -->
    <div id="torrent_38377_info">   <!-- torrent info -->
```

The parser iterates `#tabs .torrent_c > div` (the quality tabs) but:

- read the quality from the tab's **parent** (`.torrent_c`, which has no id) — so release titles never carried a quality token and Sonarr/Radarr parsed every Anidub release as **Unknown quality** (rejected by most quality profiles);
- built the download link from the **tab id itself**, producing `engine/download.php?id=tv1080` which returns an error page instead of the `.torrent` file — downloads were broken (verified live: HTTP 500 with an error body).

This reads the quality from the tab node and resolves the torrent id from the nested `torrent_{id}_info` node, falling back to the tab node itself for single-quality layouts (where the info node sits directly under `.torrent_c`).

Covered by `AnidubParserFixture` running the full parse against a captured release page: asserts the `[HDTV 1080p]` title suffix, `engine/download.php?id=38377` download link, resolution, and seeders.

Related Anidub fixes (independent): #2699, #2703.

#### Todos

- [x] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] Wiki Updates

#### Issues Fixed or Closed by this PR

*
