### PR TITLE
Fixed: (Indexer) Update GGN Nintendo Categories

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/GazelleGames.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/GazelleGames.cs
@@ -71,19 +71,19 @@ namespace NzbDrone.Core.Indexers.Definitions
             caps.Categories.AddCategoryMapping("Xbox 360", NewznabStandardCategory.ConsoleXBox360, "Xbox 360");
 
             // Nintendo
-            caps.Categories.AddCategoryMapping("Game Boy", NewznabStandardCategory.ConsoleOther, "Game Boy");
-            caps.Categories.AddCategoryMapping("Game Boy Advance", NewznabStandardCategory.ConsoleOther, "Game Boy Advance");
-            caps.Categories.AddCategoryMapping("Game Boy Color", NewznabStandardCategory.ConsoleOther, "Game Boy Color");
-            caps.Categories.AddCategoryMapping("NES", NewznabStandardCategory.ConsoleOther, "NES");
-            caps.Categories.AddCategoryMapping("Nintendo 64", NewznabStandardCategory.ConsoleOther, "Nintendo 64");
-            caps.Categories.AddCategoryMapping("Nintendo 3DS", NewznabStandardCategory.ConsoleOther, "Nintendo 3DS");
-            caps.Categories.AddCategoryMapping("New Nintendo 3DS", NewznabStandardCategory.ConsoleOther, "New Nintendo 3DS");
+            caps.Categories.AddCategoryMapping("Game Boy", NewznabStandardCategory.ConsoleGameBoy, "Game Boy");
+            caps.Categories.AddCategoryMapping("Game Boy Advance", NewznabStandardCategory.ConsoleGameBoyAdvance, "Game Boy Advance");
+            caps.Categories.AddCategoryMapping("Game Boy Color", NewznabStandardCategory.ConsoleGameBoyColor, "Game Boy Color");
+            caps.Categories.AddCategoryMapping("NES", NewznabStandardCategory.ConsoleNES, "NES");
+            caps.Categories.AddCategoryMapping("Nintendo 64", NewznabStandardCategory.ConsoleNintendo64, "Nintendo 64");
+            caps.Categories.AddCategoryMapping("Nintendo 3DS", NewznabStandardCategory.Console3DS, "Nintendo 3DS");
+            caps.Categories.AddCategoryMapping("New Nintendo 3DS", NewznabStandardCategory.ConsoleNewNintendo3DS, "New Nintendo 3DS");
             caps.Categories.AddCategoryMapping("Nintendo DS", NewznabStandardCategory.ConsoleNDS, "Nintendo DS");
-            caps.Categories.AddCategoryMapping("Nintendo GameCube", NewznabStandardCategory.ConsoleOther, "Nintendo GameCube");
-            caps.Categories.AddCategoryMapping("Pokemon Mini", NewznabStandardCategory.ConsoleOther, "Pokemon Mini");
-            caps.Categories.AddCategoryMapping("SNES", NewznabStandardCategory.ConsoleOther, "SNES");
-            caps.Categories.AddCategoryMapping("Switch", NewznabStandardCategory.ConsoleOther, "Switch");
-            caps.Categories.AddCategoryMapping("Virtual Boy", NewznabStandardCategory.ConsoleOther, "Virtual Boy");
+            caps.Categories.AddCategoryMapping("Nintendo GameCube", NewznabStandardCategory.ConsoleGameCube, "Nintendo GameCube");
+            caps.Categories.AddCategoryMapping("Pokemon Mini", NewznabStandardCategory.ConsolePokemonMini, "Pokemon Mini");
+            caps.Categories.AddCategoryMapping("SNES", NewznabStandardCategory.ConsoleSNES, "SNES");
+            caps.Categories.AddCategoryMapping("Switch", NewznabStandardCategory.ConsoleSwitch, "Switch");
+            caps.Categories.AddCategoryMapping("Virtual Boy", NewznabStandardCategory.ConsoleVirtualBoy, "Virtual Boy");
             caps.Categories.AddCategoryMapping("Wii", NewznabStandardCategory.ConsoleWii, "Wii");
             caps.Categories.AddCategoryMapping("Wii U", NewznabStandardCategory.ConsoleWiiU, "Wii U");
 

--- a/src/NzbDrone.Core/Indexers/NewznabStandardCategory.cs
+++ b/src/NzbDrone.Core/Indexers/NewznabStandardCategory.cs
@@ -24,6 +24,17 @@ namespace NzbDrone.Core.Indexers
         public static readonly IndexerCategory ConsoleWiiU = new(1130, "Console/WiiU");
         public static readonly IndexerCategory ConsoleXBoxOne = new(1140, "Console/XBox One");
         public static readonly IndexerCategory ConsolePS4 = new(1180, "Console/PS4");
+        public static readonly IndexerCategory ConsoleGameBoy = new(1190, "Console/Game Boy");
+        public static readonly IndexerCategory ConsoleGameBoyAdvance = new(1200, "Console/Game Boy Advance");
+        public static readonly IndexerCategory ConsoleGameBoyColor = new(1210, "Console/Game Boy Color");
+        public static readonly IndexerCategory ConsoleNES = new(1220, "Console/NES");
+        public static readonly IndexerCategory ConsoleNintendo64 = new(1230, "Console/Nintendo 64");
+        public static readonly IndexerCategory ConsoleGameCube = new(1240, "Console/Nintendo GameCube");
+        public static readonly IndexerCategory ConsolePokemonMini = new(1250, "Console/Pokemon Mini");
+        public static readonly IndexerCategory ConsoleSNES = new(1260, "Console/SNES");
+        public static readonly IndexerCategory ConsoleSwitch = new(1270, "Console/Switch");
+        public static readonly IndexerCategory ConsoleVirtualBoy = new(1280, "Console/Virtual Boy");
+        public static readonly IndexerCategory ConsoleNewNintendo3DS = new(1290, "Console/New Nintendo 3DS");
 
         public static readonly IndexerCategory Movies = new(2000, "Movies");
         public static readonly IndexerCategory MoviesForeign = new(2010, "Movies/Foreign");
@@ -120,6 +131,17 @@ namespace NzbDrone.Core.Indexers
             ConsoleWiiU,
             ConsoleXBoxOne,
             ConsolePS4,
+            ConsoleGameBoy,
+            ConsoleGameBoyAdvance,
+            ConsoleGameBoyColor,
+            ConsoleNES,
+            ConsoleNintendo64,
+            ConsoleGameCube,
+            ConsolePokemonMini,
+            ConsoleSNES,
+            ConsoleSwitch,
+            ConsoleVirtualBoy,
+            ConsoleNewNintendo3DS,
             Movies,
             MoviesForeign,
             MoviesOther,
@@ -202,7 +224,18 @@ namespace NzbDrone.Core.Indexers
                     ConsolePSVita,
                     ConsoleWiiU,
                     ConsoleXBoxOne,
-                    ConsolePS4
+                    ConsolePS4,
+                    ConsoleGameBoy,
+                    ConsoleGameBoyAdvance,
+                    ConsoleGameBoyColor,
+                    ConsoleNES,
+                    ConsoleNintendo64,
+                    ConsoleGameCube,
+                    ConsolePokemonMini,
+                    ConsoleSNES,
+                    ConsoleSwitch,
+                    ConsoleVirtualBoy,
+                    ConsoleNewNintendo3DS
                 });
             Movies.SubCategories.AddRange(
                 new List<IndexerCategory>


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Make querying for Nintendo Games on GGN nicer via Prowlarr.

Previously had to use Console/Other which would produce a lot of bad results, now each console has it's own category making finding specific games eaiser.

#### Screenshot (if UI related)
n/a 

#### Todos
- [X] Tests (Manually checked the categories in search) 

#### Issues Fixed or Closed by this PR

n/a