### PR TITLE
Fixed: Treat invalid contents as unavailable releases

### DIFF
--- a/src/NzbDrone.Core/Indexers/HttpIndexerBase.cs
+++ b/src/NzbDrone.Core/Indexers/HttpIndexerBase.cs
@@ -291,6 +291,13 @@ namespace NzbDrone.Core.Indexers
                 elapsedTime = response.ElapsedTime;
 
                 _logger.Debug("Downloaded for release finished ({0} bytes from {1})", fileData.Length, link.AbsoluteUri);
+
+                if (response.Headers?.ContentType?.Contains("text/html", StringComparison.OrdinalIgnoreCase) == true)
+                {
+                    throw new HttpException(request, response, "Site responded with html content.");
+                }
+
+                ValidateDownloadData(fileData);
             }
             catch (HttpException ex)
             {
@@ -323,8 +330,6 @@ namespace NzbDrone.Core.Indexers
                 _logger.Error(ex, "Release download failed ({0})", link.AbsoluteUri);
                 throw;
             }
-
-            ValidateDownloadData(fileData);
 
             return new IndexerDownloadResponse(fileData, elapsedTime);
         }

--- a/src/NzbDrone.Core/Indexers/HttpIndexerBase.cs
+++ b/src/NzbDrone.Core/Indexers/HttpIndexerBase.cs
@@ -284,7 +284,7 @@ namespace NzbDrone.Core.Indexers
 
                         response = await _httpClient.ExecuteProxiedAsync(request, Definition);
                     }
-                    while (response.StatusCode is HttpStatusCode.MovedPermanently or HttpStatusCode.Found or HttpStatusCode.SeeOther);
+                    while (response.StatusCode is HttpStatusCode.MovedPermanently or HttpStatusCode.Found or HttpStatusCode.SeeOther or HttpStatusCode.TemporaryRedirect or HttpStatusCode.PermanentRedirect);
                 }
 
                 fileData = response.ResponseData;


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Returning 410 Gone instead of 500 internal server error for invalid nzb or torrent contents.

#### Issues Fixed or Closed by this PR

* Fixes #2556
* Closes #2783