### PR TITLE
Fixed: (Indexers) Improve size precision for parsing bytes

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/ParseUtilFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParseUtilFixture.cs
@@ -8,14 +8,14 @@ namespace NzbDrone.Core.Test.ParserTests
     [TestFixture]
     public class ParseUtilFixture : CoreTest
     {
-        [TestCase("1023.4 KB", 1047961)]
-        [TestCase("1023.4 MB", 1073112704)]
-        [TestCase("1,023.4 MB", 1073112704)]
-        [TestCase("1.023,4 MB", 1073112704)]
-        [TestCase("1 023,4 MB", 1073112704)]
-        [TestCase("1.023.4 MB", 1073112704)]
-        [TestCase("1023.4 GB", 1098867408896)]
-        [TestCase("1023.4 TB", 1125240226709504)]
+        [TestCase("1023.4 KB", 1047961L)]
+        [TestCase("1023.4 MB", 1073112678L)]
+        [TestCase("1,023.4 MB", 1073112678L)]
+        [TestCase("1.023,4 MB", 1073112678L)]
+        [TestCase("1 023,4 MB", 1073112678L)]
+        [TestCase("1.023.4 MB", 1073112678L)]
+        [TestCase("1023.4 GB", 1098867382681L)]
+        [TestCase("1023.4 TB", 1125240199865958L)]
         public void should_parse_size(string stringSize, long size)
         {
             ParseUtil.GetBytes(stringSize).Should().Be(size);

--- a/src/NzbDrone.Core/Parser/ParseUtil.cs
+++ b/src/NzbDrone.Core/Parser/ParseUtil.cs
@@ -135,11 +135,11 @@ namespace NzbDrone.Core.Parser
         public static long GetBytes(string str)
         {
             var unit = new string(str.Where(char.IsLetter).ToArray());
-            var val = CoerceFloat(str);
+            var val = CoerceDouble(str);
             return GetBytes(unit, val);
         }
 
-        private static long GetBytes(string unit, float value)
+        private static long GetBytes(string unit, double value)
         {
             unit = unit.Replace("i", "").ToLowerInvariant();
             if (unit.Contains("kb"))
@@ -165,12 +165,12 @@ namespace NzbDrone.Core.Parser
             return (long)value;
         }
 
-        private static long BytesFromTB(float tb) => BytesFromGB(tb * 1024f);
+        private static long BytesFromTB(double tb) => BytesFromGB(tb * 1024d);
 
-        private static long BytesFromGB(float gb) => BytesFromMB(gb * 1024f);
+        private static long BytesFromGB(double gb) => BytesFromMB(gb * 1024d);
 
-        private static long BytesFromMB(float mb) => BytesFromKB(mb * 1024f);
+        private static long BytesFromMB(double mb) => BytesFromKB(mb * 1024d);
 
-        private static long BytesFromKB(float kb) => (long)(kb * 1024f);
+        private static long BytesFromKB(double kb) => (long)(kb * 1024d);
     }
 }

--- a/src/NzbDrone.Core/Prowlarr.Core.csproj
+++ b/src/NzbDrone.Core/Prowlarr.Core.csproj
@@ -6,13 +6,13 @@
     <PackageReference Include="AngleSharp.Xml" Version="1.0.0" />
     <PackageReference Include="Dapper" Version="2.1.79" />
     <PackageReference Include="Diacritical.Net" Version="1.0.4" />
-    <PackageReference Include="MailKit" Version="4.16.0" />
+    <PackageReference Include="MailKit" Version="4.17.0" />
     <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="8.0.27" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="8.0.27" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.5" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.6" />
     <PackageReference Include="NLog.Targets.Syslog" Version="7.0.0" />
     <PackageReference Include="Npgsql" Version="9.0.5" />
-    <PackageReference Include="Polly" Version="8.6.6" />
+    <PackageReference Include="Polly" Version="8.7.0" />
     <PackageReference Include="FluentMigrator.Runner.Core" Version="6.2.0" />
     <PackageReference Include="FluentMigrator.Runner.Postgres" Version="6.2.0" />
     <PackageReference Include="FluentMigrator.Runner.SQLite" Version="6.2.0" />
@@ -25,7 +25,7 @@
     <PackageReference Include="System.Text.Json" Version="8.0.6" />
     <PackageReference Include="MonoTorrent" Version="2.0.7" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
-    <PackageReference Include="AngleSharp" Version="1.4.0" />
+    <PackageReference Include="AngleSharp" Version="1.5.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NzbDrone.Common\Prowlarr.Common.csproj" />


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Switching parsing bytes to double, since float has issues with rounding and less precision.

#### Issues Fixed or Closed by this PR

* Fixes #2740