### PR TITLE
Fixed: (BTN) Improve searching for episodes with 3 digit numbering

### DIFF
--- a/src/NzbDrone.Core.Test/IndexerTests/BroadcastheNetTests/BroadcastheNetRequestGeneratorFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/BroadcastheNetTests/BroadcastheNetRequestGeneratorFixture.cs
@@ -91,15 +91,16 @@ namespace NzbDrone.Core.Test.IndexerTests.BroadcastheNetTests
             secondQuery.Name.Should().Be("S01E%");
         }
 
-        [Test]
-        public void should_search_by_tvdbid_season_episode_if_supported()
+        [TestCase(1, "3", "S01E%03%")]
+        [TestCase(1, "103", "S01E103%")]
+        public void should_search_by_tvdbid_season_episode_if_supported(int season, string episode, string expectedQuery)
         {
             var tvSearchCriteria = new TvSearchCriteria
             {
                 Categories = new[] { NewznabStandardCategory.TV.Id, NewznabStandardCategory.TVHD.Id },
                 TvdbId = 371980,
-                Season = 1,
-                Episode = "3"
+                Season = season,
+                Episode = episode
             };
 
             var results = Subject.GetSearchRequests(tvSearchCriteria);
@@ -114,7 +115,7 @@ namespace NzbDrone.Core.Test.IndexerTests.BroadcastheNetTests
             query.Tvrage.Should().BeNull();
             query.Search.Should().BeNull();
             query.Category.Should().Be("Episode");
-            query.Name.Should().Be("S01E03%");
+            query.Name.Should().Be(expectedQuery);
         }
 
         [Test]
@@ -226,15 +227,16 @@ namespace NzbDrone.Core.Test.IndexerTests.BroadcastheNetTests
             secondQuery.Name.Should().Be("S02E%");
         }
 
-        [Test]
-        public void should_search_by_term_season_episode_if_supported()
+        [TestCase(2, "3", "S02E%03%")]
+        [TestCase(2, "103", "S02E103%")]
+        public void should_search_by_term_season_episode_if_supported(int season, string episode, string expectedQuery)
         {
             var tvSearchCriteria = new TvSearchCriteria
             {
                 Categories = new[] { NewznabStandardCategory.TV.Id, NewznabStandardCategory.TVHD.Id },
                 SearchTerm = "Malcolm in the Middle",
-                Season = 2,
-                Episode = "3"
+                Season = season,
+                Episode = episode
             };
 
             var results = Subject.GetSearchRequests(tvSearchCriteria);
@@ -249,7 +251,7 @@ namespace NzbDrone.Core.Test.IndexerTests.BroadcastheNetTests
             query.Tvrage.Should().BeNull();
             query.Search.Should().Be("Malcolm%in%the%Middle");
             query.Category.Should().Be("Episode");
-            query.Name.Should().Be("S02E03%");
+            query.Name.Should().Be(expectedQuery);
         }
 
         [Test]

--- a/src/NzbDrone.Core/Indexers/Definitions/BroadcastheNet/BroadcastheNetRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/BroadcastheNet/BroadcastheNetRequestGenerator.cs
@@ -81,7 +81,9 @@ namespace NzbDrone.Core.Indexers.BroadcastheNet
             else if (searchCriteria.Season > 0 && int.TryParse(searchCriteria.Episode, out var episode) && episode > 0)
             {
                 // Standard (S/E) Episode
-                parameters.Name = $"S{searchCriteria.Season:00}E{episode:00}%";
+                parameters.Name = episode is > 0 and < 100
+                    ? $"S{searchCriteria.Season:00}E%{episode:00}%"
+                    : $"S{searchCriteria.Season:00}E{episode:00}%";
                 parameters.Category = "Episode";
                 pageableRequests.Add(GetPagedRequests(parameters, btnResults, btnOffset));
             }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Change to use a wildcard to combine S01E01 and S01E001 for cases where the indexer may use 3 digits to indicate episode numbering.

https://github.com/Sonarr/Sonarr/pull/8895