### PR TITLE
[Toloka] Add "Add UKR to Title" option

### DIFF
--- a/src/NzbDrone.Core.Test/IndexerTests/TolokaTests/TolokaTitleParserFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/TolokaTests/TolokaTitleParserFixture.cs
@@ -41,5 +41,14 @@ namespace NzbDrone.Core.Test.IndexerTests.TolokaTests
             result.Should().EndWith("UKR");
             result.Should().Contain("Castlevania");
         }
+
+        [Test]
+        public void should_not_append_ukr_when_already_present()
+        {
+            var result = _parser.Parse("Castlevania S03E01 1080p WEB-DL UKR", new List<IndexerCategory>(), addUkrainianToTitle: true);
+
+            result.Should().EndWith("UKR");
+            result.Should().NotContain("UKR UKR");
+        }
     }
 }

--- a/src/NzbDrone.Core.Test/IndexerTests/TolokaTests/TolokaTitleParserFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/TolokaTests/TolokaTitleParserFixture.cs
@@ -17,38 +17,14 @@ namespace NzbDrone.Core.Test.IndexerTests.TolokaTests
             _parser = new TolokaTitleParser();
         }
 
-        [Test]
-        public void should_not_append_ukr_when_disabled()
+        [TestCase("Castlevania S03E01 1080p WEB-DL", false, "Castlevania S03E01 1080p WEB-DL")]
+        [TestCase("Castlevania S03E01 1080p WEB-DL", true, "Castlevania S03E01 1080p WEB-DL UKR")]
+        [TestCase("Castlevania S03E01 1080p WEB-DL UKR", true, "Castlevania S03E01 1080p WEB-DL UKR")]
+        public void should_parse_title_with_ukr_option(string title, bool addUkrainianToTitle, string expected)
         {
-            var result = _parser.Parse("Castlevania S03E01 1080p WEB-DL", new List<IndexerCategory>(), addUkrainianToTitle: false);
+            var result = _parser.Parse(title, new List<IndexerCategory>(), addUkrainianToTitle: addUkrainianToTitle);
 
-            result.Should().NotEndWith("UKR");
-        }
-
-        [Test]
-        public void should_append_ukr_when_enabled()
-        {
-            var result = _parser.Parse("Castlevania S03E01 1080p WEB-DL", new List<IndexerCategory>(), addUkrainianToTitle: true);
-
-            result.Should().EndWith("UKR");
-        }
-
-        [Test]
-        public void should_append_ukr_after_cyrillic_stripping()
-        {
-            var result = _parser.Parse("Замок Кастлеванія / Castlevania S03E01 1080p WEB-DL", new List<IndexerCategory>(), stripCyrillicLetters: true, addUkrainianToTitle: true);
-
-            result.Should().EndWith("UKR");
-            result.Should().Contain("Castlevania");
-        }
-
-        [Test]
-        public void should_not_append_ukr_when_already_present()
-        {
-            var result = _parser.Parse("Castlevania S03E01 1080p WEB-DL UKR", new List<IndexerCategory>(), addUkrainianToTitle: true);
-
-            result.Should().EndWith("UKR");
-            result.Should().NotContain("UKR UKR");
+            result.Should().Be(expected);
         }
     }
 }

--- a/src/NzbDrone.Core.Test/IndexerTests/TolokaTests/TolokaTitleParserFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/TolokaTests/TolokaTitleParserFixture.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.Indexers.Definitions;
+using NzbDrone.Core.Parser.Model;
+
+namespace NzbDrone.Core.Test.IndexerTests.TolokaTests
+{
+    [TestFixture]
+    public class TolokaTitleParserFixture
+    {
+        private TolokaTitleParser _parser;
+
+        [SetUp]
+        public void Setup()
+        {
+            _parser = new TolokaTitleParser();
+        }
+
+        [Test]
+        public void should_not_append_ukr_when_disabled()
+        {
+            var result = _parser.Parse("Castlevania S03E01 1080p WEB-DL", new List<IndexerCategory>(), addUkrainianToTitle: false);
+
+            result.Should().NotEndWith("UKR");
+        }
+
+        [Test]
+        public void should_append_ukr_when_enabled()
+        {
+            var result = _parser.Parse("Castlevania S03E01 1080p WEB-DL", new List<IndexerCategory>(), addUkrainianToTitle: true);
+
+            result.Should().EndWith("UKR");
+        }
+
+        [Test]
+        public void should_append_ukr_after_cyrillic_stripping()
+        {
+            var result = _parser.Parse("Замок Кастлеванія / Castlevania S03E01 1080p WEB-DL", new List<IndexerCategory>(), stripCyrillicLetters: true, addUkrainianToTitle: true);
+
+            result.Should().EndWith("UKR");
+            result.Should().Contain("Castlevania");
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/IndexerTests/TolokaTests/TolokaTitleParserFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/TolokaTests/TolokaTitleParserFixture.cs
@@ -1,8 +1,8 @@
 using System.Collections.Generic;
 using FluentAssertions;
 using NUnit.Framework;
+using NzbDrone.Core.Indexers;
 using NzbDrone.Core.Indexers.Definitions;
-using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.Test.IndexerTests.TolokaTests
 {

--- a/src/NzbDrone.Core.Test/IndexerTests/TolokaTests/TolokaTitleParserFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/TolokaTests/TolokaTitleParserFixture.cs
@@ -20,9 +20,19 @@ namespace NzbDrone.Core.Test.IndexerTests.TolokaTests
         [TestCase("Castlevania S03E01 1080p WEB-DL", false, "Castlevania S03E01 1080p WEB-DL")]
         [TestCase("Castlevania S03E01 1080p WEB-DL", true, "Castlevania S03E01 1080p WEB-DL UKR")]
         [TestCase("Castlevania S03E01 1080p WEB-DL UKR", true, "Castlevania S03E01 1080p WEB-DL UKR")]
-        public void should_parse_title_with_ukr_option(string title, bool addUkrainianToTitle, string expected)
+        public void should_parse_tv_title_with_ukr_option(string title, bool addUkrainianToTitle, string expected)
         {
-            var result = _parser.Parse(title, new List<IndexerCategory>(), addUkrainianToTitle: addUkrainianToTitle);
+            var result = _parser.Parse(title, new List<IndexerCategory> { NewznabStandardCategory.TV }, addUkrainianToTitle: addUkrainianToTitle);
+
+            result.Should().Be(expected);
+        }
+
+        [TestCase("Inception 1080p WEB-DL", true, "Inception 1080p WEB-DL UKR")]
+        [TestCase("Inception 1080p WEB-DL UKR", true, "Inception 1080p WEB-DL UKR")]
+        [TestCase("Inception 1080p WEB-DL", false, "Inception 1080p WEB-DL")]
+        public void should_parse_movie_title_with_ukr_option(string title, bool addUkrainianToTitle, string expected)
+        {
+            var result = _parser.Parse(title, new List<IndexerCategory> { NewznabStandardCategory.Movies }, addUkrainianToTitle: addUkrainianToTitle);
 
             result.Should().Be(expected);
         }

--- a/src/NzbDrone.Core/Indexers/Definitions/Toloka.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Toloka.cs
@@ -511,7 +511,7 @@ namespace NzbDrone.Core.Indexers.Definitions
             // replace multiple spaces with a single space
             title = Regex.Replace(title, @"\s+", " ");
 
-            if (addUkrainianToTitle && !Regex.IsMatch(title, @"\bUKR\b", RegexOptions.IgnoreCase))
+            if (addUkrainianToTitle && (IsAnyTvCategory(categories) || IsAnyMovieCategory(categories)) && !Regex.IsMatch(title, @"\bUKR\b", RegexOptions.IgnoreCase))
             {
                 title += " UKR";
             }
@@ -522,6 +522,11 @@ namespace NzbDrone.Core.Indexers.Definitions
         private static bool IsAnyTvCategory(ICollection<IndexerCategory> category)
         {
             return category.Contains(NewznabStandardCategory.TV) || NewznabStandardCategory.TV.SubCategories.Any(subCategory => category.Contains(subCategory));
+        }
+
+        private static bool IsAnyMovieCategory(ICollection<IndexerCategory> category)
+        {
+            return category.Contains(NewznabStandardCategory.Movies) || NewznabStandardCategory.Movies.SubCategories.Any(subCategory => category.Contains(subCategory));
         }
 
         private static string MoveFirstTagsToEndOfReleaseTitle(string input)

--- a/src/NzbDrone.Core/Indexers/Definitions/Toloka.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Toloka.cs
@@ -399,7 +399,7 @@ namespace NzbDrone.Core.Indexers.Definitions
                     Guid = infoUrl,
                     InfoUrl = infoUrl,
                     DownloadUrl = _settings.BaseUrl + downloadUrl,
-                    Title = _titleParser.Parse(title, categories, _settings.StripCyrillicLetters),
+                    Title = _titleParser.Parse(title, categories, _settings.StripCyrillicLetters, _settings.AddUkrainianToTitle),
                     Description = title,
                     Categories = categories,
                     Seeders = seeders,
@@ -462,7 +462,7 @@ namespace NzbDrone.Core.Indexers.Definitions
 
         private readonly Regex _stripCyrillicRegex = new(@"(\([\p{IsCyrillic}\W]+\))|(^[\p{IsCyrillic}\W\d]+\/ )|([\p{IsCyrillic} \-]+,+)|([\p{IsCyrillic}]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-        public string Parse(string title, ICollection<IndexerCategory> categories, bool stripCyrillicLetters = true)
+        public string Parse(string title, ICollection<IndexerCategory> categories, bool stripCyrillicLetters = true, bool addUkrainianToTitle = false)
         {
             // https://www.fileformat.info/info/unicode/category/Pd/list.htm
             title = Regex.Replace(title, @"\p{Pd}", "-", RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -510,6 +510,11 @@ namespace NzbDrone.Core.Indexers.Definitions
 
             // replace multiple spaces with a single space
             title = Regex.Replace(title, @"\s+", " ");
+
+            if (addUkrainianToTitle)
+            {
+                title += " UKR";
+            }
 
             return title.Trim();
         }
@@ -563,5 +568,8 @@ namespace NzbDrone.Core.Indexers.Definitions
 
         [FieldDefinition(5, Label = "Strip Cyrillic Letters", Type = FieldType.Checkbox)]
         public bool StripCyrillicLetters { get; set; }
+
+        [FieldDefinition(6, Label = "Add UKR to Title", HelpText = "Appends UKR to the end of all release titles to improve language detection by Sonarr and Radarr. Will cause English-only results to be misidentified.", Type = FieldType.Checkbox)]
+        public bool AddUkrainianToTitle { get; set; }
     }
 }

--- a/src/NzbDrone.Core/Indexers/Definitions/Toloka.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Toloka.cs
@@ -511,7 +511,7 @@ namespace NzbDrone.Core.Indexers.Definitions
             // replace multiple spaces with a single space
             title = Regex.Replace(title, @"\s+", " ");
 
-            if (addUkrainianToTitle)
+            if (addUkrainianToTitle && !Regex.IsMatch(title, @"\bUKR\b", RegexOptions.IgnoreCase))
             {
                 title += " UKR";
             }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Adds an optional "Add UKR to Title" setting to the Toloka indexer. When enabled, appends `UKR` to the end of all release titles to improve language detection by Sonarr and Radarr. Specifically it addresses two potential issues:
1. Not picking up Ukrainian language for the releases that do not explicitly mention the language.
2. Treating entries from Toloka as English, since it is default if none specified.

The change mirrors an equivalent `addukrainiantotitle` option already available in Cardigann-based indexers such as [Utopia](https://github.com/Prowlarr/Indexers/blob/master/definitions/v11/utopia.yml#L37-L39).

#### Todos
- [x] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)
