### PR TITLE
Remove unused package references

### DIFF
--- a/src/NzbDrone.Common/Prowlarr.Common.csproj
+++ b/src/NzbDrone.Common/Prowlarr.Common.csproj
@@ -21,7 +21,6 @@
     <PackageReference Include="System.Private.Uri" Version="4.3.2" />
     <PackageReference Include="System.Text.Json" Version="8.0.6" />
     <PackageReference Include="System.ValueTuple" Version="4.6.2" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.1" />
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="8.0.1" />

--- a/src/NzbDrone.Core/Prowlarr.Core.csproj
+++ b/src/NzbDrone.Core/Prowlarr.Core.csproj
@@ -9,7 +9,6 @@
     <PackageReference Include="MailKit" Version="4.17.0" />
     <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="8.0.27" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="8.0.27" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.6" />
     <PackageReference Include="NLog.Targets.Syslog" Version="7.0.0" />
     <PackageReference Include="Npgsql" Version="9.0.5" />
     <PackageReference Include="Polly" Version="8.7.0" />
@@ -17,8 +16,6 @@
     <PackageReference Include="FluentMigrator.Runner.Postgres" Version="6.2.0" />
     <PackageReference Include="FluentMigrator.Runner.SQLite" Version="6.2.0" />
     <PackageReference Include="System.Drawing.Common" Version="8.0.27" />
-    <PackageReference Include="System.Memory" Version="4.6.3" />
-    <PackageReference Include="System.ServiceModel.Syndication" Version="8.0.0" />
     <PackageReference Include="FluentValidation" Version="9.5.4" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="NLog" Version="5.5.1" />


### PR DESCRIPTION
1. `Microsoft.Data.SqlClient`: Prowlarr only talks to SQLite and PostgreSQL, and there is no `using Microsoft.Data` anywhere.

    It also pulls in `Microsoft.Identity.Client.Broker` -> `Microsoft.Identity.Client.NativeInterop`, which ships a prebuilt `libmsalruntime.so` linked against Ubuntu's `libcurl`. That library requires `libcurl.so.4(CURL_OPENSSL_4)`, a symbol version that does not exist in any other distribution.

    I was trying to package Prowlarr for Fedora, and this is how the audit for the dependencies came to be.

    Dropping it removes **44 files** from the output (`Azure.Core`, `Azure.Identity`, `Microsoft.Identity.*`, `Microsoft.IdentityModel.*`, `System.IdentityModel.Tokens.Jwt`, `Microsoft.SqlServer.Server` and the SqlClient resource assemblies).

2. `System.ServiceModel.Syndication` and `System.Configuration.ConfigurationManager` are leftovers from the `net462/netcoreapp` multi-targeting era, nothing uses them.

3. `System.Memory:` a no-op on .Net 8.0, the types live in the shared framework, in fact in the build `System.Memory.dll` is .NET 8's own (8.0.30) from the self-contained runtime pack.

`dotnet msbuild -restore src/Prowlarr.sln -p:Configuration=Release -p:Platform=Posix` builds everything, including `Prowlarr.Windows`, `Prowlarr.Windows.Test`, `Prowlarr.Mono.Test` and all other test projects with 0 errors.