### PR TITLE
Fixed: (Toloka) Normalise season and episode tags for Sonarr

### DIFF
--- a/src/NzbDrone.Core.Test/IndexerTests/TolokaTests/TolokaTitleParserFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/TolokaTests/TolokaTitleParserFixture.cs
@@ -1,0 +1,61 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.Indexers;
+using NzbDrone.Core.Indexers.Definitions;
+using NzbDrone.Test.Common;
+
+namespace NzbDrone.Core.Test.IndexerTests.TolokaTests
+{
+    [TestFixture]
+    public class TolokaTitleParserFixture : TestBase
+    {
+        private readonly TolokaTitleParser _parser = new();
+
+        private static readonly ICollection<IndexerCategory> TvCategories = new List<IndexerCategory> { NewznabStandardCategory.TV, NewznabStandardCategory.TVHD };
+        private static readonly ICollection<IndexerCategory> MovieCategories = new List<IndexerCategory> { NewznabStandardCategory.Movies, NewznabStandardCategory.MoviesHD };
+
+        [TestCase("Спліт / Split (2016) UHD BDRemux 4K 2160p HDR H.265 Ukr/Eng | Sub Ukr",
+                  "Split (2016) UHD BDRemux 4K 2160p HDR H.265 Ukr/Eng | Sub Ukr")]
+        public void should_strip_cyrillic_title_from_movie_release(string title, string expected)
+        {
+            _parser.Parse(title, MovieCategories).Should().Be(expected);
+        }
+
+        [TestCase("Укриття (Сезон 3, Серії 1-9) / Silo (Season 3, Episodes 1-9) (2026) WEB-DL 1080p H.265 Ukr/Eng | sub Ukr/Eng",
+                  "Silo (S03E01-09) (2026) WEB-DL 1080p H.265 Ukr/Eng | sub Ukr/Eng")]
+        [TestCase("Укриття (Сезон 3, Серії 1-9) / Silo (S3, EP 1-9) (2026) WEB-DL 1080p Ukr/Eng | sub Ukr/Eng",
+                  "Silo (S03E01-09) (2026) WEB-DL 1080p Ukr/Eng | sub Ukr/Eng")]
+        [TestCase("Укриття (S3, C 1-9) / Silo (S3) (2026) WEB-DL 4K 2160p H.265 HDR DV P8 Ukr/Eng | Sub Ukr/Eng/Heb",
+                  "Silo (S03E01-09) (2026) WEB-DL 4K 2160p H.265 HDR DV P8 Ukr/Eng | Sub Ukr/Eng/Heb")]
+        [TestCase("Укриття (Сезон 3, Серія 10) / Silo (S3, E 10) (2026) WEB-DL 2160p Ukr/Eng",
+                  "Silo (S03E10) (2026) WEB-DL 2160p Ukr/Eng")]
+        public void should_normalize_partial_season_pack_to_zero_padded_episode_range(string title, string expected)
+        {
+            _parser.Parse(title, TvCategories).Should().Be(expected);
+        }
+
+        [TestCase("Укриття (Сезон 2) / Silo (S2) (2023) WEB-DL 2160p DV HDR10+ 3xUkr/Eng | sub Ukr/Eng",
+                  "Silo (S02) (2023) WEB-DL 2160p DV HDR10+ 3xUkr/Eng | sub Ukr/Eng")]
+        [TestCase("Укриття (Сезон 2) / Silo (Season 2) (2023) WEB-DL 1080p 3xUkr/Eng | Sub Ukr/Eng",
+                  "Silo (S02) (2023) WEB-DL 1080p 3xUkr/Eng | Sub Ukr/Eng")]
+        public void should_normalize_full_season_pack_to_zero_padded_season_and_drop_duplicate_tag(string title, string expected)
+        {
+            _parser.Parse(title, TvCategories).Should().Be(expected);
+        }
+
+        [TestCase("Дім (Сезон 1-8) / House (Seasons 1-8) (2004-2012) BDRip 1080p Ukr/Eng | Sub Eng",
+                  "House (S1-8) (2004-2012) BDRip 1080p Ukr/Eng | Sub Eng (S1-8)")]
+        public void should_leave_multi_season_range_untouched(string title, string expected)
+        {
+            _parser.Parse(title, TvCategories).Should().Be(expected);
+        }
+
+        [TestCase("Укриття (Сезон 3, Серії 1-9 з 10) / Silo (2026) WEB-DL 1080p Ukr/Eng",
+                  "Silo (2026) WEB-DL 1080p Ukr/Eng (S03E01-09 of 10)")]
+        public void should_zero_pad_episode_of_count_form(string title, string expected)
+        {
+            _parser.Parse(title, TvCategories).Should().Be(expected);
+        }
+    }
+}

--- a/src/NzbDrone.Core/Indexers/Definitions/Toloka.cs
+++ b/src/NzbDrone.Core/Indexers/Definitions/Toloka.cs
@@ -460,6 +460,14 @@ namespace NzbDrone.Core.Indexers.Definitions
         private readonly Regex _tvTitleEngEpisodeOfRegex = new(@"(?:Episodes?)+\s*[:]*\s+(\d+(?:-\d+)?)\s*of\s*([\w?])", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         private readonly Regex _tvTitleEngEpisodeRegex = new(@"(?:Episodes?)+\s*[:]+\s*[:]*\s+(\d+(?:-\d+)?)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
+        // "S3, C 1-9", "S3, EP 1-9", "S3, E 10", "S3 Серії 1-9" -> "S3E1-9" / "S3E10"
+        private readonly Regex _tvTitleSeasonEpisodeAbbreviationRegex = new(@"\bS(\d{1,2})\s*[,;]?\s*(?:EP|E|C|С|Серії|Серія|Серій)\.?\s*(\d{1,3})(?:\s*-\s*(\d{1,3}))?\b", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        // "S3E1-9" -> "S03E01-09", "S2" -> "S02"; multi-season ranges such as "S1-8" are left alone
+        private readonly Regex _tvTitleSeasonEpisodePaddingRegex = new(@"\bS(?<season>\d{1,2})(?:E(?<episode>\d{1,3})(?:-E?(?<lastEpisode>\d{1,3}))?)?\b(?!-\d)", RegexOptions.Compiled);
+
+        private static readonly Regex SeasonTagRegex = new(@"\((?<tag>S(?<season>\d{2,4})(?<episodes>E\d{2,3}(?:-\d{2,3})?)?(?: of \d+)?)\)", RegexOptions.Compiled);
+
         private readonly Regex _stripCyrillicRegex = new(@"(\([\p{IsCyrillic}\W]+\))|(^[\p{IsCyrillic}\W\d]+\/ )|([\p{IsCyrillic} \-]+,+)|([\p{IsCyrillic}]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         public string Parse(string title, ICollection<IndexerCategory> categories, bool stripCyrillicLetters = true)
@@ -486,6 +494,9 @@ namespace NzbDrone.Core.Indexers.Definitions
                 title = _tvTitleEngSeasonRegex.Replace(title, "S$1");
                 title = _tvTitleEngEpisodeOfRegex.Replace(title, "E$1 of $2");
                 title = _tvTitleEngEpisodeRegex.Replace(title, "E$1");
+
+                title = _tvTitleSeasonEpisodeAbbreviationRegex.Replace(title, JoinSeasonAndEpisodes);
+                title = _tvTitleSeasonEpisodePaddingRegex.Replace(title, PadSeasonAndEpisodes);
             }
 
             if (stripCyrillicLetters)
@@ -500,6 +511,11 @@ namespace NzbDrone.Core.Indexers.Definitions
             title = Regex.Replace(title, @"\bWEBDL\b", "WEB-DL", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
             title = MoveFirstTagsToEndOfReleaseTitle(title);
+
+            if (IsAnyTvCategory(categories))
+            {
+                title = ReconcileSeasonTags(title);
+            }
 
             title = Regex.Replace(title, @"\(\s*\/\s*", "(", RegexOptions.Compiled);
             title = Regex.Replace(title, @"\s*\/\s*\)", ")", RegexOptions.Compiled);
@@ -517,6 +533,68 @@ namespace NzbDrone.Core.Indexers.Definitions
         private static bool IsAnyTvCategory(ICollection<IndexerCategory> category)
         {
             return category.Contains(NewznabStandardCategory.TV) || NewznabStandardCategory.TV.SubCategories.Any(subCategory => category.Contains(subCategory));
+        }
+
+        private static string JoinSeasonAndEpisodes(Match match)
+        {
+            var result = $"S{match.Groups[1].Value}E{match.Groups[2].Value}";
+
+            if (match.Groups[3].Success)
+            {
+                result += $"-{match.Groups[3].Value}";
+            }
+
+            return result;
+        }
+
+        private static string PadSeasonAndEpisodes(Match match)
+        {
+            var result = $"S{match.Groups["season"].Value.PadLeft(2, '0')}";
+
+            if (match.Groups["episode"].Success)
+            {
+                result += $"E{match.Groups["episode"].Value.PadLeft(2, '0')}";
+
+                if (match.Groups["lastEpisode"].Success)
+                {
+                    result += $"-{match.Groups["lastEpisode"].Value.PadLeft(2, '0')}";
+                }
+            }
+
+            return result;
+        }
+
+        // Toloka titles carry the season tag twice (Ukrainian and English part), and the Ukrainian one is moved to
+        // the end of the title. Keep the most specific tag next to the series title and drop repeated tags, so that
+        // "Silo (S03) ... (S03E01-09)" becomes "Silo (S03E01-09) ..." which Sonarr parses as an episode range.
+        private static string ReconcileSeasonTags(string title)
+        {
+            var tags = SeasonTagRegex.Matches(title).Cast<Match>().ToList();
+
+            if (tags.Count < 2)
+            {
+                return title;
+            }
+
+            foreach (var bareTag in tags.Where(t => !t.Groups["episodes"].Success))
+            {
+                var specificTag = tags.FirstOrDefault(t => t.Groups["episodes"].Success && t.Groups["season"].Value == bareTag.Groups["season"].Value);
+
+                if (specificTag != null)
+                {
+                    title = title.Replace(bareTag.Value, specificTag.Value);
+                }
+            }
+
+            foreach (var tag in SeasonTagRegex.Matches(title).Cast<Match>().Select(m => m.Value).Distinct().ToList())
+            {
+                var firstIndex = title.IndexOf(tag, StringComparison.Ordinal);
+                var afterFirst = firstIndex + tag.Length;
+
+                title = title.Substring(0, afterFirst) + title.Substring(afterFirst).Replace(tag, string.Empty);
+            }
+
+            return title;
         }
 
         private static string MoveFirstTagsToEndOfReleaseTitle(string input)


### PR DESCRIPTION
#### Database Migration

NO

#### Description

Toloka release titles carry the season/episode information twice, once in the Ukrainian part and once in the English part, in free-form tags such as `(Сезон 3, Серії 1-9)`, `(S3, EP 1-9)`, `(S3, C 1-9)`, `(S3E1-9)` or `(S3)`. The parser converts some of them to `S3E1-9` / `S3` and moves the Ukrainian tag to the end of the title.

Sonarr only recognises the bracketed two-digit form `(S03E01-09)`, and its generic patterns refuse a season token that directly follows `(`. The current output therefore parses badly in Sonarr, observed with live Toloka results:

| Current output | Sonarr reads it as |
|---|---|
| `Silo (S3E1-9) (2026) WEB-DL 1080p H.265 Ukr/Eng \| sub Ukr/Eng (S3E1-9)` | one episode, so a 9-episode pack fails the single-episode size limit |
| `Silo (S3, EP 1-9) (2026) WEB-DL 1080p Ukr/Eng \| sub Ukr/Eng (S3E1-9)` | one episode, same rejection |
| `Silo (S3) (2026) WEB-DL 4K 2160p H.265 HDR DV P8 Ukr/Eng \| Sub Ukr/Eng/Heb (S3, C 1-9)` | **S01E09**; Sonarr grabbed a season 3 pack as an upgrade for 1x09, could not import any file ("Episode 3x01 was not found in the grabbed release"), and RSS retried the grab every 15 minutes |

Changes, all limited to TV categories:

- rewrite abbreviated forms (`S3, C 1-9`, `S3, EP 1-9`, `S3, E 10`, Cyrillic `С`/`Серії`) to `S3E1-9` / `S3E10`;
- zero-pad seasons and episodes: `S3E1-9` -> `S03E01-09`, `S2` -> `S02`; multi-season ranges such as `S1-8` are deliberately left alone;
- after the first tags are moved to the end of the title, replace a bare `(S03)` next to the series title with the more specific `(S03E01-09)` when one exists for the same season, and drop repeated identical tags.

Resulting titles for the rows above: `Silo (S03E01-09) (2026) WEB-DL 1080p ...`, `Silo (S03E01-09) (2026) WEB-DL 2160p ...`; a full season becomes `Silo (S02) (2023) ...`. Movie titles are untouched.

Related: #2700 fixes a different case (tokens stranded in front of the foreign title after stripping) and #2714 adds a title option; both touch `Toloka.cs` and add the same `TolokaTitleParserFixture.cs`, so this will need a trivial rebase on whichever lands first. Happy to do that.

#### Screenshot (if UI related)

n/a

#### Todos

- [x] Tests (`TolokaTitleParserFixture`, 9 cases; `dotnet test --filter FullyQualifiedName~IndexerTests` and the full `Prowlarr.Core.Test` project pass on net8.0)
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* none filed; same bug class as #2316 / #2317
