### PR TITLE
Fixed: Use FlareSolverr response body instead of re-requesting

### DIFF
--- a/src/NzbDrone.Core.Test/IndexerProxies/FlareSolverr/FlareSolverrFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerProxies/FlareSolverr/FlareSolverrFixture.cs
@@ -1,0 +1,213 @@
+using System.Collections.Generic;
+using System.Net;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using NzbDrone.Common.Http;
+using NzbDrone.Common.Serializer;
+using NzbDrone.Core.IndexerProxies;
+using NzbDrone.Core.IndexerProxies.FlareSolverr;
+using NzbDrone.Core.Test.Framework;
+
+namespace NzbDrone.Core.Test.IndexerProxies.FlareSolverr
+{
+    [TestFixture]
+    public class FlareSolverrFixture : CoreTest<NzbDrone.Core.IndexerProxies.FlareSolverr.FlareSolverr>
+    {
+        private HttpResponse _cloudflareResponse;
+
+        [SetUp]
+        public void Setup()
+        {
+            Subject.Definition = new IndexerProxyDefinition
+            {
+                Settings = new FlareSolverrSettings
+                {
+                    Host = "http://localhost:8191/",
+                    RequestTimeout = 60
+                }
+            };
+
+            var headers = new HttpHeader();
+            headers.Add("server", "cloudflare");
+
+            var request = new HttpRequest("http://example.com/search");
+            var content = "<title>Just a moment...</title>";
+
+            _cloudflareResponse = new HttpResponse(
+                request,
+                headers,
+                new CookieCollection(),
+                content,
+                100,
+                HttpStatusCode.Forbidden);
+        }
+
+        private string BuildFlareSolverrJson(string responseBody, string contentType = null)
+        {
+            var solution = new Dictionary<string, object>
+            {
+                ["url"] = "http://example.com/search",
+                ["status"] = "200",
+                ["response"] = responseBody,
+                ["cookies"] = new[]
+                {
+                    new Dictionary<string, object>
+                    {
+                        ["name"] = "cf_clearance",
+                        ["value"] = "abc123",
+                        ["domain"] = "example.com",
+                        ["path"] = "/",
+                        ["expires"] = 0,
+                        ["size"] = 10,
+                        ["httpOnly"] = false,
+                        ["secure"] = true,
+                        ["session"] = false,
+                        ["sameSite"] = "None"
+                    }
+                },
+                ["userAgent"] = "Mozilla/5.0 (X11; Linux x86_64) FlareSolverr"
+            };
+
+            if (contentType != null)
+            {
+                solution["headers"] = new Dictionary<string, object>
+                {
+                    ["status"] = "200",
+                    ["date"] = "Thu, 01 Jan 2026 00:00:00 GMT",
+                    ["content-type"] = contentType
+                };
+            }
+
+            var fsResponse = new Dictionary<string, object>
+            {
+                ["status"] = "ok",
+                ["message"] = "Challenge solved!",
+                ["startTimestamp"] = 1000,
+                ["endTimestamp"] = 5000,
+                ["version"] = "3.5.0",
+                ["solution"] = solution
+            };
+
+            return fsResponse.ToJson();
+        }
+
+        private void GivenFlareSolverrReturns(string responseBody, string contentType = null)
+        {
+            var json = BuildFlareSolverrJson(responseBody, contentType);
+
+            Mocker.GetMock<IHttpClient>()
+                  .Setup(s => s.Execute(It.Is<HttpRequest>(r => r.Url.ToString().Contains("/v1"))))
+                  .Returns<HttpRequest>(r => new HttpResponse(
+                      r,
+                      new HttpHeader(),
+                      new CookieCollection(),
+                      json,
+                      50,
+                      HttpStatusCode.OK));
+        }
+
+        [Test]
+        public void should_use_flaresolverr_response_body_directly()
+        {
+            var solvedHtml = "<html><body>Search results</body></html>";
+            GivenFlareSolverrReturns(solvedHtml);
+
+            var result = Subject.PostResponse(_cloudflareResponse);
+
+            result.Content.Should().Be(solvedHtml);
+            result.StatusCode.Should().Be(HttpStatusCode.OK);
+
+            Mocker.GetMock<IHttpClient>()
+                  .Verify(v => v.Execute(It.Is<HttpRequest>(r => r.Url.ToString().Contains("/v1"))), Times.Once());
+
+            // Should NOT make a second request to the original URL
+            Mocker.GetMock<IHttpClient>()
+                  .Verify(v => v.Execute(It.Is<HttpRequest>(r => r.Url.ToString() == "http://example.com/search")), Times.Never());
+        }
+
+        [Test]
+        public void should_update_content_type_from_flaresolverr_headers()
+        {
+            GivenFlareSolverrReturns("<html>results</html>", "text/html; charset=utf-8");
+
+            var result = Subject.PostResponse(_cloudflareResponse);
+
+            result.Headers.ContentType.Should().Be("text/html; charset=utf-8");
+        }
+
+        [Test]
+        public void should_fall_back_to_cookie_retry_when_no_response_body()
+        {
+            GivenFlareSolverrReturns(null);
+
+            var retryResponse = new HttpResponse(
+                _cloudflareResponse.Request,
+                new HttpHeader(),
+                new CookieCollection(),
+                "<html>retry results</html>",
+                200,
+                HttpStatusCode.OK);
+
+            Mocker.GetMock<IHttpClient>()
+                  .Setup(s => s.Execute(It.Is<HttpRequest>(r => r.Url.ToString() == "http://example.com/search")))
+                  .Returns(retryResponse);
+
+            var result = Subject.PostResponse(_cloudflareResponse);
+
+            result.Content.Should().Be("<html>retry results</html>");
+
+            Mocker.GetMock<IHttpClient>()
+                  .Verify(v => v.Execute(It.Is<HttpRequest>(r => r.Url.ToString() == "http://example.com/search")), Times.Once());
+        }
+
+        [Test]
+        public void should_return_original_response_when_not_cloudflare_protected()
+        {
+            var normalHeaders = new HttpHeader();
+            var request = new HttpRequest("http://example.com/search");
+            var normalResponse = new HttpResponse(
+                request,
+                normalHeaders,
+                new CookieCollection(),
+                "<html>normal</html>",
+                50,
+                HttpStatusCode.OK);
+
+            var result = Subject.PostResponse(normalResponse);
+
+            result.Should().BeSameAs(normalResponse);
+        }
+
+        [Test]
+        public void should_throw_when_flaresolverr_returns_bad_status()
+        {
+            Mocker.GetMock<IHttpClient>()
+                  .Setup(s => s.Execute(It.Is<HttpRequest>(r => r.Url.ToString().Contains("/v1"))))
+                  .Returns<HttpRequest>(r => new HttpResponse(
+                      r,
+                      new HttpHeader(),
+                      new CookieCollection(),
+                      "error",
+                      50,
+                      HttpStatusCode.BadGateway));
+
+            Assert.Throws<FlareSolverrException>(() => Subject.PostResponse(_cloudflareResponse));
+        }
+
+        [Test]
+        public void should_cache_user_agent_from_flaresolverr()
+        {
+            GivenFlareSolverrReturns("<html>solved</html>");
+
+            Subject.PostResponse(_cloudflareResponse);
+
+            // Make a second request, the UA should be injected via PreRequest
+            var newRequest = new HttpRequest("http://example.com/other");
+
+            var result = Subject.PreRequest(newRequest);
+
+            result.Headers.UserAgent.Should().Be("Mozilla/5.0 (X11; Linux x86_64) FlareSolverr");
+        }
+    }
+}

--- a/src/NzbDrone.Core/IndexerProxies/FlareSolverr/FlareSolverr.cs
+++ b/src/NzbDrone.Core/IndexerProxies/FlareSolverr/FlareSolverr.cs
@@ -58,7 +58,7 @@ namespace NzbDrone.Core.IndexerProxies.FlareSolverr
 
             if (flaresolverrResponse.StatusCode != HttpStatusCode.OK && flaresolverrResponse.StatusCode != HttpStatusCode.InternalServerError)
             {
-                throw new FlareSolverrException("HTTP StatusCode not 200 or 500. Status is :" + response.StatusCode);
+                throw new FlareSolverrException("HTTP StatusCode not 200 or 500. Status is :" + flaresolverrResponse.StatusCode);
             }
 
             var result = JsonConvert.DeserializeObject<FlareSolverrResponse>(flaresolverrResponse.Content);
@@ -71,7 +71,28 @@ namespace NzbDrone.Core.IndexerProxies.FlareSolverr
 
             InjectCookies(newRequest, result);
 
-            //Request again with User-Agent and Cookies from Flaresolverr
+            // Use the solved response body from FlareSolverr directly when available.
+            // Replaying the returned cookies from a different HTTP client is unreliable
+            // because Cloudflare may reject clearance tokens issued to the solver's browser.
+            if (result.Solution.Response.IsNotNullOrWhiteSpace())
+            {
+                var headers = new HttpHeader();
+
+                if (result.Solution.Headers?.ContentType != null)
+                {
+                    headers.ContentType = result.Solution.Headers.ContentType;
+                }
+
+                return new HttpResponse(
+                    response.Request,
+                    headers,
+                    response.Cookies,
+                    result.Solution.Response,
+                    response.ElapsedTime,
+                    HttpStatusCode.OK);
+            }
+
+            // Fallback: no response body from FlareSolverr, retry with cookies
             var finalResponse = _httpClient.Execute(newRequest);
 
             return finalResponse;


### PR DESCRIPTION
Closes #2561

### Changes

When Prowlarr detects Cloudflare protection, it sends the request to FlareSolverr (or a compatible solver like Byparr). The solver navigates the challenge in a headless browser and returns the solved page content along with cookies and User-Agent.

Previously, Prowlarr discarded the solved response body and made a second HTTP request using only the returned cookies and User-Agent. This second request frequently receives a 403 because Cloudflare clearance obtained by the solver is not reliably reusable by a different HTTP client, even when the returned cookie and User-Agent are replayed.

This change uses the solved response body from FlareSolverr directly when it is present, avoiding the unreliable second request. When FlareSolverr returns no response body (e.g. no challenge was encountered), the existing cookie-based retry is preserved as a fallback.

Also fixes a minor bug where the error message for bad FlareSolverr HTTP status referenced the original Cloudflare response status code instead of the FlareSolverr response status code.

### Relationship to #2600

PR #2600 addresses the same issue with the same architectural approach. This PR differs in:

- Uses empirically supported language about cookie replay unreliability rather than unsubstantiated claims about specific Cloudflare internals, addressing the review feedback on #2600
- Updates the response Content-Type header from FlareSolverr's solution headers when available, and avoids carrying stale entity headers (Content-Encoding, Content-Length) from the original Cloudflare challenge response
- Adds unit tests covering the direct-response, fallback, error, and caching paths

### Regarding "always going through FS for bad sites"

This was raised in the #2600 review. The concern is that using the response body directly means Prowlarr would call FlareSolverr on every request to a Cloudflare-protected site rather than once to obtain cookies.

This is not a behavioral change. Prowlarr already caches the User-Agent and injects it on subsequent requests via `PreRequest`. When the cached UA is sufficient to pass without triggering a challenge, `PostResponse` returns early because `IsCloudflareProtected` returns false. FlareSolverr is only invoked when a challenge is actually encountered, which is unchanged by this fix.

### Reproduction

Independently reproduced with Prowlarr v2.6.1.5509 (LinuxServer image), FlareSolverr 3.5.0, Chromium 148, against a Cloudflare-protected indexer. Controlled testing confirmed that replaying freshly returned `cf_clearance` cookies and exact User-Agent from a non-browser HTTP client is unreliable across HTTP/1.1, HTTP/2, and default negotiation.

Applied the same architectural fix to the exact v2.6.1.5509 source, rebuilt the DLL, and hot-swapped it into the running container. The indexer test stopped producing errors and searching returned valid parsed results with no 403 in the successful path.

### Test evidence

Unit tests (6 new, all passing):

```
Passed should_use_flaresolverr_response_body_directly [2 ms]
Passed should_update_content_type_from_flaresolverr_headers [1 ms]
Passed should_fall_back_to_cookie_retry_when_no_response_body [12 ms]
Passed should_return_original_response_when_not_cloudflare_protected [1 ms]
Passed should_throw_when_flaresolverr_returns_bad_status [3 ms]
Passed should_cache_user_agent_from_flaresolverr [142 ms]
```

Full core test suite (509 passed, 6 skipped, 0 failed):

```
Test Run Successful.
Total tests: 515
     Passed: 509
    Skipped: 6
 Total time: 11.7028 Seconds
```

### Test plan

- [x] Unit tests for direct-response, fallback, error handling, Content-Type propagation, and UA caching
- [ ] Configure FlareSolverr/Byparr as an indexer proxy
- [ ] Add a Cloudflare-protected indexer tagged with the proxy
- [ ] Verify the indexer loads successfully using the FlareSolverr response body
- [ ] Verify indexers not behind Cloudflare still work normally
- [ ] Verify the fallback path works when FlareSolverr returns an empty body