### PR TITLE
Add Hydracker indexer presets

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/Newznab/Newznab.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Newznab/Newznab.cs
@@ -97,6 +97,7 @@ namespace NzbDrone.Core.Indexers.Newznab
                 yield return GetDefinition("DOGnzb", GetSettings("https://api.dognzb.cr"), categories: new[] { 1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000 });
                 yield return GetDefinition("DrunkenSlug", GetSettings("https://drunkenslug.com"), categories: new[] { 1000, 2000, 3000, 4000, 5000, 6000, 7000 });
                 yield return GetDefinition("GingaDADDY", GetSettings("https://www.gingadaddy.com"));
+                yield return GetDefinition("Hydracker", GetSettings("https://hydracker.com", apiPath: @"/api/v1/newznab"), categories: new[] { 1000, 2000, 3000, 4000, 5000, 7000, 8000 });
                 yield return GetDefinition("Miatrix", GetSettings("https://www.miatrix.com"), categories: new[] { 1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000 });
                 yield return GetDefinition("Newz69", GetSettings("https://newz69.keagaming.com"), categories: new[] { 1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000 });
                 yield return GetDefinition("NinjaCentral", GetSettings("https://ninjacentral.co.za"), categories: new[] { 1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000 });

--- a/src/NzbDrone.Core/Indexers/Definitions/Torznab/Torznab.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Torznab/Torznab.cs
@@ -92,6 +92,7 @@ namespace NzbDrone.Core.Indexers.Torznab
             get
             {
                 yield return GetDefinition("AnimeTosho", "Anime NZB/DDL mirror", settings: GetSettings("https://feed.animetosho.org"), categories: new[] { 2020, 5070 });
+                yield return GetDefinition("Hydracker", "Private French tracker for movies, series, anime and more", settings: GetSettings("https://hydracker.com", apiPath: @"/api/v1/torznab"), categories: new[] { 1000, 2000, 3000, 4000, 5000, 7000, 8000 });
                 yield return GetDefinition("MoreThanTV", "Private torrent tracker for TV / MOVIES", settings: GetSettings("https://www.morethantv.me", apiPath: @"/api/torznab"), categories: new[] { 2000, 5000 });
                 yield return GetDefinition("Torrent Network", "Torrent Network (TN) is a GERMAN Private site for TV / MOVIES / GENERAL", language: "de-DE", settings: GetSettings("https://tntracker.org", apiPath: @"/api/torznab/api"));
                 yield return GetDefinition("Generic Torznab", "A Newznab-like api for torrents.", settings: GetSettings(""));


### PR DESCRIPTION
## Summary
- add Hydracker as a Newznab preset for NZB indexing
- add Hydracker as a Torznab preset for torrent indexing
- use the standard Prowlarr API path behavior with Hydracker's `/api` aliases

## Validation
- `git diff --check`

`dotnet` is not available in this local environment, so a full build was not run locally.
