### PR TITLE
Fixed: (IPTorrents) Advertise correct page size in capabilities

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/IPTorrents.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/IPTorrents.cs
@@ -84,6 +84,8 @@ namespace NzbDrone.Core.Indexers.Definitions
         {
             var caps = new IndexerCapabilities
             {
+                LimitsDefault = 50,
+                LimitsMax = 50,
                 TvSearchParams = new List<TvSearchParam>
                 {
                     TvSearchParam.Q, TvSearchParam.Season, TvSearchParam.Ep, TvSearchParam.ImdbId


### PR DESCRIPTION
IPTorrents serves 50 results per page, but the indexer did not override LimitsDefault/LimitsMax, inheriting the generic default of 100 from the IndexerCapabilities constructor.

The advertised limit must match the site's real page size, because IPTorrentsRequestGenerator derives the page number from it:

    var page = (int)(searchCriteria.Offset / searchCriteria.Limit) + 1;
    qc.Add("p", page.ToString());

Advertising 100 against a 50-row page therefore breaks paging for apps that page by the advertised limit. Sonarr computes its page size from these caps (Math.Min(100, Math.Max(DefaultPageSize, MaxPageSize)) = 100), requests limit=100, receives 50, and its IsFullPage(50 >= 100) check is false — so it treats the short page as the last page and stops after page one. Everything past the first 50 results becomes unreachable, even though offset paging works correctly.

Declaring 50 makes IsFullPage true at a full 50-row page, so paging continues via the existing offset -> p translation. No behaviour change for callers that do not page.

Matches the existing pattern in Redacted, AlphaRatio, AvistaZ and others which already declare their real page size.

#### Database Migration
YES - XXXX | NO

#### Description
A few sentences describing the overall goals of the pull request's commits.

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX