### PR TITLE
Fixed: FlareSolverr fallback to solved response when origin blocks replay

### DIFF
--- a/src/NzbDrone.Core/IndexerProxies/FlareSolverr/FlareSolverr.cs
+++ b/src/NzbDrone.Core/IndexerProxies/FlareSolverr/FlareSolverr.cs
@@ -74,6 +74,27 @@ namespace NzbDrone.Core.IndexerProxies.FlareSolverr
             //Request again with User-Agent and Cookies from Flaresolverr
             var finalResponse = _httpClient.Execute(newRequest);
 
+            // Some sites block Prowlarr's header-stripped replay at the origin (e.g. an nginx
+            // 403) even after Cloudflare has been passed with the cf_clearance cookie. When that
+            // happens, fall back to the page HTML that FlareSolverr already retrieved with a real
+            // browser so Cardigann can still parse the response instead of failing.
+            if ((int)finalResponse.StatusCode >= 400 &&
+                result.Status.IsNotNullOrWhiteSpace() &&
+                result.Status.Equals("ok", StringComparison.OrdinalIgnoreCase) &&
+                result.Solution?.Response.IsNotNullOrWhiteSpace() == true)
+            {
+                _logger.Debug("Replayed request to {0} returned {1}; falling back to FlareSolverr solved HTML", newRequest.Url, finalResponse.StatusCode);
+
+                var headers = new HttpHeader
+                {
+                    ContentType = result.Solution.Headers?.ContentType.IsNotNullOrWhiteSpace() == true
+                        ? result.Solution.Headers.ContentType
+                        : "text/html"
+                };
+
+                return new HttpResponse(newRequest, headers, finalResponse.Cookies, result.Solution.Response, statusCode: HttpStatusCode.OK);
+            }
+
             return finalResponse;
         }
 


### PR DESCRIPTION
## Description

When an indexer is behind Cloudflare, the FlareSolverr indexer proxy (`PostResponse`) re-executes the **original** request directly, injecting only the `cf_clearance` cookie and `User-Agent` returned by FlareSolverr. FlareSolverr's already-solved page HTML (`solution.response`) is discarded.

Some origins reject this header-stripped .NET replay with a **403** even though the Cloudflare edge has already been passed with the valid `cf_clearance` cookie. The result is a hard failure in Cardigann:

```
Warn|Cardigann|HTTP Error - Res: HTTP/2.0 [GET] https://<indexer>/...: 403.Forbidden (1052 bytes)
NzbDrone.Core.Indexers.Exceptions.IndexerException: Unexpected response status Forbidden code from indexer request
```

The 403 body is a plain `nginx` error page (with a Cloudflare RUM beacon injected), confirming the request passed Cloudflare but was blocked by the **origin** server because the replay lacks a full browser's header set / fingerprint.

## Fix

When the replayed request returns an error status (`>= 400`) **and** FlareSolverr returned a valid solved page (`status == "ok"` with a non-empty `solution.response`), fall back to that HTML instead of surfacing the origin error. This lets Cardigann parse the page FlareSolverr already retrieved with a real browser.

The guard is intentionally narrow so genuine failures (no solution, empty body) still surface unchanged.

## Tests

Added `FlareSolverrFixture` (`src/NzbDrone.Core.Test/IndexerProxyTests`) covering:

- Fallback to solved HTML when the replay is blocked at the origin (403)
- Replay response returned unchanged when it succeeds (200)
- No fallback when the solved response body is empty (origin error surfaces)
- Original response returned untouched when the site is not Cloudflare-protected (no FlareSolverr call)

All four pass locally.

## How it was tested

- Reproduced against a KickassTorrents mirror that consistently returned `403 Forbidden` after a successful FlareSolverr solve.
- Built `Prowlarr.Core.dll` from this branch, swapped it into a running v2.4.0.5397 install, and confirmed the indexer **Test** now succeeds and torrents parse.
- FlareSolverr debug logs confirmed the challenge was solved and `solution.response` was present in both the failing and fixed runs.

## Notes

- No behaviour change when the replay succeeds, or when FlareSolverr did not return a usable solved page.