### PR TITLE
Fix: Cardigann dateparse assumes local TZ for timezone-less timestamps

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/DateTimeUtilFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/DateTimeUtilFixture.cs
@@ -39,5 +39,36 @@ namespace NzbDrone.Core.Test.ParserTests
                 .ToString(standardFormat, CultureInfo.InvariantCulture)
                 .Should().Be(expectedDate);
         }
+
+        [TestCase("2026-06-03 01:01:21", "yyyy-MM-dd HH:mm:ss")]
+        [TestCase("2022-08-08 02:07:39", "yyyy-MM-dd HH:mm:ss")]
+        [TestCase("2022-01-15 12:30:45", "yyyy-MM-dd HH:mm:ss")]
+        public void parse_datetime_golang_timezone_less_should_assume_utc(string dateInput, string format)
+        {
+            var result = DateTimeUtil.ParseDateTimeGoLang(dateInput, format);
+
+            result.Kind.Should().Be(DateTimeKind.Utc);
+            result.Year.Should().Be(int.Parse(dateInput.AsSpan(0, 4)));
+            result.Month.Should().Be(int.Parse(dateInput.AsSpan(5, 2)));
+            result.Day.Should().Be(int.Parse(dateInput.AsSpan(8, 2)));
+        }
+
+        [TestCase("2026-06-03 01:01:21", "2006-01-02 15:04:05")]
+        [TestCase("2022-08-08 02:07:39", "2006-01-02 15:04:05")]
+        public void parse_datetime_golang_golang_format_timezone_less_should_assume_utc(string dateInput, string format)
+        {
+            var result = DateTimeUtil.ParseDateTimeGoLang(dateInput, format);
+
+            result.Kind.Should().Be(DateTimeKind.Utc);
+        }
+
+        [TestCase("2022-08-08 02:07:39 -02:00", "yyyy-MM-dd HH:mm:ss zzz")]
+        [TestCase("2022-08-08 02:07:39 -02:00", "2006-01-02 15:04:05 -07:00")]
+        public void parse_datetime_golang_timezone_aware_should_not_assume_utc(string dateInput, string format)
+        {
+            var result = DateTimeUtil.ParseDateTimeGoLang(dateInput, format);
+
+            result.Kind.Should().NotBe(DateTimeKind.Unspecified);
+        }
     }
 }

--- a/src/NzbDrone.Core/Parser/DateTimeUtil.cs
+++ b/src/NzbDrone.Core/Parser/DateTimeUtil.cs
@@ -261,6 +261,11 @@ namespace NzbDrone.Core.Parser
 
             if (commonStandardFormats.Any(layout.ContainsIgnoreCase) && DateTime.TryParseExact(date, layout, CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsedDate))
             {
+                if (parsedDate.Kind == DateTimeKind.Unspecified)
+                {
+                    return DateTime.SpecifyKind(parsedDate, DateTimeKind.Utc);
+                }
+
                 return parsedDate;
             }
 
@@ -318,7 +323,14 @@ namespace NzbDrone.Core.Parser
 
             try
             {
-                return DateTime.ParseExact(date, format, CultureInfo.InvariantCulture);
+                var parsedDate = DateTime.ParseExact(date, format, CultureInfo.InvariantCulture);
+
+                if (parsedDate.Kind == DateTimeKind.Unspecified)
+                {
+                    return DateTime.SpecifyKind(parsedDate, DateTimeKind.Utc);
+                }
+
+                return parsedDate;
             }
             catch (FormatException ex)
             {

--- a/src/NzbDrone.Core/Parser/DateTimeUtil.cs
+++ b/src/NzbDrone.Core/Parser/DateTimeUtil.cs
@@ -323,14 +323,14 @@ namespace NzbDrone.Core.Parser
 
             try
             {
-                var parsedDate = DateTime.ParseExact(date, format, CultureInfo.InvariantCulture);
+                var result = DateTime.ParseExact(date, format, CultureInfo.InvariantCulture);
 
-                if (parsedDate.Kind == DateTimeKind.Unspecified)
+                if (result.Kind == DateTimeKind.Unspecified)
                 {
-                    return DateTime.SpecifyKind(parsedDate, DateTimeKind.Utc);
+                    return DateTime.SpecifyKind(result, DateTimeKind.Utc);
                 }
 
-                return parsedDate;
+                return result;
             }
             catch (FormatException ex)
             {

--- a/src/NzbDrone.Core/Parser/DateTimeUtil.cs
+++ b/src/NzbDrone.Core/Parser/DateTimeUtil.cs
@@ -323,14 +323,14 @@ namespace NzbDrone.Core.Parser
 
             try
             {
-                var result = DateTime.ParseExact(date, format, CultureInfo.InvariantCulture);
+                var dt = DateTime.ParseExact(date, format, CultureInfo.InvariantCulture);
 
-                if (result.Kind == DateTimeKind.Unspecified)
+                if (dt.Kind == DateTimeKind.Unspecified)
                 {
-                    return DateTime.SpecifyKind(result, DateTimeKind.Utc);
+                    return DateTime.SpecifyKind(dt, DateTimeKind.Utc);
                 }
 
-                return result;
+                return dt;
             }
             catch (FormatException ex)
             {


### PR DESCRIPTION
#### Database Migration

NO

#### Description

When a Cardigann YML definition uses the `dateparse` filter with a timezone-less format (e.g. `yyyy-MM-dd HH:mm:ss`), `ParseDateTimeGoLang` returns a `DateTime` with `DateTimeKind.Unspecified`. The filter chain then formats this with `Rfc1123ZPattern` which includes the `z` (UTC offset) specifier. For `Unspecified` `DateTime` values, .NET treats them as `Local` and uses the **system/container timezone offset**, corrupting dates whenever the container TZ differs from UTC.

**Concrete example:** TorrentLeech sends `addedTimestamp` in UTC as `2026-06-03 01:01:21` (format: `yyyy-MM-dd HH:mm:ss`, no timezone). With a non-UTC container TZ (e.g. `US/Pacific`, UTC-7), the `dateparse` filter produces a shifted offset in the output string, making the effective UTC time off by the container's UTC offset. This causes downstream consumers (e.g. Sonarr delay profiles) to see an incorrect release age.

**Root Cause:** `ParseDateTimeGoLang` uses `DateTimeStyles.None` for both its fast path (`TryParseExact`) and slow path (`ParseExact`). When the format lacks timezone specifiers, this produces `DateTimeKind.Unspecified`.

**Fix:** After parsing, if the resulting `DateTime` has `DateTimeKind.Unspecified`, assume UTC via `DateTime.SpecifyKind`. This aligns with the existing codebase convention — for example `AnimeBytes.cs:388` uses `DateTimeStyles.AssumeUniversal` for the same timezone-less format:

```csharp
torrent.UploadTime = DateTime.ParseExact(row.upload_time, "yyyy-MM-dd HH:mm:ss",
    CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal);
```

Timezone-aware formats (`-07:00`, `Z07:00`, `zzz`, etc.) already produce `Local` or `Utc` `DateTimeKind` and are unaffected.

#### Todos

- [x] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] Wiki Updates
