### PR TITLE
Bump Sentry to 5.16.3

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -109,10 +109,6 @@
     <SentryUrl></SentryUrl> <!--  If empty, assumed to be sentry.io -->
     <SentryAuthToken></SentryAuthToken> <!-- Use env var instead: SENTRY_AUTH_TOKEN -->
 
-    <!-- Upload PDBs to Sentry, enabling stack traces with line numbers and file paths
-      without the need to deploy the application with PDBs -->
-    <SentryUploadSymbols>true</SentryUploadSymbols>
-
     <!-- Source Link settings -->
     <!-- https://github.com/dotnet/sourcelink/blob/main/docs/README.md#publishrepositoryurl -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/src/NzbDrone.Common/Prowlarr.Common.csproj
+++ b/src/NzbDrone.Common/Prowlarr.Common.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="NLog.Layouts.ClefJsonLayout" Version="1.0.5" />
     <PackageReference Include="NLog.Extensions.Logging" Version="5.5.0" />
     <PackageReference Include="Npgsql" Version="9.0.5" />
-    <PackageReference Include="Sentry" Version="4.0.2" />
+    <PackageReference Include="Sentry" Version="5.16.3" />
     <PackageReference Include="NLog.Targets.Syslog" Version="7.0.0" />
     <PackageReference Include="SharpZipLib" Version="1.4.2" />
     <PackageReference Include="SourceGear.sqlite3" Version="3.53.4" />


### PR DESCRIPTION
#### Database Migration
NO

#### Description
4.0.2 is deprecated. See https://www.nuget.org/packages/Sentry/4.0.2

Since sentry is not being configured for CI builds, disabling SentryUploadSymbols is needed for a successful build.