### PR TITLE
Fixed: Stats page indexer/tag filters missing 'does not contain' option

### DIFF
--- a/frontend/src/Store/Actions/indexerStatsActions.js
+++ b/frontend/src/Store/Actions/indexerStatsActions.js
@@ -58,7 +58,7 @@ export const defaultState = {
     {
       name: 'indexers',
       label: () => translate('Indexers'),
-      type: filterBuilderTypes.CONTAINS,
+      type: filterBuilderTypes.ARRAY,
       valueType: filterBuilderValueTypes.INDEXER
     },
     {
@@ -70,7 +70,7 @@ export const defaultState = {
     {
       name: 'tags',
       label: () => translate('Tags'),
-      type: filterBuilderTypes.CONTAINS,
+      type: filterBuilderTypes.ARRAY,
       valueType: filterBuilderValueTypes.TAG
     }
   ],


### PR DESCRIPTION
Fixes #2617

## Root cause

The Stats page's `indexers` and `tags` filter fields (`frontend/src/Store/Actions/indexerStatsActions.js`) used `filterBuilderTypes.CONTAINS`, which only exposes a single `contains` operator (see `possibleFilterTypes` in `frontend/src/Helpers/Props/filterBuilderTypes.js`).

The main Indexers page (`frontend/src/Store/Actions/indexerIndexActions.js`) already uses `filterBuilderTypes.ARRAY` for the equivalent `tags`/`categories` fields, which exposes both `contains` and `does not contain`.

## Fix

Changed the Stats page's `indexers` and `tags` fields from `CONTAINS` to `ARRAY`, matching the existing pattern used on the Indexers page. Two-line change, purely frontend — all filtering for these fields happens client-side (`filterTypePredicates.js`), so no backend changes are needed.

## Testing

- `npx eslint` clean on the changed file
- No existing frontend test suite covers this file (repo has no `.test.js`/`.test.ts` files under `frontend/src`), so no test added, consistent with current coverage