### PR TITLE
fix: RetroFlix/SpeedApp search returns nothing when the only match is dead

### DIFF
--- a/src/NzbDrone.Core/Indexers/Definitions/SpeedApp/SpeedAppBase.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/SpeedApp/SpeedAppBase.cs
@@ -185,7 +185,14 @@ namespace NzbDrone.Core.Indexers.Definitions
             {
                 { "itemsPerPage", Math.Min(_pageSize, searchCriteria.Limit.GetValueOrDefault(_pageSize)).ToString() },
                 { "sort", "torrent.createdAt" },
-                { "direction", "desc" }
+                { "direction", "desc" },
+
+                // Without this, the API silently excludes dead (0 seed/leech) torrents
+                // server-side, so a search whose only match is dead returns zero results
+                // instead of the dead result itself (see Prowlarr#2778). Downstream apps
+                // already rank/filter by seeder count, so surfacing a dead result is a
+                // strict improvement over a search that looks like it found nothing.
+                { "includingDead", "1" }
             };
 
             if (searchCriteria.Limit is > 0 && searchCriteria.Offset is > 0)


### PR DESCRIPTION
Fixes #2778.

## What and why

The SpeedApp API (shared by RetroFlix and SpeedApp - they use the same request generator, `SpeedAppRequestGenerator`) excludes dead (0 seed/leech) torrents by default. So a search whose only matching result is dead returns an empty response from the API - looking exactly like the indexer found nothing, rather than like it found and hid a result.

A commenter on the issue found that Jackett's implementation of the same SpeedApp API adds `includingDead=1` and gets the dead result back. Downstream apps (Sonarr/Radarr etc.) already rank and filter by seeder count, so surfacing a dead result is a strict improvement over a search that silently returns nothing.

This affects both RetroFlix and SpeedApp, since they share this request generator - flagging that explicitly since it's a slightly wider blast radius than the issue title alone suggests.

## How I tested it

Build verified clean (`dotnet build`, 0 warnings/0 errors) on the affected project. No existing test fixture for SpeedApp/RetroFlix in this repo, so no test added, consistent with current coverage. I don't have API credentials for either tracker to exercise this against the real service - the fix directly mirrors Jackett's known-working reference implementation of the same API rather than being untested guesswork.

## AI-assisted contribution

Drafted with an AI assistant, reviewed and build-verified manually.