### PR TITLE
New: Show indexer specific categories in search

### DIFF
--- a/frontend/src/Components/Form/NewznabCategorySelectInputConnector.js
+++ b/frontend/src/Components/Form/NewznabCategorySelectInputConnector.js
@@ -8,7 +8,9 @@ function createMapStateToProps() {
   return createSelector(
     (state, { value }) => value,
     (state) => state.settings.indexerCategories,
-    (value, categories) => {
+    (state) => state.indexers.items,
+    (state, { indexerIds }) => indexerIds,
+    (value, categories, indexers, indexerIds) => {
       const values = [];
 
       categories.items.forEach((element) => {
@@ -29,6 +31,31 @@ function createMapStateToProps() {
           });
         }
       });
+
+      if (indexerIds && indexerIds.length === 1) {
+        const indexer = indexers.find((i) => i.id === indexerIds[0]);
+        const indexerCategories = (indexer?.capabilities?.categories ?? [])
+          .filter((category) => category.id >= 100000);
+
+        if (indexerCategories.length) {
+          const customCategoryGroup = {
+            key: `indexerCategories-${indexer.id}`,
+            value: indexer.name,
+            isDisabled: true
+          };
+
+          values.push(customCategoryGroup);
+
+          indexerCategories.forEach((category) => {
+            values.push({
+              key: category.id,
+              value: category.name,
+              hint: `(${category.id})`,
+              parentKey: customCategoryGroup.key
+            });
+          });
+        }
+      }
 
       return {
         value: value || [],
@@ -60,7 +87,7 @@ class IndexersSelectInputConnector extends Component {
 
 IndexersSelectInputConnector.propTypes = {
   name: PropTypes.string.isRequired,
-  indexerIds: PropTypes.number,
+  indexerIds: PropTypes.arrayOf(PropTypes.number),
   value: PropTypes.arrayOf(PropTypes.number).isRequired,
   values: PropTypes.arrayOf(PropTypes.object).isRequired,
   onChange: PropTypes.func.isRequired

--- a/frontend/src/Search/SearchFooter.js
+++ b/frontend/src/Search/SearchFooter.js
@@ -250,6 +250,7 @@ class SearchFooter extends Component {
 
           <NewznabCategorySelectInputConnector
             name='searchCategories'
+            indexerIds={searchIndexerIds}
             value={searchCategories}
             isDisabled={isFetching}
             onChange={this.onInputChange}

--- a/frontend/src/Search/SearchFooterConnector.js
+++ b/frontend/src/Search/SearchFooterConnector.js
@@ -80,6 +80,19 @@ class SearchFooterConnector extends Component {
   // Listeners
 
   onInputChange = ({ name, value }) => {
+    if (name === 'searchIndexerIds') {
+      const searchCategories = this.props.defaultCategories.filter(
+        (category) => category < 100000
+      );
+
+      this.props.setSearchDefault({
+        [name]: value,
+        searchCategories
+      });
+
+      return;
+    }
+
     this.props.setSearchDefault({ [name]: value });
   };
 
@@ -98,6 +111,7 @@ class SearchFooterConnector extends Component {
 
 SearchFooterConnector.propTypes = {
   defaultSearchQueryParams: PropTypes.object.isRequired,
+  defaultCategories: PropTypes.arrayOf(PropTypes.number).isRequired,
   setSearchDefault: PropTypes.func.isRequired
 };
 


### PR DESCRIPTION
Show custom categories when a single indexer is selected. Clear them if another indexer is selected.

#### Database Migration
NO

#### Description

Expose the custom categories to the UI search when **ONE** Indexer is selected. 
When two are selected, it will clear the custom categories.

I chose to make this only work for one indexer selected at a time because: 
1. It uses a shared category list on the search
2. This would then search Indexer A with Indexer B Custom categories
3. To prevent this would require backend changes instead of just front end

I think just being able to search one indexer in this case is perfectly fine, as if you're drilling down to a indexers categories you're probably only doing it for that specific indexer anyway. Standard categories are still selectale 

This is an alternative to : https://github.com/Prowlarr/Prowlarr/pull/2753 

Reason for something like this:

> Using Console/3DS for Pokemon X = 0 Results. It passes 3DS instead of 'Nintendo 3DS' into the query 
> So you would need to use Console/Other -> 162 Results, from wrong consoles
> Using the 'Nintendo 3DS' category, that could be selected from the UI (but cannot currently do, but can do in this branch)
> 65 Results, Only groups that reference "Pokemon X" are returned - Pokemon X & Y, and 3DS megapacks
>= much more usable

#### Screenshot (if UI related)
<img width="1646" height="1183" alt="image" src="https://github.com/user-attachments/assets/9b791893-9950-4661-b97a-74b9402d5f20" />
<img width="1646" height="1183" alt="image" src="https://github.com/user-attachments/assets/ec78df17-26ed-4c67-876c-0f79785f5010" />


#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

n/a