### PR TITLE
Fix: HTTP Basic Auth credentials with non-ASCII characters (Transmission and others)

### DIFF
--- a/src/NzbDrone.Common.Test/Http/HttpClientFixture.cs
+++ b/src/NzbDrone.Common.Test/Http/HttpClientFixture.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Text;
 using System.Threading;
 using FluentAssertions;
 using Moq;
@@ -360,6 +361,28 @@ namespace NzbDrone.Common.Test.Http
             var response = Subject.Get<HttpBinResource>(request);
 
             response.Resource.Headers[header].ToString().Should().Be(value);
+        }
+
+        [Test]
+        public void should_send_basic_auth_header_as_utf8()
+        {
+            var username = "tèst";
+            var password = "pâsswörd_ș";
+
+            var request = new HttpRequest($"https://{_httpBinHost}/get")
+            {
+                Credentials = new BasicNetworkCredential(username, password)
+            };
+
+            var response = Subject.Get<HttpBinResource>(request);
+
+            response.Resource.Headers.Should().ContainKey("Authorization");
+
+            var authHeader = response.Resource.Headers["Authorization"].ToString();
+            var encodedPart = authHeader.Split(' ')[1];
+            var decoded = Encoding.UTF8.GetString(Convert.FromBase64String(encodedPart));
+
+            decoded.Should().Be($"{username}:{password}");
         }
 
         [Test]

--- a/src/NzbDrone.Common.Test/Http/HttpClientFixture.cs
+++ b/src/NzbDrone.Common.Test/Http/HttpClientFixture.cs
@@ -7,6 +7,7 @@ using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
 using NLog;
@@ -364,7 +365,7 @@ namespace NzbDrone.Common.Test.Http
         }
 
         [Test]
-        public void should_send_basic_auth_header_as_utf8()
+        public async Task should_send_basic_auth_header_as_utf8()
         {
             var username = "tèst";
             var password = "pâsswörd_ș";
@@ -374,12 +375,12 @@ namespace NzbDrone.Common.Test.Http
                 Credentials = new BasicNetworkCredential(username, password)
             };
 
-            var response = Subject.Get<HttpBinResource>(request);
+            var response = await Subject.GetAsync<HttpBinResource>(request);
 
             response.Resource.Headers.Should().ContainKey("Authorization");
 
             var authHeader = response.Resource.Headers["Authorization"].ToString();
-            var encodedPart = authHeader.Split(' ')[1];
+            var encodedPart = authHeader!.Split(' ', 2).Last();
             var decoded = Encoding.UTF8.GetString(Convert.FromBase64String(encodedPart));
 
             decoded.Should().Be($"{username}:{password}");

--- a/src/NzbDrone.Common/Http/Dispatchers/ManagedHttpDispatcher.cs
+++ b/src/NzbDrone.Common/Http/Dispatchers/ManagedHttpDispatcher.cs
@@ -78,7 +78,7 @@ namespace NzbDrone.Common.Http.Dispatchers
                 {
                     // Manually set header to avoid initial challenge response
                     var authInfo = bc.UserName + ":" + bc.Password;
-                    authInfo = Convert.ToBase64String(Encoding.GetEncoding("ISO-8859-1").GetBytes(authInfo));
+                    authInfo = Convert.ToBase64String(Encoding.UTF8.GetBytes(authInfo));
                     requestMessage.Headers.Add("Authorization", "Basic " + authInfo);
                 }
                 else if (request.Credentials is NetworkCredential nc)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
`ManagedHttpDispatcher` manually builds the `Authorization: Basic` header for `BasicNetworkCredential` requests, and hardcoded `ISO-8859-1` for the byte encoding. Characters outside the Latin-1 repertoire (e.g. Romanian `ș`/`ț`) get silently replaced with `?` by .NET's default encoder fallback, corrupting the credential and breaking authentication, reported against the Transmission download client, but the same encoding call is shared by every other `BasicNetworkCredential` consumer (other download clients, application proxies, indexer request generators, notification proxies) via this single code path.

This PR changes that one encoding call from `ISO-8859-1` to UTF-8 (RFC 7617's recommended charset for HTTP Basic Auth since 2015), and adds a regression test. No other behavior of `ManagedHttpDispatcher` changes, and none of the ~20 other call sites that construct a `BasicNetworkCredential` needed to change.

**Note on backward compatibility:** for a credential containing a Latin-1-range character (e.g. `é`, `ñ`), the on-the-wire bytes change from a single Latin-1 byte to a multi-byte UTF-8 sequence. Pure-ASCII credentials (the large majority) are byte-identical under both encodings, so this is a no-op for most users. A hypothetical setup with a non-ASCII credential *and* a target server that specifically expects Latin-1-decoded Basic Auth would need to update its credential. This seems unlikely in practice (Transmission and the other actual consumers on this path decode UTF-8), but flagging it since it's the one behavior change beyond the bug being fixed.

#### Screenshot (if UI related)
N/A: no UI change.

#### Todos
- [x] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json), not applicable, no user-facing string changed
- [ ] [Wiki Updates](https://wiki.servarr.com), not applicable, no documented behavior changed (RFC-compliant encoding fix)

#### Issues Fixed or Closed by this PR

* Fixes #2484

#### Test plan
- [x] New test `should_send_basic_auth_header_as_utf8` (`src/NzbDrone.Common.Test/Http/HttpClientFixture.cs`): sends a request with a `BasicNetworkCredential` containing non-Latin-1 characters, decodes the `Authorization` header echoed back by the shared httpbin test host, and asserts it matches the original `username:password` exactly. Confirmed this test fails against the pre-fix ISO-8859-1 code (decodes to corrupted/mojibake text) and passes after the fix.
- [x] Full `NzbDrone.Common.Test` suite: 639 passing, 39 skipped, 1 pre-existing failure unrelated to this change (`event_handlers_should_be_unique`, a DI-container assembly-scan test failing on a missing `Prowlarr.Mono.dll` in this environment, unrelated to HTTP/credentials).

#### AI assistance disclosure
This PR was implemented with Claude Code (Anthropic) assistance, working from a written implementation plan (ticket → requirements → plan → execute) that I reviewed before and after implementation, including the root-cause investigation into `ManagedHttpDispatcher.cs` and the decision to fix the shared code path rather than a per-consumer special case.

