### PR TITLE
Fixed: Apply notification tags to indexer health check notifications

### DIFF
--- a/src/NzbDrone.Core.Test/NotificationTests/NotificationServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/NotificationTests/NotificationServiceFixture.cs
@@ -1,0 +1,124 @@
+using System.Collections.Generic;
+using Moq;
+using NUnit.Framework;
+using NzbDrone.Core.HealthCheck;
+using NzbDrone.Core.HealthCheck.Checks;
+using NzbDrone.Core.Indexers;
+using NzbDrone.Core.Notifications;
+using NzbDrone.Core.Test.Framework;
+using HealthCheckModel = NzbDrone.Core.HealthCheck.HealthCheck;
+
+namespace NzbDrone.Core.Test.NotificationTests
+{
+    [TestFixture]
+    public class NotificationServiceFixture : CoreTest<NotificationService>
+    {
+        private List<INotification> _notifications = new List<INotification>();
+        private List<IndexerDefinition> _indexers = new List<IndexerDefinition>();
+
+        [SetUp]
+        public void SetUp()
+        {
+            _notifications = new List<INotification>();
+            _indexers = new List<IndexerDefinition>();
+
+            Mocker.GetMock<INotificationFactory>()
+                  .Setup(v => v.OnHealthIssueEnabled(It.IsAny<bool>()))
+                  .Returns(_notifications);
+
+            Mocker.GetMock<INotificationFactory>()
+                  .Setup(v => v.OnHealthRestoredEnabled(It.IsAny<bool>()))
+                  .Returns(_notifications);
+
+            Mocker.GetMock<IIndexerFactory>()
+                  .Setup(v => v.All())
+                  .Returns(_indexers);
+        }
+
+        private Mock<INotification> GivenNotification(params int[] tags)
+        {
+            var mockNotification = new Mock<INotification>();
+            mockNotification.SetupGet(s => s.Definition).Returns(new NotificationDefinition
+            {
+                Id = _notifications.Count + 1,
+                IncludeHealthWarnings = true,
+                Tags = new HashSet<int>(tags)
+            });
+
+            _notifications.Add(mockNotification.Object);
+
+            return mockNotification;
+        }
+
+        private void GivenIndexer(int id, params int[] tags)
+        {
+            _indexers.Add(new IndexerDefinition
+            {
+                Id = id,
+                Tags = new HashSet<int>(tags)
+            });
+        }
+
+        private HealthCheckModel GivenHealthCheck(params int[] relatedProviders)
+        {
+            return new HealthCheckModel(typeof(IndexerStatusCheck), HealthCheckResult.Error, "Test health check")
+            {
+                RelatedProviders = relatedProviders
+            };
+        }
+
+        [Test]
+        public void should_send_health_issue_when_notification_has_no_tags()
+        {
+            var notification = GivenNotification();
+            GivenIndexer(1, 1);
+
+            Subject.Handle(new HealthCheckFailedEvent(GivenHealthCheck(1), false));
+
+            notification.Verify(v => v.OnHealthIssue(It.IsAny<HealthCheckModel>()), Times.Once());
+        }
+
+        [Test]
+        public void should_send_health_issue_when_a_related_indexer_has_a_matching_tag()
+        {
+            var notification = GivenNotification(1);
+            GivenIndexer(5, 1);
+
+            Subject.Handle(new HealthCheckFailedEvent(GivenHealthCheck(5), false));
+
+            notification.Verify(v => v.OnHealthIssue(It.IsAny<HealthCheckModel>()), Times.Once());
+        }
+
+        [Test]
+        public void should_not_send_health_issue_when_no_related_indexer_has_a_matching_tag()
+        {
+            var notification = GivenNotification(1);
+            GivenIndexer(5, 2);
+
+            Subject.Handle(new HealthCheckFailedEvent(GivenHealthCheck(5), false));
+
+            notification.Verify(v => v.OnHealthIssue(It.IsAny<HealthCheckModel>()), Times.Never());
+        }
+
+        [Test]
+        public void should_send_health_issue_when_check_has_no_related_indexers()
+        {
+            var notification = GivenNotification(1);
+
+            Subject.Handle(new HealthCheckFailedEvent(GivenHealthCheck(), false));
+
+            notification.Verify(v => v.OnHealthIssue(It.IsAny<HealthCheckModel>()), Times.Once());
+        }
+
+        [Test]
+        public void should_not_send_health_restored_when_no_related_indexer_has_a_matching_tag()
+        {
+            var notification = GivenNotification(1);
+            GivenIndexer(5, 2);
+
+            Subject.Handle(new HealthCheckRestoredEvent(GivenHealthCheck(5), false));
+
+            notification.Verify(v => v.OnHealthRestored(It.IsAny<HealthCheckModel>()), Times.Never());
+        }
+    }
+}

--- a/src/NzbDrone.Core/HealthCheck/Checks/IndexerDownloadClientCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/Checks/IndexerDownloadClientCheck.cs
@@ -44,7 +44,10 @@ namespace NzbDrone.Core.HealthCheck.Checks
                     {
                         { "indexerNames", string.Join(", ", invalidIndexers.Select(v => v.Name).ToArray()) }
                     }),
-                    "#invalid-indexer-download-client-setting");
+                    "#invalid-indexer-download-client-setting")
+                {
+                    RelatedProviders = invalidIndexers.Select(v => v.Id).ToList()
+                };
             }
 
             return new HealthCheck(GetType());

--- a/src/NzbDrone.Core/HealthCheck/Checks/IndexerLongTermStatusCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/Checks/IndexerLongTermStatusCheck.cs
@@ -46,7 +46,10 @@ namespace NzbDrone.Core.HealthCheck.Checks
                 return new HealthCheck(GetType(),
                     HealthCheckResult.Error,
                     _localizationService.GetLocalizedString("IndexerLongTermStatusAllUnavailableHealthCheckMessage"),
-                    "#indexers-are-unavailable-due-to-failures");
+                    "#indexers-are-unavailable-due-to-failures")
+                {
+                    RelatedProviders = backOffProviders.Select(v => v.Provider.Definition.Id).ToList()
+                };
             }
 
             return new HealthCheck(GetType(),
@@ -55,7 +58,10 @@ namespace NzbDrone.Core.HealthCheck.Checks
                 {
                     { "indexerNames", string.Join(", ", backOffProviders.Select(v => v.Provider.Definition.Name)) }
                 }),
-                "#indexers-are-unavailable-due-to-failures");
+                "#indexers-are-unavailable-due-to-failures")
+            {
+                RelatedProviders = backOffProviders.Select(v => v.Provider.Definition.Id).ToList()
+            };
         }
     }
 }

--- a/src/NzbDrone.Core/HealthCheck/Checks/IndexerNoDefinitionCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/Checks/IndexerNoDefinitionCheck.cs
@@ -40,7 +40,10 @@ namespace NzbDrone.Core.HealthCheck.Checks
                 {
                     { "indexerNames", string.Join(", ", noDefinitionIndexers.Select(v => v.Definition.Name).ToArray()) }
                 }),
-                "#indexers-have-no-definition");
+                "#indexers-have-no-definition")
+            {
+                RelatedProviders = noDefinitionIndexers.Select(v => v.Definition.Id).ToList()
+            };
         }
 
         public override bool CheckOnSchedule => false;

--- a/src/NzbDrone.Core/HealthCheck/Checks/IndexerStatusCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/Checks/IndexerStatusCheck.cs
@@ -46,7 +46,10 @@ namespace NzbDrone.Core.HealthCheck.Checks
                 return new HealthCheck(GetType(),
                     HealthCheckResult.Error,
                     _localizationService.GetLocalizedString("IndexerStatusAllUnavailableHealthCheckMessage"),
-                    "#indexers-are-unavailable-due-to-failures");
+                    "#indexers-are-unavailable-due-to-failures")
+                {
+                    RelatedProviders = backOffProviders.Select(v => v.Provider.Definition.Id).ToList()
+                };
             }
 
             return new HealthCheck(GetType(),
@@ -55,7 +58,10 @@ namespace NzbDrone.Core.HealthCheck.Checks
                 {
                     { "indexerNames", string.Join(", ", backOffProviders.Select(v => v.Provider.Definition.Name)) }
                 }),
-                "#indexers-are-unavailable-due-to-failures");
+                "#indexers-are-unavailable-due-to-failures")
+            {
+                RelatedProviders = backOffProviders.Select(v => v.Provider.Definition.Id).ToList()
+            };
         }
     }
 }

--- a/src/NzbDrone.Core/HealthCheck/Checks/IndexerVIPCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/Checks/IndexerVIPCheck.cs
@@ -55,7 +55,10 @@ namespace NzbDrone.Core.HealthCheck.Checks
                     {
                         { "indexerNames", string.Join(", ", expiringProviders.Select(v => v.Definition.Name).ToArray()) }
                     }),
-                    "#indexer-vip-expiring");
+                    "#indexer-vip-expiring")
+                {
+                    RelatedProviders = expiringProviders.Select(v => v.Definition.Id).ToList()
+                };
             }
 
             return new HealthCheck(GetType());

--- a/src/NzbDrone.Core/HealthCheck/Checks/IndexerVIPExpiredCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/Checks/IndexerVIPExpiredCheck.cs
@@ -55,7 +55,10 @@ namespace NzbDrone.Core.HealthCheck.Checks
                     {
                         { "indexerNames", string.Join(", ", expiredProviders.Select(v => v.Definition.Name).ToArray()) }
                     }),
-                    "#indexer-vip-expired");
+                    "#indexer-vip-expired")
+                {
+                    RelatedProviders = expiredProviders.Select(v => v.Definition.Id).ToList()
+                };
             }
 
             return new HealthCheck(GetType());

--- a/src/NzbDrone.Core/HealthCheck/Checks/OutdatedDefinitionCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/Checks/OutdatedDefinitionCheck.cs
@@ -43,7 +43,10 @@ namespace NzbDrone.Core.HealthCheck.Checks
             return new HealthCheck(GetType(),
                 healthType,
                 healthMessage,
-                "#indexers-are-obsolete");
+                "#indexers-are-obsolete")
+            {
+                RelatedProviders = oldIndexers.Select(v => v.Definition.Id).ToList()
+            };
         }
 
         public override bool CheckOnSchedule => false;

--- a/src/NzbDrone.Core/HealthCheck/HealthCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/HealthCheck.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using NzbDrone.Common.Http;
 using NzbDrone.Core.Datastore;
@@ -13,6 +14,13 @@ namespace NzbDrone.Core.HealthCheck
         public HealthCheckResult Type { get; set; }
         public string Message { get; set; }
         public HttpUri WikiUrl { get; set; }
+
+        /// <summary>
+        /// Ids of the indexers this health check relates to, when applicable. Used to scope
+        /// notifications by tag; an empty collection means the check is not tied to specific
+        /// indexers (e.g. a system check) and applies to every notification.
+        /// </summary>
+        public IEnumerable<int> RelatedProviders { get; set; } = Array.Empty<int>();
 
         public HealthCheck()
         {

--- a/src/NzbDrone.Core/Notifications/NotificationService.cs
+++ b/src/NzbDrone.Core/Notifications/NotificationService.cs
@@ -21,12 +21,14 @@ namespace NzbDrone.Core.Notifications
     {
         private readonly INotificationFactory _notificationFactory;
         private readonly INotificationStatusService _notificationStatusService;
+        private readonly IIndexerFactory _indexerFactory;
         private readonly Logger _logger;
 
-        public NotificationService(INotificationFactory notificationFactory, INotificationStatusService notificationStatusService, Logger logger)
+        public NotificationService(INotificationFactory notificationFactory, INotificationStatusService notificationStatusService, IIndexerFactory indexerFactory, Logger logger)
         {
             _notificationFactory = notificationFactory;
             _notificationStatusService = notificationStatusService;
+            _indexerFactory = indexerFactory;
             _logger = logger;
         }
 
@@ -85,7 +87,8 @@ namespace NzbDrone.Core.Notifications
             {
                 try
                 {
-                    if (ShouldHandleHealthFailure(message.HealthCheck, ((NotificationDefinition)notification.Definition).IncludeHealthWarnings))
+                    if (ShouldHandleHealthFailure(message.HealthCheck, ((NotificationDefinition)notification.Definition).IncludeHealthWarnings) &&
+                        ShouldHandleHealthCheck(notification.Definition, message.HealthCheck))
                     {
                         notification.OnHealthIssue(message.HealthCheck);
                         _notificationStatusService.RecordSuccess(notification.Definition.Id);
@@ -110,7 +113,8 @@ namespace NzbDrone.Core.Notifications
             {
                 try
                 {
-                    if (ShouldHandleHealthFailure(message.PreviousCheck, ((NotificationDefinition)notification.Definition).IncludeHealthWarnings))
+                    if (ShouldHandleHealthFailure(message.PreviousCheck, ((NotificationDefinition)notification.Definition).IncludeHealthWarnings) &&
+                        ShouldHandleHealthCheck(notification.Definition, message.PreviousCheck))
                     {
                         notification.OnHealthRestored(message.PreviousCheck);
                         _notificationStatusService.RecordSuccess(notification.Definition.Id);
@@ -218,6 +222,42 @@ namespace NzbDrone.Core.Notifications
             }
 
             _logger.Debug("{0} does not have any intersecting tags with {1}. Notification will not be sent.", definition.Name, indexer.Name);
+
+            return false;
+        }
+
+        private bool ShouldHandleHealthCheck(ProviderDefinition definition, HealthCheck.HealthCheck healthCheck)
+        {
+            if (definition.Tags.Empty())
+            {
+                _logger.Debug("No tags set for this notification.");
+
+                return true;
+            }
+
+            // Health checks that aren't tied to specific indexers (e.g. system checks) are not
+            // tag-scoped, so tagged notifications still receive them rather than silently missing
+            // application-wide health issues.
+            if (healthCheck.RelatedProviders?.Any() != true)
+            {
+                _logger.Debug("Health check is not associated with any indexer, notification will be sent.");
+
+                return true;
+            }
+
+            var relatedTags = _indexerFactory.All()
+                .Where(i => healthCheck.RelatedProviders.Contains(i.Id))
+                .SelectMany(i => i.Tags)
+                .ToHashSet();
+
+            if (definition.Tags.Intersect(relatedTags).Any())
+            {
+                _logger.Debug("Notification and health check indexer(s) have one or more intersecting tags.");
+
+                return true;
+            }
+
+            _logger.Debug("{0} does not have any intersecting tags with the health check indexer(s). Notification will not be sent.", definition.Name);
 
             return false;
         }


### PR DESCRIPTION
## Description

Notification connections with a **Tag** filter currently receive health-issue / health-restored notifications for **every** indexer, regardless of tags — the tag association is only applied to `OnGrab` events. This makes the Tags field on a health-only notification (e.g. a Telegram connection with *On Health Issue* enabled) misleading, since the "Applies to indexers with at least one matching tag" hint has no effect for health events.

This PR makes indexer-related health checks tag-aware.

### How

- `HealthCheck` gains an optional `RelatedProviders` (indexer ids the check concerns). It defaults to empty and is **not** exposed via the API (`HealthResource` mapping is unchanged).
- The indexer health checks populate it: `IndexerStatusCheck`, `IndexerLongTermStatusCheck`, `IndexerVIPCheck`, `IndexerVIPExpiredCheck`, `IndexerNoDefinitionCheck`, `IndexerDownloadClientCheck`, `OutdatedDefinitionCheck`.
- `NotificationService` gains `ShouldHandleHealthCheck(...)` (mirroring the existing `ShouldHandleIndexer` used for grabs), gating both `HealthCheckFailedEvent` and `HealthCheckRestoredEvent`.

### Behaviour

- Notification with **no tags** → unchanged (receives everything).
- Notification **with tags** → an indexer health notification is sent only if at least one affected indexer has a matching tag.
- Health checks **not** tied to specific indexers (system checks, "no indexers configured", proxy checks, etc.) carry no `RelatedProviders` and are still sent to tagged connections, so application-wide health issues are never silently dropped.

The check messages remain aggregated, so a single alert may still list an untagged indexer if it fails in the same cycle as a tagged one; the change stops alerts firing when *only* untagged indexers are affected.

## Related Issue(s)

Closes #1977

## Todos

- [x] Tests (`NotificationServiceFixture`)

## Database Changes

None.
