### PR TITLE
Fixed: Definition existence check before grabbing the remote definition

### DIFF
--- a/src/NzbDrone.Core/IndexerVersions/IndexerDefinitionUpdateService.cs
+++ b/src/NzbDrone.Core/IndexerVersions/IndexerDefinitionUpdateService.cs
@@ -58,7 +58,6 @@ namespace NzbDrone.Core.IndexerVersions
         private readonly IHttpClient _httpClient;
         private readonly IAppFolderInfo _appFolderInfo;
         private readonly IDiskProvider _diskProvider;
-        private readonly IIndexerDefinitionVersionService _versionService;
         private readonly ICached<CardigannDefinition> _cache;
         private readonly Logger _logger;
 
@@ -70,16 +69,15 @@ namespace NzbDrone.Core.IndexerVersions
         public IndexerDefinitionUpdateService(IHttpClient httpClient,
                                           IAppFolderInfo appFolderInfo,
                                           IDiskProvider diskProvider,
-                                          IIndexerDefinitionVersionService versionService,
                                           ICacheManager cacheManager,
                                           Logger logger)
         {
             _appFolderInfo = appFolderInfo;
             _diskProvider = diskProvider;
-            _versionService = versionService;
-            _cache = cacheManager.GetCache<CardigannDefinition>(typeof(CardigannDefinition), "definitions");
             _httpClient = httpClient;
             _logger = logger;
+
+            _cache = cacheManager.GetCache<CardigannDefinition>(typeof(CardigannDefinition), "definitions");
         }
 
         public List<CardigannMetaDefinition> All()
@@ -209,7 +207,7 @@ namespace NzbDrone.Core.IndexerVersions
                 }
             }
 
-            var dbDefs = _versionService.All();
+            var dbDefs = All();
 
             //Check to ensure it's in versioned defs before we go to web
             if (dbDefs.Count > 0 && dbDefs.All(x => x.File != fileKey))


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fixing an issue for those users with an installation before 2022 due to c29735741cc327dddaabc7ead8ea3b4252e8c27f still checking the stale data.

Check the current definition list which is actually updated.

```
System.ArgumentNullException: Value cannot be null. (Parameter 'fileKey')
   at NzbDrone.Core.IndexerVersions.IndexerDefinitionUpdateService.GetUncachedDefinition(String fileKey) in ./NzbDrone.Core/IndexerVersions/IndexerDefinitionUpdateService.cs:line 217
   at NzbDrone.Core.IndexerVersions.IndexerDefinitionUpdateService.<>c__DisplayClass12_0.<GetCachedDefinition>b__0() in ./NzbDrone.Core/IndexerVersions/IndexerDefinitionUpdateService.cs:line 127
   at NzbDrone.Core.IndexerVersions.IndexerDefinitionUpdateService.GetCachedDefinition(String fileKey)
   at Prowlarr.Api.V1.Indexers.IndexerResourceMapper.ToModel(IndexerResource resource, IndexerDefinition existingDefinition) in ./Prowlarr.Api.V1/Indexers/IndexerResource.cs:line 124
```